### PR TITLE
[WIP] Add Elm

### DIFF
--- a/src/languages/constants.ts
+++ b/src/languages/constants.ts
@@ -4,6 +4,7 @@ export const supportedLanguageIds = [
   "cpp",
   "css",
   "csharp",
+  "elm",
   "go",
   "html",
   "java",

--- a/src/languages/elm.ts
+++ b/src/languages/elm.ts
@@ -1,0 +1,55 @@
+import { SimpleScopeTypeType } from "../typings/targetDescriptor.types";
+import { NodeMatcherAlternative } from "../typings/Types";
+import { createPatternMatchers } from "../util/nodeMatchers";
+
+const nodeMatchers: Partial<
+  Record<SimpleScopeTypeType, NodeMatcherAlternative>
+> = {
+  map: ["record_expr", "record_pattern"],
+  list: ["list_expr", "list_pattern"],
+  statement: [
+    // not all of these are "statements" in Elm, but they fit the usage pattern in Cursorless
+    "let_in_expr",
+    "case_of_expr",
+    "port_annotation",
+    "infix_declaration",
+    "if_else_expr",
+  ],
+  string: "string_constant_expr",
+  collectionItem: ["exposed_value"],
+  collectionKey: ["field_type[name]", "record_expr.field![name]"],
+  ifStatement: "if_else_expr",
+  anonymousFunction: "anonymous_function_expr",
+  functionCall: "function_call_expr",
+  functionCallee: "function_call_expr[target][name]",
+  comment: ["block_comment", "line_comment"],
+  namedFunction: "value_declaration",
+  functionName: "value_declaration[functionDeclarationLeft][0]",
+  condition: "if_else_expr[0]",
+  type: [
+    "type_ref",
+    "type_expression",
+    "type_declaration",
+    "type_annotation[typeExpression]!",
+    "type_alias_declaration",
+    // TODO: select type from within function (needs to find the previous sibling of the parent `value_decoration`)
+  ],
+  name: [
+    "type_annotation[name]",
+    "port_annotation[name]",
+    "type_declaration[name]",
+    "type_alias_declaration[name]",
+    "value_declaration.function_declaration_left.lower_case_identifier!",
+  ],
+  value: [
+    "record_expr[field][expression]",
+    "value_declaration[body]",
+    "case_of_branch[expr]",
+    "let_in_expr[body]",
+  ],
+  argumentOrParameter: [
+    "value_declaration.function_declaration_left[pattern]!",
+  ],
+};
+
+export default createPatternMatchers(nodeMatchers);

--- a/src/languages/getNodeMatcher.ts
+++ b/src/languages/getNodeMatcher.ts
@@ -10,6 +10,7 @@ import { SimpleScopeTypeType } from "../typings/targetDescriptor.types";
 import cpp from "./cpp";
 import clojure from "./clojure";
 import csharp from "./csharp";
+import elm from "./elm";
 import { patternMatchers as json } from "./json";
 import { patternMatchers as typescript } from "./typescript";
 import java from "./java";
@@ -58,6 +59,7 @@ const languageMatchers: Record<
   css: scss,
   csharp,
   clojure,
+  elm,
   go,
   html,
   java,

--- a/src/languages/getTextFragmentExtractor.ts
+++ b/src/languages/getTextFragmentExtractor.ts
@@ -136,6 +136,7 @@ const textFragmentExtractors: Record<
     "css",
     scssStringTextFragmentExtractor
   ),
+  elm: constructDefaultTextFragmentExtractor("elm"),
   go: constructDefaultTextFragmentExtractor("go"),
   html: constructDefaultTextFragmentExtractor(
     "html",

--- a/src/test/extensionDependencies.ts
+++ b/src/test/extensionDependencies.ts
@@ -2,4 +2,5 @@ export const extensionDependencies = [
   "pokey.parse-tree",
   "ms-toolsai.jupyter",
   "scalameta.metals",
+  "Elmtooling.elm-ls-vscode",
 ];

--- a/src/test/suite/fixtures/recorded/languages/elm/changeCallFar.yml
+++ b/src/test/suite/fixtures/recorded/languages/elm/changeCallFar.yml
@@ -1,0 +1,30 @@
+languageId: elm
+command:
+  spokenForm: change call far
+  version: 2
+  targets:
+    - type: primitive
+      mark: {type: decoratedSymbol, symbolColor: default, character: f}
+      modifiers:
+        - type: containingScope
+          scopeType: {type: functionCall}
+  usePrePhraseSnapshot: true
+  action: {name: clearAndSetSelection}
+initialState:
+  documentContents: _ = f x
+  selections:
+    - anchor: {line: 0, character: 1}
+      active: {line: 0, character: 1}
+  marks:
+    default.f:
+      start: {line: 0, character: 4}
+      end: {line: 0, character: 5}
+finalState:
+  documentContents: "_ = "
+  selections:
+    - anchor: {line: 0, character: 4}
+      active: {line: 0, character: 4}
+  thatMark:
+    - anchor: {line: 0, character: 4}
+      active: {line: 0, character: 4}
+fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: f}, modifiers: [{type: containingScope, scopeType: {type: functionCall}}]}]

--- a/src/test/suite/fixtures/recorded/languages/elm/changeCallee.yml
+++ b/src/test/suite/fixtures/recorded/languages/elm/changeCallee.yml
@@ -1,0 +1,30 @@
+languageId: elm
+command:
+  spokenForm: change callee
+  version: 2
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: functionCallee}
+  usePrePhraseSnapshot: true
+  action: {name: clearAndSetSelection}
+initialState:
+  documentContents: |+
+    f = g x
+
+  selections:
+    - anchor: {line: 0, character: 6}
+      active: {line: 0, character: 6}
+  marks: {}
+finalState:
+  documentContents: |+
+    f =  x
+
+  selections:
+    - anchor: {line: 0, character: 4}
+      active: {line: 0, character: 4}
+  thatMark:
+    - anchor: {line: 0, character: 4}
+      active: {line: 0, character: 4}
+fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: [{type: containingScope, scopeType: {type: functionCallee}}]}]

--- a/src/test/suite/fixtures/recorded/languages/elm/changeCondition.yml
+++ b/src/test/suite/fixtures/recorded/languages/elm/changeCondition.yml
@@ -1,0 +1,30 @@
+languageId: elm
+command:
+  spokenForm: change condition
+  version: 2
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: condition}
+  usePrePhraseSnapshot: true
+  action: {name: clearAndSetSelection}
+initialState:
+  documentContents: |+
+    f = if x then y else z
+
+  selections:
+    - anchor: {line: 0, character: 20}
+      active: {line: 0, character: 20}
+  marks: {}
+finalState:
+  documentContents: |+
+    f = if  then y else z
+
+  selections:
+    - anchor: {line: 0, character: 7}
+      active: {line: 0, character: 7}
+  thatMark:
+    - anchor: {line: 0, character: 7}
+      active: {line: 0, character: 7}
+fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: [{type: containingScope, scopeType: {type: condition}}]}]

--- a/src/test/suite/fixtures/recorded/languages/elm/changeEveryItem.yml
+++ b/src/test/suite/fixtures/recorded/languages/elm/changeEveryItem.yml
@@ -1,0 +1,32 @@
+languageId: elm
+command:
+  spokenForm: change every item
+  version: 2
+  targets:
+    - type: primitive
+      modifiers:
+        - type: everyScope
+          scopeType: {type: collectionItem}
+  usePrePhraseSnapshot: true
+  action: {name: clearAndSetSelection}
+initialState:
+  documentContents: |
+    import List exposing (head, tail)
+  selections:
+    - anchor: {line: 0, character: 28}
+      active: {line: 0, character: 28}
+  marks: {}
+finalState:
+  documentContents: |
+    import List exposing (, )
+  selections:
+    - anchor: {line: 0, character: 22}
+      active: {line: 0, character: 22}
+    - anchor: {line: 0, character: 24}
+      active: {line: 0, character: 24}
+  thatMark:
+    - anchor: {line: 0, character: 22}
+      active: {line: 0, character: 22}
+    - anchor: {line: 0, character: 24}
+      active: {line: 0, character: 24}
+fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: [{type: everyScope, scopeType: {type: collectionItem}}]}]

--- a/src/test/suite/fixtures/recorded/languages/elm/changeEveryItem2.yml
+++ b/src/test/suite/fixtures/recorded/languages/elm/changeEveryItem2.yml
@@ -1,0 +1,30 @@
+languageId: elm
+command:
+  spokenForm: change every item
+  version: 2
+  targets:
+    - type: primitive
+      modifiers:
+        - type: everyScope
+          scopeType: {type: collectionItem}
+  usePrePhraseSnapshot: true
+  action: {name: clearAndSetSelection}
+initialState:
+  documentContents: module Main exposing (main, foo)
+  selections:
+    - anchor: {line: 0, character: 31}
+      active: {line: 0, character: 31}
+  marks: {}
+finalState:
+  documentContents: module Main exposing (, )
+  selections:
+    - anchor: {line: 0, character: 22}
+      active: {line: 0, character: 22}
+    - anchor: {line: 0, character: 24}
+      active: {line: 0, character: 24}
+  thatMark:
+    - anchor: {line: 0, character: 22}
+      active: {line: 0, character: 22}
+    - anchor: {line: 0, character: 24}
+      active: {line: 0, character: 24}
+fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: [{type: everyScope, scopeType: {type: collectionItem}}]}]

--- a/src/test/suite/fixtures/recorded/languages/elm/changeEveryItem3.yml
+++ b/src/test/suite/fixtures/recorded/languages/elm/changeEveryItem3.yml
@@ -1,0 +1,32 @@
+languageId: elm
+command:
+  spokenForm: change every item
+  version: 2
+  targets:
+    - type: primitive
+      modifiers:
+        - type: everyScope
+          scopeType: {type: collectionItem}
+  usePrePhraseSnapshot: true
+  action: {name: clearAndSetSelection}
+initialState:
+  documentContents: |
+    f = {x = 1, y = 2}
+  selections:
+    - anchor: {line: 0, character: 17}
+      active: {line: 0, character: 17}
+  marks: {}
+finalState:
+  documentContents: |
+    f = {, }
+  selections:
+    - anchor: {line: 0, character: 5}
+      active: {line: 0, character: 5}
+    - anchor: {line: 0, character: 7}
+      active: {line: 0, character: 7}
+  thatMark:
+    - anchor: {line: 0, character: 5}
+      active: {line: 0, character: 5}
+    - anchor: {line: 0, character: 7}
+      active: {line: 0, character: 7}
+fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: [{type: everyScope, scopeType: {type: collectionItem}}]}]

--- a/src/test/suite/fixtures/recorded/languages/elm/changeFunk.yml
+++ b/src/test/suite/fixtures/recorded/languages/elm/changeFunk.yml
@@ -1,0 +1,29 @@
+languageId: elm
+command:
+  spokenForm: change funk
+  version: 2
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: namedFunction}
+  usePrePhraseSnapshot: true
+  action: {name: clearAndSetSelection}
+initialState:
+  documentContents: |
+    f x =
+        x
+  selections:
+    - anchor: {line: 1, character: 4}
+      active: {line: 1, character: 4}
+  marks: {}
+finalState:
+  documentContents: |+
+
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  thatMark:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: [{type: containingScope, scopeType: {type: namedFunction}}]}]

--- a/src/test/suite/fixtures/recorded/languages/elm/changeFunkName.yml
+++ b/src/test/suite/fixtures/recorded/languages/elm/changeFunkName.yml
@@ -1,0 +1,30 @@
+languageId: elm
+command:
+  spokenForm: change funk name
+  version: 2
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: functionName}
+  usePrePhraseSnapshot: true
+  action: {name: clearAndSetSelection}
+initialState:
+  documentContents: |
+    f x =
+        x
+  selections:
+    - anchor: {line: 1, character: 4}
+      active: {line: 1, character: 4}
+  marks: {}
+finalState:
+  documentContents: |2
+     x =
+        x
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  thatMark:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: [{type: containingScope, scopeType: {type: functionName}}]}]

--- a/src/test/suite/fixtures/recorded/languages/elm/changeFunkName2.yml
+++ b/src/test/suite/fixtures/recorded/languages/elm/changeFunkName2.yml
@@ -1,0 +1,30 @@
+languageId: elm
+command:
+  spokenForm: change funk name
+  version: 2
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: functionName}
+  usePrePhraseSnapshot: false
+  action: {name: clearAndSetSelection}
+initialState:
+  documentContents: |
+    f x =
+        x
+  selections:
+    - anchor: {line: 1, character: 4}
+      active: {line: 1, character: 4}
+  marks: {}
+finalState:
+  documentContents: |2
+     x =
+        x
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  thatMark:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: [{type: containingScope, scopeType: {type: functionName}}]}]

--- a/src/test/suite/fixtures/recorded/languages/elm/changeIfState.yml
+++ b/src/test/suite/fixtures/recorded/languages/elm/changeIfState.yml
@@ -1,0 +1,28 @@
+languageId: elm
+command:
+  spokenForm: change if state
+  version: 2
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: ifStatement}
+  usePrePhraseSnapshot: true
+  action: {name: clearAndSetSelection}
+initialState:
+  documentContents: |
+    _ = if True then 1 else 0
+  selections:
+    - anchor: {line: 0, character: 4}
+      active: {line: 0, character: 4}
+  marks: {}
+finalState:
+  documentContents: |
+    _ = 
+  selections:
+    - anchor: {line: 0, character: 4}
+      active: {line: 0, character: 4}
+  thatMark:
+    - anchor: {line: 0, character: 4}
+      active: {line: 0, character: 4}
+fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: [{type: containingScope, scopeType: {type: ifStatement}}]}]

--- a/src/test/suite/fixtures/recorded/languages/elm/changeIfStateInk.yml
+++ b/src/test/suite/fixtures/recorded/languages/elm/changeIfStateInk.yml
@@ -1,0 +1,32 @@
+languageId: elm
+command:
+  spokenForm: change if state ink
+  version: 2
+  targets:
+    - type: primitive
+      mark: {type: decoratedSymbol, symbolColor: default, character: i}
+      modifiers:
+        - type: containingScope
+          scopeType: {type: ifStatement}
+  usePrePhraseSnapshot: true
+  action: {name: clearAndSetSelection}
+initialState:
+  documentContents: |
+    _ = if True then 1 else 0
+  selections:
+    - anchor: {line: 1, character: 0}
+      active: {line: 1, character: 0}
+  marks:
+    default.i:
+      start: {line: 0, character: 4}
+      end: {line: 0, character: 6}
+finalState:
+  documentContents: |
+    _ = 
+  selections:
+    - anchor: {line: 0, character: 4}
+      active: {line: 0, character: 4}
+  thatMark:
+    - anchor: {line: 0, character: 4}
+      active: {line: 0, character: 4}
+fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: i}, modifiers: [{type: containingScope, scopeType: {type: ifStatement}}]}]

--- a/src/test/suite/fixtures/recorded/languages/elm/changeItem.yml
+++ b/src/test/suite/fixtures/recorded/languages/elm/changeItem.yml
@@ -1,0 +1,28 @@
+languageId: elm
+command:
+  spokenForm: change item
+  version: 2
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: collectionItem}
+  usePrePhraseSnapshot: true
+  action: {name: clearAndSetSelection}
+initialState:
+  documentContents: |
+    f = {x = 1, y = 2}
+  selections:
+    - anchor: {line: 0, character: 17}
+      active: {line: 0, character: 17}
+  marks: {}
+finalState:
+  documentContents: |
+    f = {x = 1, }
+  selections:
+    - anchor: {line: 0, character: 12}
+      active: {line: 0, character: 12}
+  thatMark:
+    - anchor: {line: 0, character: 12}
+      active: {line: 0, character: 12}
+fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: [{type: containingScope, scopeType: {type: collectionItem}}]}]

--- a/src/test/suite/fixtures/recorded/languages/elm/changeKey.yml
+++ b/src/test/suite/fixtures/recorded/languages/elm/changeKey.yml
@@ -1,0 +1,30 @@
+languageId: elm
+command:
+  spokenForm: change key
+  version: 2
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: collectionKey}
+  usePrePhraseSnapshot: true
+  action: {name: clearAndSetSelection}
+initialState:
+  documentContents: |
+    f : { x : Int }
+    f = { x = 0 }
+  selections:
+    - anchor: {line: 0, character: 10}
+      active: {line: 0, character: 10}
+  marks: {}
+finalState:
+  documentContents: |
+    f : {  : Int }
+    f = { x = 0 }
+  selections:
+    - anchor: {line: 0, character: 6}
+      active: {line: 0, character: 6}
+  thatMark:
+    - anchor: {line: 0, character: 6}
+      active: {line: 0, character: 6}
+fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: [{type: containingScope, scopeType: {type: collectionKey}}]}]

--- a/src/test/suite/fixtures/recorded/languages/elm/changeKey2.yml
+++ b/src/test/suite/fixtures/recorded/languages/elm/changeKey2.yml
@@ -1,0 +1,30 @@
+languageId: elm
+command:
+  spokenForm: change key
+  version: 2
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: collectionKey}
+  usePrePhraseSnapshot: false
+  action: {name: clearAndSetSelection}
+initialState:
+  documentContents: |
+    f : { x : Int }
+    f = { x = 0 }
+  selections:
+    - anchor: {line: 1, character: 10}
+      active: {line: 1, character: 10}
+  marks: {}
+finalState:
+  documentContents: |
+    f : { x : Int }
+    f = {  = 0 }
+  selections:
+    - anchor: {line: 1, character: 6}
+      active: {line: 1, character: 6}
+  thatMark:
+    - anchor: {line: 1, character: 6}
+      active: {line: 1, character: 6}
+fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: [{type: containingScope, scopeType: {type: collectionKey}}]}]

--- a/src/test/suite/fixtures/recorded/languages/elm/changeLambda.yml
+++ b/src/test/suite/fixtures/recorded/languages/elm/changeLambda.yml
@@ -1,0 +1,26 @@
+languageId: elm
+command:
+  spokenForm: change lambda
+  version: 2
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: anonymousFunction}
+  usePrePhraseSnapshot: true
+  action: {name: clearAndSetSelection}
+initialState:
+  documentContents: _ = \x -> x
+  selections:
+    - anchor: {line: 0, character: 9}
+      active: {line: 0, character: 9}
+  marks: {}
+finalState:
+  documentContents: "_ = "
+  selections:
+    - anchor: {line: 0, character: 4}
+      active: {line: 0, character: 4}
+  thatMark:
+    - anchor: {line: 0, character: 4}
+      active: {line: 0, character: 4}
+fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: [{type: containingScope, scopeType: {type: anonymousFunction}}]}]

--- a/src/test/suite/fixtures/recorded/languages/elm/changeLambdaPlex.yml
+++ b/src/test/suite/fixtures/recorded/languages/elm/changeLambdaPlex.yml
@@ -1,0 +1,30 @@
+languageId: elm
+command:
+  spokenForm: change lambda plex
+  version: 2
+  targets:
+    - type: primitive
+      mark: {type: decoratedSymbol, symbolColor: default, character: x}
+      modifiers:
+        - type: containingScope
+          scopeType: {type: anonymousFunction}
+  usePrePhraseSnapshot: true
+  action: {name: clearAndSetSelection}
+initialState:
+  documentContents: _ = \x -> x
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  marks:
+    default.x:
+      start: {line: 0, character: 5}
+      end: {line: 0, character: 6}
+finalState:
+  documentContents: "_ = "
+  selections:
+    - anchor: {line: 0, character: 4}
+      active: {line: 0, character: 4}
+  thatMark:
+    - anchor: {line: 0, character: 4}
+      active: {line: 0, character: 4}
+fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: x}, modifiers: [{type: containingScope, scopeType: {type: anonymousFunction}}]}]

--- a/src/test/suite/fixtures/recorded/languages/elm/changeList.yml
+++ b/src/test/suite/fixtures/recorded/languages/elm/changeList.yml
@@ -1,0 +1,28 @@
+languageId: elm
+command:
+  spokenForm: change list
+  version: 2
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: list}
+  usePrePhraseSnapshot: true
+  action: {name: clearAndSetSelection}
+initialState:
+  documentContents: |
+    _ = [1, 2, 3]
+  selections:
+    - anchor: {line: 0, character: 9}
+      active: {line: 0, character: 9}
+  marks: {}
+finalState:
+  documentContents: |
+    _ = 
+  selections:
+    - anchor: {line: 0, character: 4}
+      active: {line: 0, character: 4}
+  thatMark:
+    - anchor: {line: 0, character: 4}
+      active: {line: 0, character: 4}
+fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: [{type: containingScope, scopeType: {type: list}}]}]

--- a/src/test/suite/fixtures/recorded/languages/elm/changeListAir.yml
+++ b/src/test/suite/fixtures/recorded/languages/elm/changeListAir.yml
@@ -1,0 +1,36 @@
+languageId: elm
+command:
+  spokenForm: change list air
+  version: 2
+  targets:
+    - type: primitive
+      mark: {type: decoratedSymbol, symbolColor: default, character: a}
+      modifiers:
+        - type: containingScope
+          scopeType: {type: list}
+  usePrePhraseSnapshot: true
+  action: {name: clearAndSetSelection}
+initialState:
+  documentContents: |
+    _ = case [ 1 ] of
+        [ a ] -> Just a
+        _ -> Nothing
+  selections:
+    - anchor: {line: 3, character: 0}
+      active: {line: 3, character: 0}
+  marks:
+    default.a:
+      start: {line: 1, character: 6}
+      end: {line: 1, character: 7}
+finalState:
+  documentContents: |
+    _ = case [ 1 ] of
+         -> Just a
+        _ -> Nothing
+  selections:
+    - anchor: {line: 1, character: 4}
+      active: {line: 1, character: 4}
+  thatMark:
+    - anchor: {line: 1, character: 4}
+      active: {line: 1, character: 4}
+fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: a}, modifiers: [{type: containingScope, scopeType: {type: list}}]}]

--- a/src/test/suite/fixtures/recorded/languages/elm/changeListOne.yml
+++ b/src/test/suite/fixtures/recorded/languages/elm/changeListOne.yml
@@ -1,0 +1,32 @@
+languageId: elm
+command:
+  spokenForm: change list one
+  version: 2
+  targets:
+    - type: primitive
+      mark: {type: decoratedSymbol, symbolColor: default, character: '1'}
+      modifiers:
+        - type: containingScope
+          scopeType: {type: list}
+  usePrePhraseSnapshot: true
+  action: {name: clearAndSetSelection}
+initialState:
+  documentContents: |
+    _ = [1, 2, 3]
+  selections:
+    - anchor: {line: 1, character: 0}
+      active: {line: 1, character: 0}
+  marks:
+    default.1:
+      start: {line: 0, character: 5}
+      end: {line: 0, character: 6}
+finalState:
+  documentContents: |
+    _ = 
+  selections:
+    - anchor: {line: 0, character: 4}
+      active: {line: 0, character: 4}
+  thatMark:
+    - anchor: {line: 0, character: 4}
+      active: {line: 0, character: 4}
+fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: '1'}, modifiers: [{type: containingScope, scopeType: {type: list}}]}]

--- a/src/test/suite/fixtures/recorded/languages/elm/changeMap.yml
+++ b/src/test/suite/fixtures/recorded/languages/elm/changeMap.yml
@@ -1,0 +1,28 @@
+languageId: elm
+command:
+  spokenForm: change map
+  version: 2
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: map}
+  usePrePhraseSnapshot: true
+  action: {name: clearAndSetSelection}
+initialState:
+  documentContents: |
+    _ = \{ x } -> {x = x}
+  selections:
+    - anchor: {line: 0, character: 8}
+      active: {line: 0, character: 8}
+  marks: {}
+finalState:
+  documentContents: |
+    _ = \ -> {x = x}
+  selections:
+    - anchor: {line: 0, character: 5}
+      active: {line: 0, character: 5}
+  thatMark:
+    - anchor: {line: 0, character: 5}
+      active: {line: 0, character: 5}
+fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: [{type: containingScope, scopeType: {type: map}}]}]

--- a/src/test/suite/fixtures/recorded/languages/elm/changeMap2.yml
+++ b/src/test/suite/fixtures/recorded/languages/elm/changeMap2.yml
@@ -1,0 +1,28 @@
+languageId: elm
+command:
+  spokenForm: change map
+  version: 2
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: map}
+  usePrePhraseSnapshot: false
+  action: {name: clearAndSetSelection}
+initialState:
+  documentContents: |
+    _ = \{ x } -> {x = x}
+  selections:
+    - anchor: {line: 0, character: 17}
+      active: {line: 0, character: 17}
+  marks: {}
+finalState:
+  documentContents: |
+    _ = \{ x } -> 
+  selections:
+    - anchor: {line: 0, character: 14}
+      active: {line: 0, character: 14}
+  thatMark:
+    - anchor: {line: 0, character: 14}
+      active: {line: 0, character: 14}
+fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: [{type: containingScope, scopeType: {type: map}}]}]

--- a/src/test/suite/fixtures/recorded/languages/elm/changeName.yml
+++ b/src/test/suite/fixtures/recorded/languages/elm/changeName.yml
@@ -1,0 +1,28 @@
+languageId: elm
+command:
+  spokenForm: change name
+  version: 2
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: name}
+  usePrePhraseSnapshot: true
+  action: {name: clearAndSetSelection}
+initialState:
+  documentContents: |
+    f x = x
+  selections:
+    - anchor: {line: 0, character: 3}
+      active: {line: 0, character: 3}
+  marks: {}
+finalState:
+  documentContents: |2
+     x = x
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  thatMark:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: [{type: containingScope, scopeType: {type: name}}]}]

--- a/src/test/suite/fixtures/recorded/languages/elm/changeName2.yml
+++ b/src/test/suite/fixtures/recorded/languages/elm/changeName2.yml
@@ -1,0 +1,30 @@
+languageId: elm
+command:
+  spokenForm: change name
+  version: 2
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: name}
+  usePrePhraseSnapshot: false
+  action: {name: clearAndSetSelection}
+initialState:
+  documentContents: |-
+    type alias X =
+        Int
+  selections:
+    - anchor: {line: 1, character: 4}
+      active: {line: 1, character: 4}
+  marks: {}
+finalState:
+  documentContents: |-
+    type alias  =
+        Int
+  selections:
+    - anchor: {line: 0, character: 11}
+      active: {line: 0, character: 11}
+  thatMark:
+    - anchor: {line: 0, character: 11}
+      active: {line: 0, character: 11}
+fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: [{type: containingScope, scopeType: {type: name}}]}]

--- a/src/test/suite/fixtures/recorded/languages/elm/changeName3.yml
+++ b/src/test/suite/fixtures/recorded/languages/elm/changeName3.yml
@@ -1,0 +1,30 @@
+languageId: elm
+command:
+  spokenForm: change name
+  version: 2
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: name}
+  usePrePhraseSnapshot: true
+  action: {name: clearAndSetSelection}
+initialState:
+  documentContents: |-
+    type X
+        = Int
+  selections:
+    - anchor: {line: 1, character: 8}
+      active: {line: 1, character: 8}
+  marks: {}
+finalState:
+  documentContents: |-
+    type 
+        = Int
+  selections:
+    - anchor: {line: 0, character: 5}
+      active: {line: 0, character: 5}
+  thatMark:
+    - anchor: {line: 0, character: 5}
+      active: {line: 0, character: 5}
+fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: [{type: containingScope, scopeType: {type: name}}]}]

--- a/src/test/suite/fixtures/recorded/languages/elm/changeName4.yml
+++ b/src/test/suite/fixtures/recorded/languages/elm/changeName4.yml
@@ -1,0 +1,28 @@
+languageId: elm
+command:
+  spokenForm: change name
+  version: 2
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: name}
+  usePrePhraseSnapshot: true
+  action: {name: clearAndSetSelection}
+initialState:
+  documentContents: |
+    port log : Cmg msg
+  selections:
+    - anchor: {line: 0, character: 11}
+      active: {line: 0, character: 11}
+  marks: {}
+finalState:
+  documentContents: |
+    port  : Cmg msg
+  selections:
+    - anchor: {line: 0, character: 5}
+      active: {line: 0, character: 5}
+  thatMark:
+    - anchor: {line: 0, character: 5}
+      active: {line: 0, character: 5}
+fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: [{type: containingScope, scopeType: {type: name}}]}]

--- a/src/test/suite/fixtures/recorded/languages/elm/changeType.yml
+++ b/src/test/suite/fixtures/recorded/languages/elm/changeType.yml
@@ -1,0 +1,32 @@
+languageId: elm
+command:
+  spokenForm: change type
+  version: 2
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: type}
+  usePrePhraseSnapshot: true
+  action: {name: clearAndSetSelection}
+initialState:
+  documentContents: |+
+    type T
+        = A
+        | B
+
+  selections:
+    - anchor: {line: 2, character: 6}
+      active: {line: 2, character: 6}
+  marks: {}
+finalState:
+  documentContents: |+
+
+
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  thatMark:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: [{type: containingScope, scopeType: {type: type}}]}]

--- a/src/test/suite/fixtures/recorded/languages/elm/changeType2.yml
+++ b/src/test/suite/fixtures/recorded/languages/elm/changeType2.yml
@@ -1,0 +1,30 @@
+languageId: elm
+command:
+  spokenForm: change type
+  version: 2
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: type}
+  usePrePhraseSnapshot: true
+  action: {name: clearAndSetSelection}
+initialState:
+  documentContents: |
+    type alias X =
+        Int
+  selections:
+    - anchor: {line: 1, character: 6}
+      active: {line: 1, character: 6}
+  marks: {}
+finalState:
+  documentContents: |
+    type alias X =
+        
+  selections:
+    - anchor: {line: 1, character: 4}
+      active: {line: 1, character: 4}
+  thatMark:
+    - anchor: {line: 1, character: 4}
+      active: {line: 1, character: 4}
+fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: [{type: containingScope, scopeType: {type: type}}]}]

--- a/src/test/suite/fixtures/recorded/languages/elm/changeType3.yml
+++ b/src/test/suite/fixtures/recorded/languages/elm/changeType3.yml
@@ -1,0 +1,29 @@
+languageId: elm
+command:
+  spokenForm: change type
+  version: 2
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: type}
+  usePrePhraseSnapshot: true
+  action: {name: clearAndSetSelection}
+initialState:
+  documentContents: |
+    type alias X =
+        Int
+  selections:
+    - anchor: {line: 0, character: 6}
+      active: {line: 0, character: 6}
+  marks: {}
+finalState:
+  documentContents: |+
+
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  thatMark:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: [{type: containingScope, scopeType: {type: type}}]}]

--- a/src/test/suite/fixtures/recorded/languages/elm/changeTypeDash.yml
+++ b/src/test/suite/fixtures/recorded/languages/elm/changeTypeDash.yml
@@ -1,0 +1,30 @@
+languageId: elm
+command:
+  spokenForm: change type dash
+  version: 2
+  targets:
+    - type: primitive
+      mark: {type: decoratedSymbol, symbolColor: default, character: '-'}
+      modifiers:
+        - type: containingScope
+          scopeType: {type: type}
+  usePrePhraseSnapshot: true
+  action: {name: clearAndSetSelection}
+initialState:
+  documentContents: "f : Int -> Result String Int"
+  selections:
+    - anchor: {line: 0, character: 28}
+      active: {line: 0, character: 28}
+  marks:
+    default.-:
+      start: {line: 0, character: 8}
+      end: {line: 0, character: 10}
+finalState:
+  documentContents: "f : "
+  selections:
+    - anchor: {line: 0, character: 4}
+      active: {line: 0, character: 4}
+  thatMark:
+    - anchor: {line: 0, character: 4}
+      active: {line: 0, character: 4}
+fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: '-'}, modifiers: [{type: containingScope, scopeType: {type: type}}]}]

--- a/src/test/suite/fixtures/recorded/languages/elm/changeTypeRed.yml
+++ b/src/test/suite/fixtures/recorded/languages/elm/changeTypeRed.yml
@@ -1,0 +1,30 @@
+languageId: elm
+command:
+  spokenForm: change type red
+  version: 2
+  targets:
+    - type: primitive
+      mark: {type: decoratedSymbol, symbolColor: default, character: r}
+      modifiers:
+        - type: containingScope
+          scopeType: {type: type}
+  usePrePhraseSnapshot: true
+  action: {name: clearAndSetSelection}
+initialState:
+  documentContents: "f : Int -> Result String Int"
+  selections:
+    - anchor: {line: 0, character: 28}
+      active: {line: 0, character: 28}
+  marks:
+    default.r:
+      start: {line: 0, character: 11}
+      end: {line: 0, character: 17}
+finalState:
+  documentContents: "f : Int -> "
+  selections:
+    - anchor: {line: 0, character: 11}
+      active: {line: 0, character: 11}
+  thatMark:
+    - anchor: {line: 0, character: 11}
+      active: {line: 0, character: 11}
+fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: r}, modifiers: [{type: containingScope, scopeType: {type: type}}]}]

--- a/src/test/suite/fixtures/recorded/languages/elm/changeValue.yml
+++ b/src/test/suite/fixtures/recorded/languages/elm/changeValue.yml
@@ -1,0 +1,30 @@
+languageId: elm
+command:
+  spokenForm: change value
+  version: 2
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: value}
+  usePrePhraseSnapshot: true
+  action: {name: clearAndSetSelection}
+initialState:
+  documentContents: |+
+    f = let x = 0 in x
+
+  selections:
+    - anchor: {line: 0, character: 9}
+      active: {line: 0, character: 9}
+  marks: {}
+finalState:
+  documentContents: |+
+    f = let x =  in x
+
+  selections:
+    - anchor: {line: 0, character: 12}
+      active: {line: 0, character: 12}
+  thatMark:
+    - anchor: {line: 0, character: 12}
+      active: {line: 0, character: 12}
+fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: [{type: containingScope, scopeType: {type: value}}]}]

--- a/src/test/suite/fixtures/recorded/languages/elm/changeValue2.yml
+++ b/src/test/suite/fixtures/recorded/languages/elm/changeValue2.yml
@@ -1,0 +1,30 @@
+languageId: elm
+command:
+  spokenForm: change value
+  version: 2
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: value}
+  usePrePhraseSnapshot: false
+  action: {name: clearAndSetSelection}
+initialState:
+  documentContents: |+
+    f = let x = 0 in x
+
+  selections:
+    - anchor: {line: 0, character: 15}
+      active: {line: 0, character: 15}
+  marks: {}
+finalState:
+  documentContents: |+
+    f = let x = 0 in 
+
+  selections:
+    - anchor: {line: 0, character: 17}
+      active: {line: 0, character: 17}
+  thatMark:
+    - anchor: {line: 0, character: 17}
+      active: {line: 0, character: 17}
+fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: [{type: containingScope, scopeType: {type: value}}]}]

--- a/src/test/suite/fixtures/recorded/languages/elm/chuckArg.yml
+++ b/src/test/suite/fixtures/recorded/languages/elm/chuckArg.yml
@@ -1,0 +1,28 @@
+languageId: elm
+command:
+  spokenForm: chuck arg
+  version: 2
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: argumentOrParameter}
+  usePrePhraseSnapshot: true
+  action: {name: remove}
+initialState:
+  documentContents: |
+    f x y = x
+  selections:
+    - anchor: {line: 0, character: 7}
+      active: {line: 0, character: 7}
+  marks: {}
+finalState:
+  documentContents: |
+    f y = x
+  selections:
+    - anchor: {line: 0, character: 5}
+      active: {line: 0, character: 5}
+  thatMark:
+    - anchor: {line: 0, character: 2}
+      active: {line: 0, character: 2}
+fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: [{type: containingScope, scopeType: {type: argumentOrParameter}}]}]

--- a/src/test/suite/fixtures/recorded/languages/elm/chuckArg2.yml
+++ b/src/test/suite/fixtures/recorded/languages/elm/chuckArg2.yml
@@ -1,0 +1,28 @@
+languageId: elm
+command:
+  spokenForm: chuck arg
+  version: 2
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: argumentOrParameter}
+  usePrePhraseSnapshot: false
+  action: {name: remove}
+initialState:
+  documentContents: |
+    f y = x
+  selections:
+    - anchor: {line: 0, character: 5}
+      active: {line: 0, character: 5}
+  marks: {}
+finalState:
+  documentContents: |
+    f = x
+  selections:
+    - anchor: {line: 0, character: 3}
+      active: {line: 0, character: 3}
+  thatMark:
+    - anchor: {line: 0, character: 2}
+      active: {line: 0, character: 2}
+fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: [{type: containingScope, scopeType: {type: argumentOrParameter}}]}]

--- a/src/test/suite/fixtures/recorded/languages/elm/chuckItem.yml
+++ b/src/test/suite/fixtures/recorded/languages/elm/chuckItem.yml
@@ -1,0 +1,28 @@
+languageId: elm
+command:
+  spokenForm: chuck item
+  version: 2
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: collectionItem}
+  usePrePhraseSnapshot: true
+  action: {name: remove}
+initialState:
+  documentContents: |
+    f = [1, 2, 3]
+  selections:
+    - anchor: {line: 0, character: 11}
+      active: {line: 0, character: 11}
+  marks: {}
+finalState:
+  documentContents: |
+    f = [1, 2]
+  selections:
+    - anchor: {line: 0, character: 9}
+      active: {line: 0, character: 9}
+  thatMark:
+    - anchor: {line: 0, character: 9}
+      active: {line: 0, character: 9}
+fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: [{type: containingScope, scopeType: {type: collectionItem}}]}]

--- a/src/test/suite/fixtures/recorded/languages/elm/chuckItem2.yml
+++ b/src/test/suite/fixtures/recorded/languages/elm/chuckItem2.yml
@@ -1,0 +1,28 @@
+languageId: elm
+command:
+  spokenForm: chuck item
+  version: 2
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: collectionItem}
+  usePrePhraseSnapshot: false
+  action: {name: remove}
+initialState:
+  documentContents: |
+    f = [1]
+  selections:
+    - anchor: {line: 0, character: 6}
+      active: {line: 0, character: 6}
+  marks: {}
+finalState:
+  documentContents: |
+    f = []
+  selections:
+    - anchor: {line: 0, character: 5}
+      active: {line: 0, character: 5}
+  thatMark:
+    - anchor: {line: 0, character: 5}
+      active: {line: 0, character: 5}
+fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: [{type: containingScope, scopeType: {type: collectionItem}}]}]

--- a/src/test/suite/fixtures/recorded/languages/elm/chuckItem3.yml
+++ b/src/test/suite/fixtures/recorded/languages/elm/chuckItem3.yml
@@ -1,0 +1,28 @@
+languageId: elm
+command:
+  spokenForm: chuck item
+  version: 2
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: collectionItem}
+  usePrePhraseSnapshot: true
+  action: {name: remove}
+initialState:
+  documentContents: |
+    f = {x = 1, y = 2}
+  selections:
+    - anchor: {line: 0, character: 17}
+      active: {line: 0, character: 17}
+  marks: {}
+finalState:
+  documentContents: |
+    f = {x = 1}
+  selections:
+    - anchor: {line: 0, character: 10}
+      active: {line: 0, character: 10}
+  thatMark:
+    - anchor: {line: 0, character: 10}
+      active: {line: 0, character: 10}
+fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: [{type: containingScope, scopeType: {type: collectionItem}}]}]

--- a/src/test/suite/fixtures/recorded/languages/elm/chuckItem4.yml
+++ b/src/test/suite/fixtures/recorded/languages/elm/chuckItem4.yml
@@ -1,0 +1,28 @@
+languageId: elm
+command:
+  spokenForm: chuck item
+  version: 2
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: collectionItem}
+  usePrePhraseSnapshot: false
+  action: {name: remove}
+initialState:
+  documentContents: |
+    f = {x = 1}
+  selections:
+    - anchor: {line: 0, character: 10}
+      active: {line: 0, character: 10}
+  marks: {}
+finalState:
+  documentContents: |
+    f = {}
+  selections:
+    - anchor: {line: 0, character: 5}
+      active: {line: 0, character: 5}
+  thatMark:
+    - anchor: {line: 0, character: 5}
+      active: {line: 0, character: 5}
+fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: [{type: containingScope, scopeType: {type: collectionItem}}]}]


### PR DESCRIPTION
## What

Adds support for the Elm programming language

## Checklist

- [ x ] Recorded tests for the new language
- [ x ] Used `"change"` / `"clear"` instead of` "take"` for selection tests to make recorded tests easier to read
- [ x ] Added a few specific tests that use `"chuck"` instead of `"change"` to test removal behaviour when it's interesting, especially:
  - [ x ] `"chuck arg"` with single argument in list
  - [ x ] `"chuck arg"` with multiple arguments in list
  - [ x ] `"chuck item"` with single argument in list
  - [ x ] `"chuck item"` with multiple arguments in list
- [ ] Added a test for `"change round"` inside a string, eg `"hello (there)"`
- [ x ] Supported` "type"` both for type annotations (eg `foo: string`) and declarations (eg `interface Foo {}`) (and added tests for this behaviour 😊)
- [ x ] Supported` "item"` both for map pairs and list entries (with tests of course)

## Currently not working

- Strings
- "take every arg"
