### PR TITLE
Fix status bar icon

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -4,9 +4,11 @@
 !NOTICE.md
 !README.md
 !build-info.json
-!cursorless-snippets/**
 !cursorless-nx/dist/apps/cheatsheet-local/index.html
+!cursorless-snippets/**
 !dist/extension.js
+!fonts/cursorless-glyph.svg
+!fonts/cursorless.woff
 !images/hats/**
 !images/icon.png
 !package.json


### PR DESCRIPTION
The assets for the status bar icon were being excluded by our .vscodeignore, so this is what we currently see in status bar in production:

<img width="103" alt="image" src="https://user-images.githubusercontent.com/755842/184673897-03efe67d-7333-4248-91ce-0cf2e2803045.png">


## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
