### PR TITLE
Added necessary spacing in talon rules

### DIFF
--- a/cursorless-talon/src/modifiers/sub_token.py
+++ b/cursorless-talon/src/modifiers/sub_token.py
@@ -47,7 +47,7 @@ def cursorless_first_last_range(m) -> str:
 
 @mod.capture(
     rule=(
-        "(<user.cursorless_ordinal_range> | <user.cursorless_first_last_range>)"
+        "(<user.cursorless_ordinal_range> | <user.cursorless_first_last_range>) "
         "{user.cursorless_subtoken_scope_type}"
     )
 )


### PR DESCRIPTION
Solves issue with talon's new `DeprecationWarning: Rule needs a space between tokens:`

## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
