### PR TITLE
Fixed regression in vertical range target

### DIFF
--- a/src/processTargets/processTargets.ts
+++ b/src/processTargets/processTargets.ts
@@ -10,6 +10,8 @@ import { ProcessedTargetsContext } from "../typings/Types";
 import { ensureSingleEditor } from "../util/targetUtils";
 import getMarkStage from "./getMarkStage";
 import getModifierStage from "./getModifierStage";
+import PlainTarget from "./targets/PlainTarget";
+import PositionTarget from "./targets/PositionTarget";
 
 /**
  * Converts the abstract target descriptions provided by the user to a concrete
@@ -144,7 +146,17 @@ function processVerticalRangeTarget(
       anchorTarget.contentRange.end.character
     );
 
-    results.push(anchorTarget.withContentRange(contentRange));
+    if (anchorTarget instanceof PositionTarget) {
+      results.push(anchorTarget.withContentRange(contentRange));
+    } else {
+      results.push(
+        new PlainTarget({
+          editor: anchorTarget.editor,
+          isReversed: anchorTarget.isReversed,
+          contentRange,
+        })
+      );
+    }
 
     if (i === activeLine) {
       return results;

--- a/src/test/suite/fixtures/recorded/compoundTargets/chuckLineRiskSliceMade.yml
+++ b/src/test/suite/fixtures/recorded/compoundTargets/chuckLineRiskSliceMade.yml
@@ -1,0 +1,51 @@
+languageId: plaintext
+command:
+  spokenForm: chuck line risk slice made
+  version: 2
+  targets:
+    - type: range
+      anchor:
+        type: primitive
+        mark: {type: decoratedSymbol, symbolColor: default, character: r}
+        modifiers:
+          - type: containingScope
+            scopeType: {type: line}
+      active:
+        type: primitive
+        mark: {type: decoratedSymbol, symbolColor: default, character: m}
+      excludeAnchor: false
+      excludeActive: false
+      rangeType: vertical
+  usePrePhraseSnapshot: true
+  action: {name: remove}
+initialState:
+  documentContents: |-
+    short
+    something longer
+    something even longer
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  marks:
+    default.r:
+      start: {line: 0, character: 0}
+      end: {line: 0, character: 5}
+    default.m:
+      start: {line: 2, character: 0}
+      end: {line: 2, character: 9}
+finalState:
+  documentContents: |-
+
+    hing longer
+    hing even longer
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  thatMark:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+    - anchor: {line: 1, character: 0}
+      active: {line: 1, character: 0}
+    - anchor: {line: 2, character: 0}
+      active: {line: 2, character: 0}
+fullTargets: [{type: range, excludeAnchor: false, excludeActive: false, rangeType: vertical, anchor: {type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: r}, modifiers: &ref_0 [{type: containingScope, scopeType: {type: line}}]}, active: {type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: m}, modifiers: *ref_0}}]


### PR DESCRIPTION
```
short
something longer
something even longer
```

"chuck line R slice M"

All three lines are completely removed because the new targets are still lines. This is a regression in how vertical range target is supposed to work. The solution is to always default to a plain target except in the case of a position target.

## Checklist

- [x] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
