### PR TITLE
Remove unsupported command from documentation.

### DIFF
--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -104,10 +104,9 @@ minimize syllables.
 
 ##### `"this"`
 
-The word `"this"` can be used as a mark to refer to the current cursor(s) or selection(s) as a target. Note that when combined with a modifier, the `"this"` mark can be omitted, and it will be implied.
+The word `"this"` can be used as a mark to refer to the current cursor(s) or selection(s) as a target. Note that when combined with a modifier, the `"this"` mark must be omitted, and it will be implied.
 
 - `chuck this`
-- `take this funk`
 - `pre funk`
 - `chuck line`
 


### PR DESCRIPTION
This tripped me up when I was first getting started, and is apparently still in the documentation and unsupported.

## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
