### PR TITLE
Remove empty trailing line for "chuck item" with trailing comma

### DIFF
--- a/src/processTargets/modifiers/ItemStage/ItemStage.ts
+++ b/src/processTargets/modifiers/ItemStage/ItemStage.ts
@@ -8,6 +8,7 @@ import {
 } from "../../../typings/targetDescriptor.types";
 import { ProcessedTargetsContext } from "../../../typings/Types";
 import { getInsertionDelimiter } from "../../../util/nodeSelectors";
+import { getRangeLength } from "../../../util/rangeUtils";
 import { ModifierStage } from "../../PipelineStages.types";
 import ScopeTypeTarget from "../../targets/ScopeTypeTarget";
 import ContainingSyntaxScopeStage, {
@@ -70,10 +71,24 @@ export default class ItemStage implements ModifierStage {
       trailingDelimiterRange: last.trailingDelimiterRange,
     };
 
-    return this.itemInfoToTarget(target, itemInfo);
+    // We have both leading and trailing delimiter ranges
+    // The leading one is longer/more specific so prefer to use that for removal.
+    const removalRange =
+      itemInfo.leadingDelimiterRange != null &&
+      itemInfo.trailingDelimiterRange != null &&
+      getRangeLength(target.editor, itemInfo.leadingDelimiterRange) >
+        getRangeLength(target.editor, itemInfo.trailingDelimiterRange)
+        ? itemInfo.contentRange.union(itemInfo.leadingDelimiterRange)
+        : undefined;
+
+    return this.itemInfoToTarget(target, itemInfo, removalRange);
   }
 
-  private itemInfoToTarget(target: Target, itemInfo: ItemInfo) {
+  private itemInfoToTarget(
+    target: Target,
+    itemInfo: ItemInfo,
+    removalRange?: Range
+  ) {
     const delimiter = getInsertionDelimiter(
       target.editor,
       itemInfo.leadingDelimiterRange,
@@ -88,6 +103,7 @@ export default class ItemStage implements ModifierStage {
       delimiter,
       leadingDelimiterRange: itemInfo.leadingDelimiterRange,
       trailingDelimiterRange: itemInfo.trailingDelimiterRange,
+      removalRange,
     });
   }
 }

--- a/src/test/suite/fixtures/recorded/itemTextual/chuckItem3.yml
+++ b/src/test/suite/fixtures/recorded/itemTextual/chuckItem3.yml
@@ -1,0 +1,33 @@
+languageId: plaintext
+command:
+  spokenForm: chuck item
+  version: 2
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: collectionItem}
+  usePrePhraseSnapshot: true
+  action: {name: remove}
+initialState:
+  documentContents: |-
+    [
+        foo,
+        bar,
+    ]
+  selections:
+    - anchor: {line: 2, character: 4}
+      active: {line: 2, character: 4}
+  marks: {}
+finalState:
+  documentContents: |-
+    [
+        foo,
+    ]
+  selections:
+    - anchor: {line: 1, character: 7}
+      active: {line: 1, character: 7}
+  thatMark:
+    - anchor: {line: 1, character: 7}
+      active: {line: 1, character: 7}
+fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: [{type: containingScope, scopeType: {type: collectionItem}}]}]

--- a/src/test/suite/fixtures/recorded/itemTextual/chuckItem4.yml
+++ b/src/test/suite/fixtures/recorded/itemTextual/chuckItem4.yml
@@ -1,0 +1,34 @@
+languageId: plaintext
+command:
+  spokenForm: chuck item
+  version: 2
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: collectionItem}
+  usePrePhraseSnapshot: true
+  action: {name: remove}
+initialState:
+  documentContents: |-
+    [
+        foo,
+        bar,
+        baz,
+    ]
+  selections:
+    - anchor: {line: 2, character: 8}
+      active: {line: 2, character: 7}
+  marks: {}
+finalState:
+  documentContents: |-
+    [
+        foo,
+    ]
+  selections:
+    - anchor: {line: 1, character: 7}
+      active: {line: 1, character: 7}
+  thatMark:
+    - anchor: {line: 1, character: 7}
+      active: {line: 1, character: 7}
+fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: [{type: containingScope, scopeType: {type: collectionItem}}]}]

--- a/src/util/rangeUtils.ts
+++ b/src/util/rangeUtils.ts
@@ -28,3 +28,10 @@ export function expandToFullLine(editor: TextEditor, range: Range) {
 export function makeEmptyRange(position: Position) {
   return new Range(position, position);
 }
+
+export function getRangeLength(editor: TextEditor, range: Range) {
+  return range.isEmpty
+    ? 0
+    : editor.document.offsetAt(range.end) -
+        editor.document.offsetAt(range.start);
+}


### PR DESCRIPTION
Fixes #834

This actually broke 45 tests. Basically we get off by one errors on the that mark.
`const value = "Hello world";` `"chuck vest"`. At the moment the that mark will be an empty selection adjacent the equal sign. If we prefer the leading range it will be adjacent the const instead. 


## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
