### PR TITLE
Change scopeType matchers to rely on tree-sitter style scheme queries

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -41,6 +41,12 @@
 				"reveal": "never"
 			},
 			"group": "build"
+		},
+		{
+			"label": "Parse quarry",
+			"type": "shell",
+			"command": "npx tree-sitter query scopeTypes.scm ts-test.ts",
+			"presentation": {}
 		}
 	]
 }

--- a/queries/typescript/scopeTypes.scm
+++ b/queries/typescript/scopeTypes.scm
@@ -1,0 +1,56 @@
+(object) @map
+
+(arrow_function) @anonymousFunction
+(function) @anonymousFunction
+
+; We could also have used an alternation here, but the above style is clean and
+; seems to be more commonly used.
+; [
+;     (arrow_function)
+;     (function)
+; ] @anonymousFunction 
+
+; The following doesn't work because we can't have a `(` before the field name (`key`)
+; (
+;     (object
+;         (pair
+;             (key: (_) @key
+;             .
+;             ":") @key.removalRange
+;         ) @key.searchScope
+;     ) @key.iterationScope
+; )
+
+; As a workaround, we could allow defining the end of an annotation
+(
+    (object
+        (pair
+            key: (_) @key
+            .
+            ":" @key.removalRange.end
+        ) @key.searchScope
+    ) @key.iterationScope
+)
+
+; We could instead tag the delimiter itself.  Gives us a bit more information,
+; so maybe that's better?
+(
+    (object
+        (pair
+            key: (_) @key
+            .
+            ":" @key.delimiter.trailing)
+        @key.searchScope)
+    @key.iterationScope)
+
+; We could also try setting an attribute.  This approach is likely how we'd
+; handle comma-separated lists, because they'd be a bit painful to define as
+; parse tree patterns
+(
+    (object
+        (pair
+            key: (_) @key
+            (#set! "delimiter" ":")
+        )
+        @key.searchScope)
+    @key.iterationScope)

--- a/queries/typescript/scopeTypes.scm
+++ b/queries/typescript/scopeTypes.scm
@@ -39,9 +39,10 @@
         (pair
             key: (_) @key
             .
-            ":" @key.delimiter.trailing)
-        @key.searchScope)
-    @key.iterationScope)
+            ":" @key.delimiter.trailing
+        ) @key.searchScope
+    ) @key.iterationScope
+)
 
 ; We could also try setting an attribute.  This approach is likely how we'd
 ; handle comma-separated lists, because they'd be a bit painful to define as
@@ -51,6 +52,6 @@
         (pair
             key: (_) @key
             (#set! "delimiter" ":")
-        )
-        @key.searchScope)
-    @key.iterationScope)
+        ) @key.searchScope
+    ) @key.iterationScope
+)

--- a/queries/typescript/scopeTypes.scm
+++ b/queries/typescript/scopeTypes.scm
@@ -8,7 +8,7 @@
 ; [
 ;     (arrow_function)
 ;     (function)
-; ] @anonymousFunction 
+; ] @anonymousFunction
 
 ; The following doesn't work because we can't have a `(` before the field name (`key`)
 ; (


### PR DESCRIPTION
Fixes #616

## Checklist

- [ ] I have added [tests](https://github.com/cursorless-dev/cursorless-vscode/blob/main/docs/contributing/test-case-recorder.md)
