### PR TITLE
Update Java patterns for new tree-sitter grammar

### DIFF
--- a/src/languages/java.ts
+++ b/src/languages/java.ts
@@ -57,7 +57,7 @@ const nodeMatchers: Partial<
   className: "class_declaration[name]",
   ifStatement: "if_statement",
   string: "string_literal",
-  comment: "comment",
+  comment: ["line_comment", "block_comment", "comment"],
   anonymousFunction: "lambda_expression",
   list: "array_initializer",
   functionCall: [

--- a/src/test/suite/fixtures/recorded/languages/java/clearComment.yml
+++ b/src/test/suite/fixtures/recorded/languages/java/clearComment.yml
@@ -1,0 +1,26 @@
+languageId: java
+command:
+  spokenForm: clear comment
+  version: 2
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: comment}
+  usePrePhraseSnapshot: true
+  action: {name: clearAndSetSelection}
+initialState:
+  documentContents: /* Hello world */
+  selections:
+    - anchor: {line: 0, character: 9}
+      active: {line: 0, character: 9}
+  marks: {}
+finalState:
+  documentContents: ""
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  thatMark:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: [{type: containingScope, scopeType: {type: comment}}]}]


### PR DESCRIPTION
Backwards compatible with existing parser; can drop that once https://github.com/cursorless-dev/vscode-parse-tree/pull/37 is released

## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
