### PR TITLE
Skip nx cache

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -26,7 +26,7 @@ jobs:
         run: npm ci
         working-directory: cursorless-nx
       - name: Build cheatsheet html
-        run: npx nx build cheatsheet-local --skip-nx-cache
+        run: npx nx build cheatsheet-local
         working-directory: cursorless-nx
       - name: Publish to Open VSX Registry
         uses: HaaLeo/publish-vscode-extension@v1

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -26,7 +26,7 @@ jobs:
         run: npm ci
         working-directory: cursorless-nx
       - name: Build cheatsheet html
-        run: npx nx build cheatsheet-local
+        run: npx nx build cheatsheet-local --skip-nx-cache
         working-directory: cursorless-nx
       - name: Publish to Open VSX Registry
         uses: HaaLeo/publish-vscode-extension@v1

--- a/cursorless-nx/nx.json
+++ b/cursorless-nx/nx.json
@@ -15,6 +15,7 @@
 			"runner": "@nrwl/nx-cloud",
 			"options": {
 				"cacheableOperations": ["build", "lint", "test", "e2e"],
+				"skipNxCache": true,
 				"accessToken": "YzRkMzkyMzQtYmEzNS00YzQ3LWEwMTMtNjQ5YWZjNGZlNDA2fHJlYWQtd3JpdGU="
 			}
 		}


### PR DESCRIPTION
Nx isn't properly caching outputs because we're outputting to a nonstandard location.  This means that when it tries to use the cache, it doesn't restore the artifacts we actually need, so in particular the cheatsheet html file doesn't get created.

At some point we need to figure out how to get the cache working, but for now let's just skip their cloud caching mechanism.  It's just used on deploy and our build is fairly cheap so should be fine for now

## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
