### PR TITLE
Support delimiter based edit newline

### DIFF
--- a/src/actions/EditNewLine.ts
+++ b/src/actions/EditNewLine.ts
@@ -59,11 +59,13 @@ class EditNewLine implements Action {
           ? contentRange.start.line
           : contentRange.end.line;
         const line = editor.document.lineAt(lineNumber);
-        const { firstNonWhitespaceCharacterIndex } = line;
-        const padding = line.text.slice(0, firstNonWhitespaceCharacterIndex);
+        const characterIndex = line.isEmptyOrWhitespace
+          ? contentRange.start.character
+          : line.firstNonWhitespaceCharacterIndex;
+        const padding = line.text.slice(0, characterIndex);
         const positionSelection = new Position(
           this.isBefore ? lineNumber : lineNumber + delimiter.length,
-          firstNonWhitespaceCharacterIndex
+          characterIndex
         );
         return {
           contentRange,

--- a/src/actions/EditNewLine.ts
+++ b/src/actions/EditNewLine.ts
@@ -1,7 +1,13 @@
-import { commands, Range, TextEditor } from "vscode";
+import {
+  commands as vscommands,
+  Position,
+  Range,
+  Selection,
+  TextEditor,
+} from "vscode";
 import { Target } from "../typings/target.types";
 import { Graph } from "../typings/Types";
-import { getNotebookFromCellDocument } from "../util/notebook";
+import { createThatMark, ensureSingleEditor } from "../util/targetUtils";
 import { Action, ActionReturnValue } from "./actions.types";
 
 class EditNewLine implements Action {
@@ -9,58 +15,101 @@ class EditNewLine implements Action {
     this.run = this.run.bind(this);
   }
 
-  private correctForParagraph(targets: Target[]) {
-    targets.forEach((target) => {
-      let { start, end } = target.contentRange;
-      if (target.scopeType === "paragraph") {
-        if (this.isAbove && target.leadingDelimiter != null) {
-          start = start.translate({ lineDelta: -1 });
-        } else if (!this.isAbove && target.trailingDelimiter != null) {
-          end = end.translate({ lineDelta: 1 });
-        }
-        target.contentRange = new Range(start, end);
-      }
-    });
-  }
-
-  private isNotebookEditor(editor: TextEditor) {
-    return getNotebookFromCellDocument(editor.document) != null;
-  }
-
-  private getCommand(target: Target) {
-    if (target.scopeType === "notebookCell") {
-      if (this.isNotebookEditor(target.editor)) {
-        return this.isAbove
-          ? "notebook.cell.insertCodeCellAbove"
-          : "notebook.cell.insertCodeCellBelow";
-      }
-      return this.isAbove
-        ? "jupyter.insertCellAbove"
-        : "jupyter.insertCellBelow";
-    }
-    return this.isAbove
-      ? "editor.action.insertLineBefore"
-      : "editor.action.insertLineAfter";
-  }
-
   async run([targets]: [Target[]]): Promise<ActionReturnValue> {
-    this.correctForParagraph(targets);
+    const editor = ensureSingleEditor(targets);
 
+    const targetsWithContext = targets.map((target) => ({
+      target,
+      context: target.getEditNewLineContext(this.isAbove),
+    }));
+    const commandTargets = targetsWithContext.filter(
+      ({ context }) => !!(<any>context).command
+    );
+    const delimiterTargets = targetsWithContext.filter(
+      ({ context }) => !!(<any>context).delimiter
+    );
+
+    if (commandTargets.length > 0 && delimiterTargets.length > 0) {
+      throw new Error("Can't insert edit using command and delimiter at once");
+    }
+
+    if (commandTargets.length > 0) {
+      const commands = commandTargets.map(
+        ({ context }) => (<any>context).command
+      );
+      return {
+        thatMark: await this.runCommand(targets, commands),
+      };
+    }
+
+    return {
+      thatMark: await this.runDelimiter(targets, editor),
+    };
+  }
+
+  async runDelimiter(targets: Target[], editor: TextEditor) {
+    const edits = targets.map((target) => {
+      const context = target.getEditNewLineContext(this.isAbove);
+      const delimiter = (<any>context).delimiter as string;
+      const lineNumber = this.isAbove
+        ? target.contentRange.start.line
+        : target.contentRange.end.line;
+      const line = editor.document.lineAt(lineNumber);
+      const { firstNonWhitespaceCharacterIndex } = line;
+      const padding = line.text.slice(0, firstNonWhitespaceCharacterIndex);
+      const text = this.isAbove ? padding + delimiter : delimiter + padding;
+      const position = this.isAbove ? line.range.start : line.range.end;
+      const lineDelta = delimiter.length;
+      return {
+        contentRange: target.contentRange,
+        lineDelta,
+        firstNonWhitespaceCharacterIndex,
+        position,
+        text,
+      };
+    });
+
+    await editor.edit((editBuilder) => {
+      edits.forEach((edit) => {
+        editBuilder.replace(edit.position, edit.text);
+      });
+    });
+
+    editor.selections = edits.map((edit) => {
+      const selectionLineNum = this.isAbove
+        ? edit.position.line
+        : edit.position.line + edit.lineDelta;
+      const positionSelection = new Position(
+        selectionLineNum,
+        edit.firstNonWhitespaceCharacterIndex
+      );
+      return new Selection(positionSelection, positionSelection);
+    });
+
+    const thatMarkRanges = edits.map((edit) => {
+      const { contentRange, lineDelta } = edit;
+      return this.isAbove
+        ? new Range(
+            contentRange.start.translate({ lineDelta }),
+            contentRange.end.translate({ lineDelta })
+          )
+        : contentRange;
+    });
+
+    return createThatMark(targets, thatMarkRanges);
+  }
+
+  async runCommand(targets: Target[], commands: string[]) {
+    if (new Set(commands).size > 1) {
+      throw new Error("Can't run multiple different commands at once");
+    }
     if (this.isAbove) {
       await this.graph.actions.setSelectionBefore.run([targets]);
     } else {
       await this.graph.actions.setSelectionAfter.run([targets]);
     }
-
-    const command = this.getCommand(targets[0]);
-    await commands.executeCommand(command);
-
-    return {
-      thatMark: targets.map((target) => ({
-        selection: target.editor.selection,
-        editor: target.editor,
-      })),
-    };
+    await vscommands.executeCommand(commands[0]);
+    return createThatMark(targets);
   }
 }
 

--- a/src/processTargets/modifiers/scopeTypeStages/ContainingSyntaxScopeStage.ts
+++ b/src/processTargets/modifiers/scopeTypeStages/ContainingSyntaxScopeStage.ts
@@ -46,7 +46,6 @@ export default class implements ModifierStage {
     return scopeNodes.map(
       (scope) =>
         new ScopeTypeTarget({
-          delimiter: "\n",
           ...selectionWithEditorWithContextToTarget(scope),
           scopeType: this.modifier.scopeType,
           isReversed: target.isReversed,

--- a/src/processTargets/targets/BaseTarget.ts
+++ b/src/processTargets/targets/BaseTarget.ts
@@ -124,7 +124,7 @@ export default class BaseTarget implements Target {
     return this.getRemovalContentHighlightRange();
   }
 
-  getEditNewLineContext(_isAbove: boolean): EditNewLineContext {
+  getEditNewLineContext(_isBefore: boolean): EditNewLineContext {
     return {
       delimiter: "\n",
     };

--- a/src/processTargets/targets/BaseTarget.ts
+++ b/src/processTargets/targets/BaseTarget.ts
@@ -6,6 +6,7 @@ import {
   Position,
   RemovalRange,
   TargetParameters,
+  EditNewLineContext,
 } from "../../typings/target.types";
 
 export default class BaseTarget implements Target {
@@ -121,5 +122,11 @@ export default class BaseTarget implements Target {
       return this.getRemovalAfterHighlightRange();
     }
     return this.getRemovalContentHighlightRange();
+  }
+
+  getEditNewLineContext(_isAbove: boolean): EditNewLineContext {
+    return {
+      delimiter: "\n",
+    };
   }
 }

--- a/src/processTargets/targets/BaseTarget.ts
+++ b/src/processTargets/targets/BaseTarget.ts
@@ -12,10 +12,10 @@ import {
 export default class BaseTarget implements Target {
   editor: TextEditor;
   isReversed: boolean;
+  contentRange: Range;
+  delimiter: string;
   scopeType?: ScopeType;
   position?: Position;
-  delimiter?: string;
-  contentRange: Range;
   removalRange?: Range;
   interiorRange?: Range;
   boundary?: [Range, Range];
@@ -26,10 +26,10 @@ export default class BaseTarget implements Target {
   constructor(parameters: TargetParameters) {
     this.editor = parameters.editor;
     this.isReversed = parameters.isReversed;
+    this.contentRange = parameters.contentRange;
+    this.delimiter = parameters.delimiter ?? " ";
     this.scopeType = parameters.scopeType;
     this.position = parameters.position;
-    this.delimiter = parameters.delimiter;
-    this.contentRange = parameters.contentRange;
     this.removalRange = parameters.removalRange;
     this.interiorRange = parameters.interiorRange;
     this.boundary = parameters.boundary;
@@ -49,13 +49,11 @@ export default class BaseTarget implements Target {
 
   /** Possibly add delimiter for positions before/after */
   maybeAddDelimiter(text: string): string {
-    if (this.delimiter != null) {
-      if (this.position === "before") {
-        return text + this.delimiter;
-      }
-      if (this.position === "after") {
-        return this.delimiter + text;
-      }
+    if (this.position === "before") {
+      return text + this.delimiter;
+    }
+    if (this.position === "after") {
+      return this.delimiter + text;
     }
     return text;
   }

--- a/src/processTargets/targets/DocumentTarget.ts
+++ b/src/processTargets/targets/DocumentTarget.ts
@@ -1,4 +1,5 @@
 import { Range, TextEditor } from "vscode";
+import { EditNewLineContext, ScopeType } from "../../typings/target.types";
 import BaseTarget from "./BaseTarget";
 
 interface DocumentTargetParameters {
@@ -8,6 +9,10 @@ interface DocumentTargetParameters {
 }
 
 export default class DocumentTarget extends BaseTarget {
+  scopeType: ScopeType;
+  delimiter: string;
+  isLine: boolean;
+
   constructor(parameters: DocumentTargetParameters) {
     super(parameters);
     this.scopeType = "document";

--- a/src/processTargets/targets/LineTarget.ts
+++ b/src/processTargets/targets/LineTarget.ts
@@ -1,5 +1,5 @@
 import { Range, TextEditor } from "vscode";
-import { RemovalRange } from "../../typings/target.types";
+import { RemovalRange, ScopeType } from "../../typings/target.types";
 import { parseRemovalRange } from "../../util/targetUtils";
 import BaseTarget from "./BaseTarget";
 
@@ -12,6 +12,10 @@ interface LineTargetParameters {
 }
 
 export default class LineTarget extends BaseTarget {
+  scopeType: ScopeType;
+  delimiter: string;
+  isLine: boolean;
+
   constructor(parameters: LineTargetParameters) {
     super(parameters);
     this.scopeType = "line";

--- a/src/processTargets/targets/NotebookCellTarget.ts
+++ b/src/processTargets/targets/NotebookCellTarget.ts
@@ -1,4 +1,6 @@
 import { Range, TextEditor } from "vscode";
+import { EditNewLineContext } from "../../typings/target.types";
+import { getNotebookFromCellDocument } from "../../util/notebook";
 import BaseTarget from "./BaseTarget";
 
 interface NotebookCellTargetParameters {
@@ -12,5 +14,22 @@ export default class NotebookCellTarget extends BaseTarget {
     super(parameters);
     this.scopeType = "notebookCell";
     this.delimiter = "\n";
+  }
+
+  getEditNewLineContext(isAbove: boolean): EditNewLineContext {
+    if (this.isNotebookEditor(this.editor)) {
+      return {
+        command: isAbove
+          ? "notebook.cell.insertCodeCellAbove"
+          : "notebook.cell.insertCodeCellBelow",
+      };
+    }
+    return {
+      command: isAbove ? "jupyter.insertCellAbove" : "jupyter.insertCellBelow",
+    };
+  }
+
+  private isNotebookEditor(editor: TextEditor) {
+    return getNotebookFromCellDocument(editor.document) != null;
   }
 }

--- a/src/processTargets/targets/NotebookCellTarget.ts
+++ b/src/processTargets/targets/NotebookCellTarget.ts
@@ -16,16 +16,16 @@ export default class NotebookCellTarget extends BaseTarget {
     this.delimiter = "\n";
   }
 
-  getEditNewLineContext(isAbove: boolean): EditNewLineContext {
+  getEditNewLineContext(isBefore: boolean): EditNewLineContext {
     if (this.isNotebookEditor(this.editor)) {
       return {
-        command: isAbove
+        command: isBefore
           ? "notebook.cell.insertCodeCellAbove"
           : "notebook.cell.insertCodeCellBelow",
       };
     }
     return {
-      command: isAbove ? "jupyter.insertCellAbove" : "jupyter.insertCellBelow",
+      command: isBefore ? "jupyter.insertCellAbove" : "jupyter.insertCellBelow",
     };
   }
 

--- a/src/processTargets/targets/ParagraphTarget.ts
+++ b/src/processTargets/targets/ParagraphTarget.ts
@@ -1,5 +1,9 @@
 import { Range, TextEditor } from "vscode";
-import { RemovalRange } from "../../typings/target.types";
+import {
+  EditNewLineContext,
+  RemovalRange,
+  ScopeType,
+} from "../../typings/target.types";
 import { parseRemovalRange } from "../../util/targetUtils";
 import BaseTarget from "./BaseTarget";
 
@@ -12,6 +16,10 @@ interface ParagraphTargetParameters {
 }
 
 export default class ParagraphTarget extends BaseTarget {
+  scopeType: ScopeType;
+  delimiter: string;
+  isLine: boolean;
+
   constructor(parameters: ParagraphTargetParameters) {
     super(parameters);
     this.scopeType = "paragraph";
@@ -66,5 +74,11 @@ export default class ParagraphTarget extends BaseTarget {
     return delimiterRange != null
       ? removalRange.union(delimiterRange)
       : removalRange;
+  }
+
+  getEditNewLineContext(_isAbove: boolean): EditNewLineContext {
+    return {
+      delimiter: this.delimiter,
+    };
   }
 }

--- a/src/processTargets/targets/ParagraphTarget.ts
+++ b/src/processTargets/targets/ParagraphTarget.ts
@@ -76,7 +76,7 @@ export default class ParagraphTarget extends BaseTarget {
       : removalRange;
   }
 
-  getEditNewLineContext(_isAbove: boolean): EditNewLineContext {
+  getEditNewLineContext(_isBefore: boolean): EditNewLineContext {
     return {
       delimiter: this.delimiter,
     };

--- a/src/processTargets/targets/ScopeTypeTarget.ts
+++ b/src/processTargets/targets/ScopeTypeTarget.ts
@@ -1,4 +1,8 @@
-import { ScopeType, TargetParameters } from "../../typings/target.types";
+import {
+  EditNewLineContext,
+  ScopeType,
+  TargetParameters,
+} from "../../typings/target.types";
 import BaseTarget from "./BaseTarget";
 
 export interface ScopeTypeTargetParameters extends TargetParameters {
@@ -14,5 +18,11 @@ export default class ScopeTypeTarget extends BaseTarget {
     super(parameters);
     this.scopeType = parameters.scopeType;
     this.delimiter = parameters.delimiter;
+  }
+
+  getEditNewLineContext(_isAbove: boolean): EditNewLineContext {
+    return {
+      delimiter: this.delimiter,
+    };
   }
 }

--- a/src/processTargets/targets/ScopeTypeTarget.ts
+++ b/src/processTargets/targets/ScopeTypeTarget.ts
@@ -20,7 +20,7 @@ export default class ScopeTypeTarget extends BaseTarget {
     this.delimiter = parameters.delimiter;
   }
 
-  getEditNewLineContext(_isAbove: boolean): EditNewLineContext {
+  getEditNewLineContext(_isBefore: boolean): EditNewLineContext {
     return {
       delimiter: this.delimiter,
     };

--- a/src/processTargets/targets/ScopeTypeTarget.ts
+++ b/src/processTargets/targets/ScopeTypeTarget.ts
@@ -20,7 +20,11 @@ export default class ScopeTypeTarget extends BaseTarget {
     this.delimiter = parameters.delimiter;
   }
 
-  getEditNewLineContext(_isBefore: boolean): EditNewLineContext {
+  getEditNewLineContext(isBefore: boolean): EditNewLineContext {
+    // This is the default and should implement the default version whatever that is.
+    if (this.delimiter === "\n") {
+      return super.getEditNewLineContext(isBefore);
+    }
     return {
       delimiter: this.delimiter,
     };

--- a/src/processTargets/targets/ScopeTypeTarget.ts
+++ b/src/processTargets/targets/ScopeTypeTarget.ts
@@ -7,7 +7,6 @@ import BaseTarget from "./BaseTarget";
 
 export interface ScopeTypeTargetParameters extends TargetParameters {
   scopeType: ScopeType;
-  delimiter: string;
 }
 
 export default class ScopeTypeTarget extends BaseTarget {
@@ -17,7 +16,22 @@ export default class ScopeTypeTarget extends BaseTarget {
   constructor(parameters: ScopeTypeTargetParameters) {
     super(parameters);
     this.scopeType = parameters.scopeType;
-    this.delimiter = parameters.delimiter;
+    this.delimiter =
+      parameters.delimiter ?? this.getDelimiter(parameters.scopeType);
+  }
+
+  private getDelimiter(scopeType: ScopeType): string {
+    switch (scopeType) {
+      case "namedFunction":
+      case "anonymousFunction":
+      case "statement":
+      case "ifStatement":
+        return "\n";
+      case "class":
+        return "\n\n";
+      default:
+        return " ";
+    }
   }
 
   getEditNewLineContext(isBefore: boolean): EditNewLineContext {

--- a/src/test/suite/fixtures/recorded/actions/drinkArg.yml
+++ b/src/test/suite/fixtures/recorded/actions/drinkArg.yml
@@ -1,0 +1,27 @@
+languageId: typescript
+command:
+  spokenForm: drink arg
+  version: 2
+  action: editNewLineBefore
+  targets:
+    - type: primitive
+      modifiers:
+        - {type: containingScope, scopeType: argumentOrParameter}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |
+    function helloWorld(foo: string, bar: number, baz: string) {}
+  selections:
+    - anchor: {line: 0, character: 40}
+      active: {line: 0, character: 40}
+  marks: {}
+finalState:
+  documentContents: |
+    function helloWorld(foo: string, , bar: number, baz: string) {}
+  selections:
+    - anchor: {line: 0, character: 33}
+      active: {line: 0, character: 33}
+  thatMark:
+    - anchor: {line: 0, character: 35}
+      active: {line: 0, character: 46}
+fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: [{type: containingScope, scopeType: argumentOrParameter}]}]

--- a/src/test/suite/fixtures/recorded/actions/drinkBlock.yml
+++ b/src/test/suite/fixtures/recorded/actions/drinkBlock.yml
@@ -1,0 +1,29 @@
+languageId: typescript
+command:
+  spokenForm: drink block
+  version: 2
+  action: editNewLineBefore
+  targets:
+    - type: primitive
+      modifiers:
+        - {type: containingScope, scopeType: paragraph}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |
+    function helloWorld(foo: string, bar: number, baz: string) {}
+  selections:
+    - anchor: {line: 0, character: 40}
+      active: {line: 0, character: 40}
+  marks: {}
+finalState:
+  documentContents: |
+
+
+    function helloWorld(foo: string, bar: number, baz: string) {}
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  thatMark:
+    - anchor: {line: 2, character: 0}
+      active: {line: 2, character: 61}
+fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: [{type: containingScope, scopeType: paragraph}]}]

--- a/src/test/suite/fixtures/recorded/actions/pourArg.yml
+++ b/src/test/suite/fixtures/recorded/actions/pourArg.yml
@@ -1,0 +1,27 @@
+languageId: typescript
+command:
+  spokenForm: pour arg
+  version: 2
+  action: editNewLineAfter
+  targets:
+    - type: primitive
+      modifiers:
+        - {type: containingScope, scopeType: argumentOrParameter}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |
+    function helloWorld(foo: string, bar: number, baz: string) {}
+  selections:
+    - anchor: {line: 0, character: 40}
+      active: {line: 0, character: 40}
+  marks: {}
+finalState:
+  documentContents: |
+    function helloWorld(foo: string, bar: number, , baz: string) {}
+  selections:
+    - anchor: {line: 0, character: 46}
+      active: {line: 0, character: 46}
+  thatMark:
+    - anchor: {line: 0, character: 33}
+      active: {line: 0, character: 44}
+fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: [{type: containingScope, scopeType: argumentOrParameter}]}]

--- a/src/test/suite/fixtures/recorded/actions/pourBlock.yml
+++ b/src/test/suite/fixtures/recorded/actions/pourBlock.yml
@@ -1,0 +1,29 @@
+languageId: typescript
+command:
+  spokenForm: pour block
+  version: 2
+  action: editNewLineAfter
+  targets:
+    - type: primitive
+      modifiers:
+        - {type: containingScope, scopeType: paragraph}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |
+    function helloWorld(foo: string, bar: number, baz: string) {}
+  selections:
+    - anchor: {line: 0, character: 40}
+      active: {line: 0, character: 40}
+  marks: {}
+finalState:
+  documentContents: |+
+    function helloWorld(foo: string, bar: number, baz: string) {}
+
+
+  selections:
+    - anchor: {line: 2, character: 0}
+      active: {line: 2, character: 0}
+  thatMark:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 61}
+fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: [{type: containingScope, scopeType: paragraph}]}]

--- a/src/typings/target.types.ts
+++ b/src/typings/target.types.ts
@@ -301,5 +301,5 @@ export interface Target extends TargetParameters {
   maybeAddDelimiter(text: string): string;
   getRemovalRange(): Range;
   getRemovalHighlightRange(): Range | undefined;
-  getEditNewLineContext(isAbove: boolean): EditNewLineContext;
+  getEditNewLineContext(isBefore: boolean): EditNewLineContext;
 }

--- a/src/typings/target.types.ts
+++ b/src/typings/target.types.ts
@@ -245,6 +245,8 @@ export interface RemovalRange {
   exclude?: boolean;
 }
 
+export type EditNewLineContext = { command: string } | { delimiter: string };
+
 export interface TargetParameters {
   /** The text editor used for all ranges */
   editor: TextEditor;
@@ -299,4 +301,5 @@ export interface Target extends TargetParameters {
   maybeAddDelimiter(text: string): string;
   getRemovalRange(): Range;
   getRemovalHighlightRange(): Range | undefined;
+  getEditNewLineContext(isAbove: boolean): EditNewLineContext;
 }

--- a/src/util/targetUtils.ts
+++ b/src/util/targetUtils.ts
@@ -1,11 +1,7 @@
 import { zip } from "lodash";
 import { Range, Selection, TextEditor } from "vscode";
 import { getTokenDelimiters } from "../processTargets/modifiers/scopeTypeStages/TokenStage";
-import {
-  RemovalRange,
-  Target,
-  TargetParameters,
-} from "../typings/target.types";
+import { RemovalRange, Target } from "../typings/target.types";
 import {
   SelectionContext,
   SelectionWithEditor,
@@ -131,7 +127,7 @@ export function parseRemovalRange(
 
 export function selectionWithEditorWithContextToTarget(
   selection: SelectionWithEditorWithContext
-): TargetParameters {
+) {
   // TODO Only use giving context in the future when all the containing scopes have proper delimiters.
   // For now fall back on token context
   const { context } = selection;

--- a/src/util/targetUtils.ts
+++ b/src/util/targetUtils.ts
@@ -166,7 +166,7 @@ export function selectionWithEditorWithContextToTarget(
     interiorRange,
     removalRange,
     boundary,
-    delimiter: tokenContext?.delimiter ?? containingListDelimiter ?? "\n",
+    delimiter: containingListDelimiter,
     leadingDelimiter,
     trailingDelimiter,
   };


### PR DESCRIPTION
In regards too `drink/pour`

Instead of relying on the built in vscode commands for inserting new lines we can now insert our own delimiters. 

`drink arg`, `pour funk` etc is now working. Some of the scope types don't have proper delimiters but as soon as we add that to the scope type definition they will automatically work with this action. 

1. Should we rename the action now that we can insert before arbitrary delimiters and not just lines?
2. The default implementation right now is to insert a new line delimiter. If we still want to use vscode command as default just change `getEditNewLineContext` in `BaseTarget.ts` to:
```
return {
  command: this.isBefore
    ? "editor.action.insertLineBefore"
    : "editor.action.insertLineAfter",
};
```


Fixes #242 

## Checklist

- [x] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] Update existing tests
