### PR TITLE
Fix Notebook CI failures; pin vscode version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,13 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
+        vscode_version: [stable]
+        include:
+          - os: ubuntu-latest
+            vscode_version: 1.58.1
     runs-on: ${{ matrix.os }}
+    env:
+      VSCODE_VERSION: ${{ matrix.vscode_version }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/package.json
+++ b/package.json
@@ -15,10 +15,11 @@
 		"url": "https://github.com/cursorless-dev/cursorless.git"
 	},
 	"engines": {
-		"vscode": "^1.61.0"
+		"vscode": "^1.58.0"
 	},
 	"extensionKind": [
-		"workspace"
+		"workspace",
+		"ui"
 	],
 	"categories": [
 		"Other"
@@ -519,7 +520,7 @@
 		"@types/node": "^16.11.3",
 		"@types/semver": "^7.3.9",
 		"@types/sinon": "^10.0.2",
-		"@types/vscode": "^1.61.0",
+		"@types/vscode": "~1.58.0",
 		"@typescript-eslint/eslint-plugin": "^5.20.0",
 		"@typescript-eslint/parser": "^5.20.0",
 		"esbuild": "^0.11.12",

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -7,6 +7,7 @@ import {
   downloadAndUnzipVSCode,
 } from "vscode-test";
 import { extensionDependencies } from "./extensionDependencies";
+import { env } from "process";
 
 async function main() {
   try {
@@ -18,7 +19,8 @@ async function main() {
     // Passed to --extensionTestsPath
     const extensionTestsPath = path.resolve(__dirname, "./suite/index");
 
-    const vscodeExecutablePath = await downloadAndUnzipVSCode();
+    const vscodeVersion = env.VSCODE_VERSION ?? "stable";
+    const vscodeExecutablePath = await downloadAndUnzipVSCode(vscodeVersion);
     const cliPath =
       resolveCliPathFromVSCodeExecutablePath(vscodeExecutablePath);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -152,15 +152,15 @@
   dependencies:
     "@types/sinonjs__fake-timers" "*"
 
+"@types/vscode@~1.58.0":
+  version "1.58.1"
+  resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.58.1.tgz#7deae08792adc73fa57383244a0c79d3530df4f7"
+  integrity sha512-sa76rDXiSif09he8KoaWWUQxsuBr2+uND0xn1GUbEODkuEjp2p7Rqd3t5qlvklfmAedLFdL7MdnsPa57uzwcOw==
+
 "@types/sinonjs__fake-timers@*":
   version "8.1.2"
   resolved "https://registry.yarnpkg.com/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.2.tgz#bf2e02a3dbd4aecaf95942ecd99b7402e03fad5e"
   integrity sha512-9GcLXF0/v3t80caGs5p2rRfkB+a8VBGLJZVih6CNFkx8IZ994wiKKLSRs9nuFwk1HevWs/1mnUmkApGrSGsShA==
-
-"@types/vscode@^1.61.0":
-  version "1.66.0"
-  resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.66.0.tgz#e90e1308ad103f2bd31b72c17b8031b4cec0713d"
-  integrity sha512-ZfJck4M7nrGasfs4A4YbUoxis3Vu24cETw3DERsNYtDZmYSYtk6ljKexKFKhImO/ZmY6ZMsmegu2FPkXoUFImA==
 
 "@typescript-eslint/eslint-plugin@^5.20.0":
   version "5.20.0"


### PR DESCRIPTION
Fixes #767
Replaces #497

Adds backwards compatibility checks for old VSCode versions

## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
