### PR TITLE
Fix CI failures by adding sleep backoff

### DIFF
--- a/src/test/suite/backwardCompatibility.test.ts
+++ b/src/test/suite/backwardCompatibility.test.ts
@@ -1,16 +1,11 @@
 import * as assert from "assert";
 import * as vscode from "vscode";
-import * as sinon from "sinon";
 import { getCursorlessApi } from "../../util/getExtensionApi";
 import { openNewEditor } from "../openNewEditor";
+import { standardSuiteSetup } from "./standardSuiteSetup";
 
 suite("Backward compatibility", async function () {
-  this.timeout("100s");
-  this.retries(3);
-
-  teardown(() => {
-    sinon.restore();
-  });
+  standardSuiteSetup(this);
 
   test("Backward compatibility", runTest);
 });

--- a/src/test/suite/breakpoints.test.ts
+++ b/src/test/suite/breakpoints.test.ts
@@ -1,19 +1,14 @@
 import * as assert from "assert";
 import * as vscode from "vscode";
-import * as sinon from "sinon";
 import { getCursorlessApi } from "../../util/getExtensionApi";
 import { openNewEditor } from "../openNewEditor";
+import { standardSuiteSetup } from "./standardSuiteSetup";
 
 suite("breakpoints", async function () {
-  this.timeout("100s");
-  this.retries(3);
+  standardSuiteSetup(this);
 
   setup(() => {
     removeBreakpoints();
-  });
-
-  teardown(() => {
-    sinon.restore();
   });
 
   suiteTeardown(() => {

--- a/src/test/suite/crossCellsSetSelection.test.ts
+++ b/src/test/suite/crossCellsSetSelection.test.ts
@@ -2,8 +2,7 @@ import * as assert from "assert";
 import * as vscode from "vscode";
 import { getCursorlessApi } from "../../util/getExtensionApi";
 import { openNewNotebookEditor } from "../openNewEditor";
-import sleep from "../../util/sleep";
-import { standardSuiteSetup } from "./standardSuiteSetup";
+import { sleepWithBackoff, standardSuiteSetup } from "./standardSuiteSetup";
 
 // Check that setSelection is able to focus the correct cell
 suite("Cross-cell set selection", async function () {
@@ -19,7 +18,7 @@ async function runTest() {
 
   // FIXME: There seems to be some timing issue when you create a notebook
   // editor
-  await sleep(1000);
+  await sleepWithBackoff(1000);
 
   await graph.hatTokenMap.addDecorations();
 

--- a/src/test/suite/crossCellsSetSelection.test.ts
+++ b/src/test/suite/crossCellsSetSelection.test.ts
@@ -1,18 +1,13 @@
 import * as assert from "assert";
 import * as vscode from "vscode";
-import * as sinon from "sinon";
 import { getCursorlessApi } from "../../util/getExtensionApi";
 import { openNewNotebookEditor } from "../openNewEditor";
 import sleep from "../../util/sleep";
+import { standardSuiteSetup } from "./standardSuiteSetup";
 
 // Check that setSelection is able to focus the correct cell
 suite("Cross-cell set selection", async function () {
-  this.timeout("100s");
-  this.retries(3);
-
-  teardown(() => {
-    sinon.restore();
-  });
+  standardSuiteSetup(this);
 
   test("Cross-cell set selection", runTest);
 });

--- a/src/test/suite/editNewCell.test.ts
+++ b/src/test/suite/editNewCell.test.ts
@@ -1,20 +1,15 @@
 import * as assert from "assert";
 import * as vscode from "vscode";
-import * as sinon from "sinon";
 import { getCursorlessApi } from "../../util/getExtensionApi";
-import { openNewNotebookEditor } from "../openNewEditor";
-import sleep from "../../util/sleep";
 import { getCellIndex } from "../../util/notebook";
+import sleep from "../../util/sleep";
+import { openNewNotebookEditor } from "../openNewEditor";
 import { getPlainNotebookContents } from "../util/notebook";
+import { standardSuiteSetup } from "./standardSuiteSetup";
 
 // Check that setSelection is able to focus the correct cell
 suite("Edit new cell", async function () {
-  this.timeout("100s");
-  this.retries(3);
-
-  teardown(() => {
-    sinon.restore();
-  });
+  standardSuiteSetup(this);
 
   test("drink cell", () =>
     runTest("drink cell", "editNewLineBefore", 0, ["", "hello"]));

--- a/src/test/suite/editNewCell.test.ts
+++ b/src/test/suite/editNewCell.test.ts
@@ -2,10 +2,9 @@ import * as assert from "assert";
 import * as vscode from "vscode";
 import { getCursorlessApi } from "../../util/getExtensionApi";
 import { getCellIndex } from "../../util/notebook";
-import sleep from "../../util/sleep";
 import { openNewNotebookEditor } from "../openNewEditor";
 import { getPlainNotebookContents } from "../util/notebook";
-import { standardSuiteSetup } from "./standardSuiteSetup";
+import { sleepWithBackoff, standardSuiteSetup } from "./standardSuiteSetup";
 
 // Check that setSelection is able to focus the correct cell
 suite("Edit new cell", async function () {
@@ -28,7 +27,7 @@ async function runTest(
 
   // FIXME: There seems to be some timing issue when you create a notebook
   // editor
-  await sleep(1000);
+  await sleepWithBackoff(1000);
 
   await graph.hatTokenMap.addDecorations();
 

--- a/src/test/suite/fold.test.ts
+++ b/src/test/suite/fold.test.ts
@@ -1,15 +1,10 @@
 import * as assert from "assert";
 import * as vscode from "vscode";
-import * as sinon from "sinon";
 import { openNewEditor } from "../openNewEditor";
+import { standardSuiteSetup } from "./standardSuiteSetup";
 
 suite("fold", async function () {
-  this.timeout("100s");
-  this.retries(3);
-
-  teardown(() => {
-    sinon.restore();
-  });
+  standardSuiteSetup(this);
 
   test("fold made", foldMade);
   test("unfold made", unfoldMade);

--- a/src/test/suite/followLink.test.ts
+++ b/src/test/suite/followLink.test.ts
@@ -1,17 +1,12 @@
 import * as assert from "assert";
-import * as vscode from "vscode";
-import * as sinon from "sinon";
 import * as os from "os";
+import * as vscode from "vscode";
 import { openNewEditor } from "../openNewEditor";
 import { getFixturePath } from "../util/getFixturePaths";
+import { standardSuiteSetup } from "./standardSuiteSetup";
 
 suite("followLink", async function () {
-  this.timeout("100s");
-  this.retries(3);
-
-  teardown(() => {
-    sinon.restore();
-  });
+  standardSuiteSetup(this);
 
   test("follow definition", followDefinition);
   test("follow link", followLink);

--- a/src/test/suite/groupByDocument.test.ts
+++ b/src/test/suite/groupByDocument.test.ts
@@ -1,16 +1,11 @@
 import * as assert from "assert";
 import * as vscode from "vscode";
-import * as sinon from "sinon";
-import { getCursorlessApi } from "../../util/getExtensionApi";
 import HatTokenMap from "../../core/HatTokenMap";
+import { getCursorlessApi } from "../../util/getExtensionApi";
+import { standardSuiteSetup } from "./standardSuiteSetup";
 
 suite("Group by document", async function () {
-  this.timeout("100s");
-  this.retries(3);
-
-  teardown(() => {
-    sinon.restore();
-  });
+  standardSuiteSetup(this);
 
   test("Group by document", runTest);
 });

--- a/src/test/suite/intraCellSetSelection.test.ts
+++ b/src/test/suite/intraCellSetSelection.test.ts
@@ -1,18 +1,13 @@
 import * as assert from "assert";
 import * as vscode from "vscode";
-import * as sinon from "sinon";
 import { getCursorlessApi } from "../../util/getExtensionApi";
-import { openNewNotebookEditor } from "../openNewEditor";
 import sleep from "../../util/sleep";
+import { openNewNotebookEditor } from "../openNewEditor";
+import { standardSuiteSetup } from "./standardSuiteSetup";
 
 // Check that setSelection is able to focus the correct cell
 suite("Within cell set selection", async function () {
-  this.timeout("100s");
-  this.retries(3);
-
-  teardown(() => {
-    sinon.restore();
-  });
+  standardSuiteSetup(this);
 
   test("Within cell set selection", runTest);
 });

--- a/src/test/suite/intraCellSetSelection.test.ts
+++ b/src/test/suite/intraCellSetSelection.test.ts
@@ -1,9 +1,8 @@
 import * as assert from "assert";
 import * as vscode from "vscode";
 import { getCursorlessApi } from "../../util/getExtensionApi";
-import sleep from "../../util/sleep";
 import { openNewNotebookEditor } from "../openNewEditor";
-import { standardSuiteSetup } from "./standardSuiteSetup";
+import { sleepWithBackoff, standardSuiteSetup } from "./standardSuiteSetup";
 
 // Check that setSelection is able to focus the correct cell
 suite("Within cell set selection", async function () {
@@ -19,7 +18,7 @@ async function runTest() {
 
   // FIXME: There seems to be some timing issue when you create a notebook
   // editor
-  await sleep(1000);
+  await sleepWithBackoff(1000);
 
   await graph.hatTokenMap.addDecorations();
 

--- a/src/test/suite/prePhraseSnapshot.test.ts
+++ b/src/test/suite/prePhraseSnapshot.test.ts
@@ -1,10 +1,10 @@
 import * as assert from "assert";
 import * as vscode from "vscode";
-import * as sinon from "sinon";
-import { getCursorlessApi } from "../../util/getExtensionApi";
 import { selectionToPlainObject } from "../../testUtil/toPlainObject";
+import { getCursorlessApi } from "../../util/getExtensionApi";
 import { mockPrePhraseGetVersion } from "../mockPrePhraseGetVersion";
 import { openNewEditor } from "../openNewEditor";
+import { standardSuiteSetup } from "./standardSuiteSetup";
 
 /**
  * The selections we expect when the pre-phrase snapshot is used
@@ -17,12 +17,7 @@ const snapshotExpectedSelections = [new vscode.Selection(0, 6, 0, 11)];
 const noSnapshotExpectedSelections = [new vscode.Selection(1, 6, 1, 11)];
 
 suite("Pre-phrase snapshots", async function () {
-  this.timeout("100s");
-  this.retries(3);
-
-  teardown(() => {
-    sinon.restore();
-  });
+  standardSuiteSetup(this);
 
   test("Pre-phrase snapshot; single phrase", () =>
     runTest(true, false, snapshotExpectedSelections));

--- a/src/test/suite/recorded.test.ts
+++ b/src/test/suite/recorded.test.ts
@@ -21,11 +21,10 @@ import {
 } from "../../testUtil/toPlainObject";
 import { Clipboard } from "../../util/Clipboard";
 import { getCursorlessApi } from "../../util/getExtensionApi";
-import sleep from "../../util/sleep";
 import { openNewEditor } from "../openNewEditor";
 import asyncSafety from "../util/asyncSafety";
 import { getRecordedTestPaths } from "../util/getFixturePaths";
-import { standardSuiteSetup } from "./standardSuiteSetup";
+import { sleepWithBackoff, standardSuiteSetup } from "./standardSuiteSetup";
 
 function createPosition(position: PositionPlainObject) {
   return new vscode.Position(position.line, position.character);
@@ -72,7 +71,7 @@ async function runTest(file: string) {
   );
 
   if (fixture.postEditorOpenSleepTimeMs != null) {
-    await sleep(fixture.postEditorOpenSleepTimeMs);
+    await sleepWithBackoff(fixture.postEditorOpenSleepTimeMs);
   }
 
   editor.selections = fixture.initialState.selections.map(createSelection);
@@ -133,7 +132,7 @@ async function runTest(file: string) {
   );
 
   if (fixture.postCommandSleepTimeMs != null) {
-    await sleep(fixture.postCommandSleepTimeMs);
+    await sleepWithBackoff(fixture.postCommandSleepTimeMs);
   }
 
   const marks =

--- a/src/test/suite/recorded.test.ts
+++ b/src/test/suite/recorded.test.ts
@@ -1,7 +1,6 @@
 import * as assert from "assert";
 import { promises as fsp } from "fs";
 import * as yaml from "js-yaml";
-import * as sinon from "sinon";
 import * as vscode from "vscode";
 import HatTokenMap from "../../core/HatTokenMap";
 import { ReadOnlyHatMap } from "../../core/IndividualHatMap";
@@ -26,6 +25,7 @@ import sleep from "../../util/sleep";
 import { openNewEditor } from "../openNewEditor";
 import asyncSafety from "../util/asyncSafety";
 import { getRecordedTestPaths } from "../util/getFixturePaths";
+import { standardSuiteSetup } from "./standardSuiteSetup";
 
 function createPosition(position: PositionPlainObject) {
   return new vscode.Position(position.line, position.character);
@@ -38,12 +38,7 @@ function createSelection(selection: SelectionPlainObject): vscode.Selection {
 }
 
 suite("recorded test cases", async function () {
-  this.timeout("100s");
-  this.retries(5);
-
-  teardown(() => {
-    sinon.restore();
-  });
+  standardSuiteSetup(this);
 
   suiteSetup(async () => {
     // Necessary because opening a notebook opens the panel for some reason

--- a/src/test/suite/recorded.test.ts
+++ b/src/test/suite/recorded.test.ts
@@ -24,6 +24,7 @@ import { getCursorlessApi } from "../../util/getExtensionApi";
 import { openNewEditor } from "../openNewEditor";
 import asyncSafety from "../util/asyncSafety";
 import { getRecordedTestPaths } from "../util/getFixturePaths";
+import shouldUpdateFixtures from "./shouldUpdateFixtures";
 import { sleepWithBackoff, standardSuiteSetup } from "./standardSuiteSetup";
 
 function createPosition(position: PositionPlainObject) {
@@ -164,7 +165,7 @@ async function runTest(file: string) {
       ? undefined
       : testDecorationsToPlainObject(graph.editStyles.testDecorations);
 
-  if (process.env.CURSORLESS_TEST_UPDATE_FIXTURES === "true") {
+  if (shouldUpdateFixtures()) {
     const outputFixture = {
       ...fixture,
       finalState: resultState,

--- a/src/test/suite/scroll.test.ts
+++ b/src/test/suite/scroll.test.ts
@@ -1,15 +1,10 @@
 import * as assert from "assert";
 import * as vscode from "vscode";
-import * as sinon from "sinon";
 import { openNewEditor } from "../openNewEditor";
+import { standardSuiteSetup } from "./standardSuiteSetup";
 
 suite("scroll", async function () {
-  this.timeout("100s");
-  this.retries(3);
-
-  teardown(() => {
-    sinon.restore();
-  });
+  standardSuiteSetup(this);
 
   test("top whale", topWhale);
   test("bottom whale", bottomWhale);

--- a/src/test/suite/shouldUpdateFixtures.ts
+++ b/src/test/suite/shouldUpdateFixtures.ts
@@ -1,0 +1,7 @@
+/**
+ * Used to check weather the update fixers launch config was used.
+ * @returns `true` if developer used to the update fixtures launch config
+ */
+export default function shouldUpdateFixtures() {
+  return process.env.CURSORLESS_TEST_UPDATE_FIXTURES === "true";
+}

--- a/src/test/suite/shouldUpdateFixtures.ts
+++ b/src/test/suite/shouldUpdateFixtures.ts
@@ -1,5 +1,5 @@
 /**
- * Used to check weather the update fixers launch config was used.
+ * Used to check weather the update fixtures launch config was used.
  * @returns `true` if developer used to the update fixtures launch config
  */
 export default function shouldUpdateFixtures() {

--- a/src/test/suite/standardSuiteSetup.ts
+++ b/src/test/suite/standardSuiteSetup.ts
@@ -1,10 +1,43 @@
+import { Context } from "mocha";
 import * as sinon from "sinon";
+import sleep from "../../util/sleep";
+
+/**
+ * The number of times the current test has been retried. Will be 0 the first
+ * time the test runs and increase by 1 each time the test fails and needs to be
+ * rerun.
+ */
+let retryCount = -1;
+
+/**
+ * The title of the previously run test. Used to keep track of
+ * {@link retryCount}.
+ */
+let previousTestTitle = "";
 
 export function standardSuiteSetup(suite: Mocha.Suite) {
-  suite.timeout("100s");
+  suite.timeout();
   suite.retries(5);
 
   teardown(() => {
     sinon.restore();
   });
+
+  setup(async function (this: Context) {
+    const title = this.test!.fullTitle();
+    retryCount = title === previousTestTitle ? retryCount + 1 : 0;
+    previousTestTitle = title;
+  });
+}
+
+/**
+ * Sleep function for use in tests that will be retried. Doubles the amount of
+ * time it sleeps each time a test is run, starting from {@link ms} / 4.
+ * @param ms The baseline number of milliseconds to sleep.
+ * @returns A promise that will resolve when the sleep is over
+ */
+
+export function sleepWithBackoff(ms: number) {
+  console.log(`Sleeping; runNumber = ${retryCount}`);
+  return sleep(ms * Math.pow(2, retryCount - 2));
 }

--- a/src/test/suite/standardSuiteSetup.ts
+++ b/src/test/suite/standardSuiteSetup.ts
@@ -36,7 +36,8 @@ export function standardSuiteSetup(suite: Mocha.Suite) {
  * time it sleeps each time a test is run, starting from {@link ms} / 4.
  *
  * If the user used the update fixtures launch config, we sleep for {@link ms} *
- * 2 every time.
+ * 2 every time so that they don't get spurious updates to fixtures due to not
+ * sleeping enough.
  * @param ms The baseline number of milliseconds to sleep.
  * @returns A promise that will resolve when the sleep is over
  */

--- a/src/test/suite/standardSuiteSetup.ts
+++ b/src/test/suite/standardSuiteSetup.ts
@@ -1,6 +1,7 @@
 import { Context } from "mocha";
 import * as sinon from "sinon";
 import sleep from "../../util/sleep";
+import shouldUpdateFixtures from "./shouldUpdateFixtures";
 
 /**
  * The number of times the current test has been retried. Will be 0 the first
@@ -33,9 +34,16 @@ export function standardSuiteSetup(suite: Mocha.Suite) {
 /**
  * Sleep function for use in tests that will be retried. Doubles the amount of
  * time it sleeps each time a test is run, starting from {@link ms} / 4.
+ *
+ * If the user used the update fixtures launch config, we sleep for {@link ms} *
+ * 2 every time.
  * @param ms The baseline number of milliseconds to sleep.
  * @returns A promise that will resolve when the sleep is over
  */
 export function sleepWithBackoff(ms: number) {
-  return sleep(ms * Math.pow(2, retryCount - 2));
+  const timeToSleep = shouldUpdateFixtures()
+    ? ms * 2
+    : ms * Math.pow(2, retryCount - 2);
+
+  return sleep(timeToSleep);
 }

--- a/src/test/suite/standardSuiteSetup.ts
+++ b/src/test/suite/standardSuiteSetup.ts
@@ -1,0 +1,10 @@
+import * as sinon from "sinon";
+
+export function standardSuiteSetup(suite: Mocha.Suite) {
+  suite.timeout("100s");
+  suite.retries(5);
+
+  teardown(() => {
+    sinon.restore();
+  });
+}

--- a/src/test/suite/standardSuiteSetup.ts
+++ b/src/test/suite/standardSuiteSetup.ts
@@ -36,8 +36,6 @@ export function standardSuiteSetup(suite: Mocha.Suite) {
  * @param ms The baseline number of milliseconds to sleep.
  * @returns A promise that will resolve when the sleep is over
  */
-
 export function sleepWithBackoff(ms: number) {
-  console.log(`Sleeping; runNumber = ${retryCount}`);
   return sleep(ms * Math.pow(2, retryCount - 2));
 }

--- a/src/test/suite/standardSuiteSetup.ts
+++ b/src/test/suite/standardSuiteSetup.ts
@@ -16,7 +16,7 @@ let retryCount = -1;
 let previousTestTitle = "";
 
 export function standardSuiteSetup(suite: Mocha.Suite) {
-  suite.timeout();
+  suite.timeout("100s");
   suite.retries(5);
 
   teardown(() => {

--- a/src/test/suite/standardSuiteSetup.ts
+++ b/src/test/suite/standardSuiteSetup.ts
@@ -35,7 +35,7 @@ export function standardSuiteSetup(suite: Mocha.Suite) {
  * Sleep function for use in tests that will be retried. Doubles the amount of
  * time it sleeps each time a test is run, starting from {@link ms} / 4.
  *
- * If the user used the update fixtures launch config, we sleep for {@link ms} *
+ * If the developer used the update fixtures launch config, we sleep for {@link ms} *
  * 2 every time so that they don't get spurious updates to fixtures due to not
  * sleeping enough.
  * @param ms The baseline number of milliseconds to sleep.

--- a/src/test/suite/toggleDecorations.test.ts
+++ b/src/test/suite/toggleDecorations.test.ts
@@ -1,16 +1,11 @@
 import * as assert from "assert";
 import * as vscode from "vscode";
-import * as sinon from "sinon";
 import { getCursorlessApi } from "../../util/getExtensionApi";
 import { openNewEditor } from "../openNewEditor";
+import { standardSuiteSetup } from "./standardSuiteSetup";
 
 suite("toggle decorations", async function () {
-  this.timeout("100s");
-  this.retries(3);
-
-  teardown(() => {
-    sinon.restore();
-  });
+  standardSuiteSetup(this);
 
   test("toggle decorations", () => runTest());
 });

--- a/src/util/sleep.ts
+++ b/src/util/sleep.ts
@@ -1,3 +1,13 @@
 import { promisify } from "util";
 
-export default promisify(setTimeout);
+/**
+ * Sleep function that returns a promise that resolves when the sleep is
+ * complete.
+ *
+ * WARNING: Please do not use this function in tests, because we retry our tests
+ * on failure, and this function will sleep the same amount of time every time
+ * the test is retried.  Prefer {@link sleepWithBackoff} instead.
+ */
+const sleep = promisify(setTimeout);
+
+export default sleep;


### PR DESCRIPTION
Instead of sleeping the same amount of time every time we run a test, we double the sleep every time

Fixes #845

## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
