### PR TITLE
docusaurus.config.js: Remove trailing slash on url

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -61,7 +61,7 @@ function remarkPluginFixLinksToRepositoryArtifacts() {
 const config = {
   title: "Cursorless",
   tagline: "Structural voice coding at the speed of thought",
-  url: "https://www.cursorless.org/",
+  url: "https://www.cursorless.org",
   baseUrl: "/docs/",
   onBrokenLinks: "throw",
   onBrokenMarkdownLinks: "throw",


### PR DESCRIPTION
Should fix #668. I haven't tested this yet.

## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
