### PR TITLE
Add javascript pair test

### DIFF
--- a/src/test/suite/fixtures/recorded/languages/javascript/clearCoreWhale.yml
+++ b/src/test/suite/fixtures/recorded/languages/javascript/clearCoreWhale.yml
@@ -1,0 +1,29 @@
+languageId: javascript
+command:
+  spokenForm: clear core whale
+  version: 2
+  targets:
+    - type: primitive
+      modifiers:
+        - {type: interiorOnly}
+      mark: {type: decoratedSymbol, symbolColor: default, character: w}
+  usePrePhraseSnapshot: true
+  action: {name: clearAndSetSelection}
+initialState:
+  documentContents: "'(hello world) testing'"
+  selections:
+    - anchor: {line: 0, character: 22}
+      active: {line: 0, character: 22}
+  marks:
+    default.w:
+      start: {line: 0, character: 8}
+      end: {line: 0, character: 13}
+finalState:
+  documentContents: "'() testing'"
+  selections:
+    - anchor: {line: 0, character: 2}
+      active: {line: 0, character: 2}
+  thatMark:
+    - anchor: {line: 0, character: 2}
+      active: {line: 0, character: 2}
+fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: w}, modifiers: [{type: interiorOnly}]}]


### PR DESCRIPTION
Looks like we don't have any Javascript tests 😳.  We have been relying on the fact that the parse tree is just a subset of Typescript.  Which is true...unless you update the Typescript parser and forget to update the Javascript parser 😅

This new test is currently breaking because we forgot to update the Javascript parser when we updated the Typescript parser.  It should start passing when https://github.com/cursorless-dev/vscode-parse-tree/pull/46 is released

## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
