### PR TITLE
Stop updating licenses automatically

### DIFF
--- a/package.json
+++ b/package.json
@@ -502,7 +502,7 @@
 	},
 	"scripts": {
 		"vscode:prepublish": "npm run -S esbuild-base -- --minify",
-		"postinstall": "npx npm-license-crawler --onlyDirectDependencies --csv third-party-licenses.csv",
+		"update-licenses": "npx npm-license-crawler --onlyDirectDependencies --csv third-party-licenses.csv",
 		"esbuild-base": "esbuild ./src/extension.ts --bundle --outfile=dist/extension.js --external:vscode --format=cjs --platform=node",
 		"esbuild": "npm run -S esbuild-base -- --sourcemap",
 		"esbuild-watch": "npm run -S esbuild-base -- --sourcemap --watch",


### PR DESCRIPTION
The process proved to be too unreliable.  I've made it a script that needs to be run manually.  We can revisit if we find ourselves frequently adding packages; today it's a fairly rare occurrence.

## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
