### PR TITLE
Initial work for smarter `that` marks

### DIFF
--- a/src/actions/BringMoveSwap.ts
+++ b/src/actions/BringMoveSwap.ts
@@ -261,7 +261,7 @@ class BringMoveSwap implements Action {
 
     await this.decorateThatMark(thatMark);
 
-    return { thatMark, sourceMark };
+    return { thatSelections: thatMark, sourceSelections: sourceMark };
   }
 }
 

--- a/src/actions/Call.ts
+++ b/src/actions/Call.ts
@@ -22,12 +22,13 @@ export default class Call implements Action {
     );
 
     // NB: We unwrap and then rewrap the return value here so that we don't include the source mark
-    const { thatMark } = await this.graph.actions.wrapWithPairedDelimiter.run(
-      [destinations],
-      texts[0] + "(",
-      ")"
-    );
+    const { thatSelections: thatMark } =
+      await this.graph.actions.wrapWithPairedDelimiter.run(
+        [destinations],
+        texts[0] + "(",
+        ")"
+      );
 
-    return { thatMark };
+    return { thatSelections: thatMark };
   }
 }

--- a/src/actions/Clear.ts
+++ b/src/actions/Clear.ts
@@ -23,7 +23,9 @@ export default class Clear implements Action {
         })
     );
 
-    const { thatMark } = await this.graph.actions.remove.run([plainTargets]);
+    const { thatSelections: thatMark } = await this.graph.actions.remove.run([
+      plainTargets,
+    ]);
 
     if (thatMark != null) {
       await setSelectionsAndFocusEditor(
@@ -32,6 +34,6 @@ export default class Clear implements Action {
       );
     }
 
-    return { thatMark };
+    return { thatSelections: thatMark };
   }
 }

--- a/src/actions/CommandAction.ts
+++ b/src/actions/CommandAction.ts
@@ -129,6 +129,6 @@ export default class CommandAction implements Action {
       await focusEditor(originalEditor);
     }
 
-    return { thatMark };
+    return { thatSelections: thatMark };
   }
 }

--- a/src/actions/CutCopy.ts
+++ b/src/actions/CutCopy.ts
@@ -42,12 +42,12 @@ export class Cut implements Action {
 
     await this.graph.actions.copyToClipboard.run([targets], options);
 
-    const { thatMark } = await this.graph.actions.remove.run(
+    const { thatSelections: thatMark } = await this.graph.actions.remove.run(
       [targets],
       options
     );
 
-    return { thatMark };
+    return { thatSelections: thatMark };
   }
 }
 

--- a/src/actions/Deselect.ts
+++ b/src/actions/Deselect.ts
@@ -30,7 +30,7 @@ export default class Deselect implements Action {
     });
 
     return {
-      thatMark: createThatMark(targets),
+      thatSelections: createThatMark(targets),
     };
   }
 }

--- a/src/actions/EditNew/EditNew.ts
+++ b/src/actions/EditNew/EditNew.ts
@@ -50,7 +50,7 @@ export class EditNew implements Action {
     await setSelectionsAndFocusEditor(editor, newSelections);
 
     return {
-      thatMark: createThatMark(state.targets, state.thatRanges),
+      thatSelections: createThatMark(state.targets, state.thatRanges),
     };
   }
 }

--- a/src/actions/EditNew/runNotebookCellTargets.ts
+++ b/src/actions/EditNew/runNotebookCellTargets.ts
@@ -25,5 +25,5 @@ export async function runNotebookCellTargets(
     );
   }
 
-  return { thatMark };
+  return { thatSelections: thatMark };
 }

--- a/src/actions/Find.ts
+++ b/src/actions/Find.ts
@@ -14,13 +14,13 @@ export class FindInFiles implements Action {
 
     const {
       returnValue: [query],
-      thatMark,
+      thatSelections: thatMark,
     } = await this.graph.actions.getText.run([targets]);
 
     await commands.executeCommand("workbench.action.findInFiles", {
       query,
     });
 
-    return { thatMark };
+    return { thatSelections: thatMark };
   }
 }

--- a/src/actions/Fold.ts
+++ b/src/actions/Fold.ts
@@ -45,7 +45,7 @@ class FoldAction implements Action {
     }
 
     return {
-      thatMark: createThatMark(targets),
+      thatSelections: createThatMark(targets),
     };
   }
 }

--- a/src/actions/FollowLink.ts
+++ b/src/actions/FollowLink.ts
@@ -30,7 +30,7 @@ export default class FollowLink implements Action {
     }
 
     return {
-      thatMark: createThatMark(targets),
+      thatSelections: createThatMark(targets),
     };
   }
 

--- a/src/actions/GenerateSnippet/GenerateSnippet.ts
+++ b/src/actions/GenerateSnippet/GenerateSnippet.ts
@@ -229,7 +229,7 @@ export default class GenerateSnippet implements Action {
     });
 
     return {
-      thatMark: targets.map(({ editor, contentSelection }) => ({
+      thatSelections: targets.map(({ editor, contentSelection }) => ({
         editor,
         selection: contentSelection,
       })),

--- a/src/actions/GetText.ts
+++ b/src/actions/GetText.ts
@@ -28,7 +28,7 @@ export default class GetText implements Action {
 
     return {
       returnValue: targets.map((target) => target.contentText),
-      thatMark: createThatMark(targets),
+      thatSelections: createThatMark(targets),
     };
   }
 }

--- a/src/actions/Highlight.ts
+++ b/src/actions/Highlight.ts
@@ -19,7 +19,7 @@ export default class Highlight implements Action {
     await this.graph.editStyles.setDecorations(targets, style);
 
     return {
-      thatMark: createThatMark(targets),
+      thatSelections: createThatMark(targets),
     };
   }
 }

--- a/src/actions/InsertCopy.ts
+++ b/src/actions/InsertCopy.ts
@@ -33,8 +33,8 @@ class InsertCopy implements Action {
     );
 
     return {
-      sourceMark: results.flatMap(({ sourceMark }) => sourceMark),
-      thatMark: results.flatMap(({ thatMark }) => thatMark),
+      sourceSelections: results.flatMap(({ sourceMark }) => sourceMark),
+      thatSelections: results.flatMap(({ thatMark }) => thatMark),
     };
   }
 

--- a/src/actions/InsertEmptyLines.ts
+++ b/src/actions/InsertEmptyLines.ts
@@ -87,7 +87,7 @@ class InsertEmptyLines implements Action {
 
     const thatMark = results.flatMap((result) => result.thatMark);
 
-    return { thatMark };
+    return { thatSelections: thatMark };
   }
 }
 

--- a/src/actions/InsertSnippet.ts
+++ b/src/actions/InsertSnippet.ts
@@ -96,7 +96,7 @@ export default class InsertSnippet implements Action {
     );
 
     return {
-      thatMark: updatedTargetSelections.map((selection) => ({
+      thatSelections: updatedTargetSelections.map((selection) => ({
         editor,
         selection,
       })),

--- a/src/actions/Paste.ts
+++ b/src/actions/Paste.ts
@@ -72,7 +72,7 @@ export class Paste {
     );
 
     return {
-      thatMark: updatedTargetSelections.map((selection) => ({
+      thatSelections: updatedTargetSelections.map((selection) => ({
         editor: targetEditor,
         selection,
       })),

--- a/src/actions/Remove.ts
+++ b/src/actions/Remove.ts
@@ -42,6 +42,6 @@ export default class Delete implements Action {
       })
     );
 
-    return { thatMark };
+    return { thatSelections: thatMark };
   }
 }

--- a/src/actions/Replace.ts
+++ b/src/actions/Replace.ts
@@ -70,6 +70,6 @@ export default class Replace implements Action {
       )
     );
 
-    return { thatMark };
+    return { thatSelections: thatMark };
   }
 }

--- a/src/actions/Rewrap.ts
+++ b/src/actions/Rewrap.ts
@@ -60,8 +60,8 @@ export default class Rewrap implements Action {
     );
 
     return {
-      sourceMark: results.flatMap(({ sourceMark }) => sourceMark),
-      thatMark: results.flatMap(({ thatMark }) => thatMark),
+      sourceSelections: results.flatMap(({ sourceMark }) => sourceMark),
+      thatSelections: results.flatMap(({ thatMark }) => thatMark),
     };
   }
 }

--- a/src/actions/Scroll.ts
+++ b/src/actions/Scroll.ts
@@ -56,7 +56,7 @@ class Scroll implements Action {
     );
 
     return {
-      thatMark: createThatMark(targets),
+      thatSelections: createThatMark(targets),
     };
   }
 }

--- a/src/actions/SetSelection.ts
+++ b/src/actions/SetSelection.ts
@@ -21,7 +21,7 @@ export class SetSelection implements Action {
     await setSelectionsAndFocusEditor(editor, selections);
 
     return {
-      thatMark: createThatMark(targets),
+      thatSelections: createThatMark(targets),
     };
   }
 }

--- a/src/actions/ToggleBreakpoint.ts
+++ b/src/actions/ToggleBreakpoint.ts
@@ -61,7 +61,7 @@ export default class ToggleBreakpoint implements Action {
     debug.removeBreakpoints(toRemove);
 
     return {
-      thatMark: createThatMark(thatTargets),
+      thatSelections: createThatMark(thatTargets),
     };
   }
 }

--- a/src/actions/Wrap.ts
+++ b/src/actions/Wrap.ts
@@ -127,8 +127,8 @@ export default class Wrap implements Action {
     );
 
     return {
-      sourceMark: results.flatMap(({ sourceMark }) => sourceMark),
-      thatMark: results.flatMap(({ thatMark }) => thatMark),
+      sourceSelections: results.flatMap(({ sourceMark }) => sourceMark),
+      thatSelections: results.flatMap(({ thatMark }) => thatMark),
     };
   }
 }

--- a/src/actions/WrapWithSnippet.ts
+++ b/src/actions/WrapWithSnippet.ts
@@ -88,7 +88,7 @@ export default class WrapWithSnippet implements Action {
     );
 
     return {
-      thatMark: updatedTargetSelections.map((selection) => ({
+      thatSelections: updatedTargetSelections.map((selection) => ({
         editor,
         selection,
       })),

--- a/src/actions/actions.types.ts
+++ b/src/actions/actions.types.ts
@@ -56,10 +56,41 @@ export type ActionType =
   | "wrapWithPairedDelimiter"
   | "wrapWithSnippet";
 
+/**
+ * To be returned by {@link Action.run}
+ */
 export interface ActionReturnValue {
+  /**
+   * The value that should be returned to the caller of the command
+   */
   returnValue?: any;
-  thatMark?: SelectionWithEditor[];
-  sourceMark?: SelectionWithEditor[];
+
+  /**
+   * A list of selections that will become the `that` mark for the next command.
+   * The given selections will be wrapped in {@link UntypedTarget}s. This
+   * attribute is provided for convenience. Mutually exclusive with
+   * {@link thatTargets}
+   */
+  thatSelections?: SelectionWithEditor[];
+
+  /**
+   * A list of targets that will become the `that` mark for the next command.
+   * Mutually exclusive with {@link thatSelections}
+   */
+  thatTargets?: Target[];
+
+  /**
+   * A list of selections that will become the `source` mark for the next command.
+   * The given selections will be wrapped in {@link UntypedTarget}s. This
+   * attribute is provided for convenience. Mutually exclusive with {@link sourceTargets}
+   */
+  sourceSelections?: SelectionWithEditor[];
+
+  /**
+   * A list of targets that will become the `source` mark for the next command.
+   * Mutually exclusive with {@link sourceSelections}
+   */
+  sourceTargets?: Target[];
 }
 
 export interface Action {

--- a/src/core/ThatMark.ts
+++ b/src/core/ThatMark.ts
@@ -1,10 +1,10 @@
-import { SelectionWithEditor } from "../typings/Types";
+import { Target } from "../typings/target.types";
 
 export class ThatMark {
-  private mark?: SelectionWithEditor[];
+  private mark?: Target[];
 
-  set(value?: SelectionWithEditor[]) {
-    this.mark = value;
+  set(targets: Target[] | undefined) {
+    this.mark = targets;
   }
 
   get() {

--- a/src/core/commandRunner/selectionToThatTarget.ts
+++ b/src/core/commandRunner/selectionToThatTarget.ts
@@ -1,0 +1,19 @@
+import { UntypedTarget } from "../../processTargets/targets";
+import { SelectionWithEditor } from "../../typings/Types";
+import { isReversed } from "../../util/selectionUtils";
+
+/**
+ * Given a selection with an editor, constructs an appropriate `Target` to use
+ * for a `that` mark.  It uses an `UntypedTarget`, and if the selection is
+ * empty, it sets `hasExplicitRange` to `false`.
+ *
+ * @param selection The selection with editor to be converted
+ * @returns A target that can be used for a `that` mark
+ */
+export const selectionToThatTarget = (selection: SelectionWithEditor) =>
+  new UntypedTarget({
+    editor: selection.editor,
+    isReversed: isReversed(selection.selection),
+    contentRange: selection.selection,
+    hasExplicitRange: !selection.selection.isEmpty,
+  });

--- a/src/processTargets/marks/CursorStage.ts
+++ b/src/processTargets/marks/CursorStage.ts
@@ -1,9 +1,9 @@
-import { Target } from "../../typings/target.types";
+import type { Target } from "../../typings/target.types";
 import type { CursorMark } from "../../typings/targetDescriptor.types";
-import { ProcessedTargetsContext } from "../../typings/Types";
+import type { ProcessedTargetsContext } from "../../typings/Types";
 import { isReversed } from "../../util/selectionUtils";
-import { MarkStage } from "../PipelineStages.types";
-import UntypedTarget from "../targets/UntypedTarget";
+import type { MarkStage } from "../PipelineStages.types";
+import { UntypedTarget } from "../targets";
 
 export default class CursorStage implements MarkStage {
   constructor(private modifier: CursorMark) {}

--- a/src/processTargets/marks/LineNumberStage.ts
+++ b/src/processTargets/marks/LineNumberStage.ts
@@ -1,12 +1,12 @@
-import { TextEditor } from "vscode";
-import {
+import type { TextEditor } from "vscode";
+import type {
   LineNumberMark,
   LineNumberPosition,
 } from "../../typings/targetDescriptor.types";
-import { ProcessedTargetsContext } from "../../typings/Types";
+import type { ProcessedTargetsContext } from "../../typings/Types";
 import { createLineTarget } from "../modifiers/scopeTypeStages/LineStage";
-import { MarkStage } from "../PipelineStages.types";
-import LineTarget from "../targets/LineTarget";
+import type { MarkStage } from "../PipelineStages.types";
+import { LineTarget } from "../targets";
 
 export default class implements MarkStage {
   constructor(private modifier: LineNumberMark) {}

--- a/src/processTargets/marks/ThatStage.ts
+++ b/src/processTargets/marks/ThatStage.ts
@@ -1,12 +1,7 @@
 import { Target } from "../../typings/target.types";
 import { SourceMark, ThatMark } from "../../typings/targetDescriptor.types";
-import {
-  ProcessedTargetsContext,
-  SelectionWithEditor,
-} from "../../typings/Types";
-import { isReversed } from "../../util/selectionUtils";
+import { ProcessedTargetsContext } from "../../typings/Types";
 import { MarkStage } from "../PipelineStages.types";
-import { UntypedTarget } from "../targets";
 
 export class ThatStage implements MarkStage {
   constructor(private modifier: ThatMark) {}
@@ -16,7 +11,7 @@ export class ThatStage implements MarkStage {
       throw Error("No available that marks");
     }
 
-    return selectionsToTarget(context.thatMark);
+    return context.thatMark;
   }
 }
 
@@ -28,18 +23,6 @@ export class SourceStage implements MarkStage {
       throw Error("No available source marks");
     }
 
-    return selectionsToTarget(context.sourceMark);
+    return context.sourceMark;
   }
-}
-
-function selectionsToTarget(selections: SelectionWithEditor[]) {
-  return selections.map(
-    (selection) =>
-      new UntypedTarget({
-        editor: selection.editor,
-        isReversed: isReversed(selection.selection),
-        contentRange: selection.selection,
-        hasExplicitRange: !selection.selection.isEmpty,
-      })
-  );
 }

--- a/src/processTargets/modifiers/OrdinalRangeSubTokenStage.ts
+++ b/src/processTargets/modifiers/OrdinalRangeSubTokenStage.ts
@@ -1,15 +1,14 @@
 import { Range } from "vscode";
 import { SUBWORD_MATCHER } from "../../core/constants";
 import { GRAPHEME_SPLIT_REGEX } from "../../core/TokenGraphemeSplitter";
-import { Target } from "../../typings/target.types";
-import {
+import type { Target } from "../../typings/target.types";
+import type {
   OrdinalRangeModifier,
   SimpleScopeType,
 } from "../../typings/targetDescriptor.types";
-import { ProcessedTargetsContext } from "../../typings/Types";
-import { ModifierStage } from "../PipelineStages.types";
-import PlainTarget from "../targets/PlainTarget";
-import SubTokenWordTarget from "../targets/SubTokenWordTarget";
+import type { ProcessedTargetsContext } from "../../typings/Types";
+import type { ModifierStage } from "../PipelineStages.types";
+import { PlainTarget, SubTokenWordTarget } from "../targets";
 import { getTokenRangeForSelection } from "./scopeTypeStages/TokenStage";
 
 interface OrdinalScopeType extends SimpleScopeType {

--- a/src/processTargets/modifiers/RawSelectionStage.ts
+++ b/src/processTargets/modifiers/RawSelectionStage.ts
@@ -1,8 +1,8 @@
-import { Target } from "../../typings/target.types";
-import { RawSelectionModifier } from "../../typings/targetDescriptor.types";
-import { ProcessedTargetsContext } from "../../typings/Types";
-import { ModifierStage } from "../PipelineStages.types";
-import RawSelectionTarget from "../targets/RawSelectionTarget";
+import type { Target } from "../../typings/target.types";
+import type { RawSelectionModifier } from "../../typings/targetDescriptor.types";
+import type { ProcessedTargetsContext } from "../../typings/Types";
+import type { ModifierStage } from "../PipelineStages.types";
+import { RawSelectionTarget } from "../targets";
 
 export default class RawSelectionStage implements ModifierStage {
   constructor(private modifier: RawSelectionModifier) {}

--- a/src/processTargets/modifiers/SurroundingPairStage.ts
+++ b/src/processTargets/modifiers/SurroundingPairStage.ts
@@ -1,8 +1,8 @@
-import { Target } from "../../typings/target.types";
-import { ContainingSurroundingPairModifier } from "../../typings/targetDescriptor.types";
-import { ProcessedTargetsContext } from "../../typings/Types";
-import { ModifierStage } from "../PipelineStages.types";
-import SurroundingPairTarget from "../targets/SurroundingPairTarget";
+import type { Target } from "../../typings/target.types";
+import type { ContainingSurroundingPairModifier } from "../../typings/targetDescriptor.types";
+import type { ProcessedTargetsContext } from "../../typings/Types";
+import type { ModifierStage } from "../PipelineStages.types";
+import { SurroundingPairTarget } from "../targets";
 import { processSurroundingPair } from "./surroundingPair";
 
 /**

--- a/src/processTargets/modifiers/scopeTypeStages/ContainingSyntaxScopeStage.ts
+++ b/src/processTargets/modifiers/scopeTypeStages/ContainingSyntaxScopeStage.ts
@@ -1,22 +1,22 @@
 import { Location, Selection } from "vscode";
-import { SyntaxNode } from "web-tree-sitter";
+import type { SyntaxNode } from "web-tree-sitter";
 import { NoContainingScopeError } from "../../../errors";
 import { getNodeMatcher } from "../../../languages/getNodeMatcher";
-import { Target } from "../../../typings/target.types";
-import {
+import type { Target } from "../../../typings/target.types";
+import type {
   ContainingScopeModifier,
   EveryScopeModifier,
   SimpleScopeType,
 } from "../../../typings/targetDescriptor.types";
-import {
+import type {
   NodeMatcher,
   ProcessedTargetsContext,
   SelectionWithEditor,
   SelectionWithEditorWithContext,
 } from "../../../typings/Types";
 import { selectionWithEditorFromRange } from "../../../util/selectionUtils";
-import { ModifierStage } from "../../PipelineStages.types";
-import ScopeTypeTarget from "../../targets/ScopeTypeTarget";
+import type { ModifierStage } from "../../PipelineStages.types";
+import { ScopeTypeTarget } from "../../targets";
 
 export interface SimpleContainingScopeModifier extends ContainingScopeModifier {
   scopeType: SimpleScopeType;

--- a/src/processTargets/modifiers/scopeTypeStages/DocumentStage.ts
+++ b/src/processTargets/modifiers/scopeTypeStages/DocumentStage.ts
@@ -1,12 +1,12 @@
 import { Position, Range, TextEditor } from "vscode";
-import { Target } from "../../../typings/target.types";
-import {
+import type { Target } from "../../../typings/target.types";
+import type {
   ContainingScopeModifier,
   EveryScopeModifier,
 } from "../../../typings/targetDescriptor.types";
-import { ProcessedTargetsContext } from "../../../typings/Types";
-import { ModifierStage } from "../../PipelineStages.types";
-import DocumentTarget from "../../targets/DocumentTarget";
+import type { ProcessedTargetsContext } from "../../../typings/Types";
+import type { ModifierStage } from "../../PipelineStages.types";
+import { DocumentTarget } from "../../targets";
 
 export default class implements ModifierStage {
   constructor(private modifier: ContainingScopeModifier | EveryScopeModifier) {}

--- a/src/processTargets/modifiers/scopeTypeStages/LineStage.ts
+++ b/src/processTargets/modifiers/scopeTypeStages/LineStage.ts
@@ -1,12 +1,12 @@
 import { Range, TextEditor } from "vscode";
-import { Target } from "../../../typings/target.types";
-import {
+import type { Target } from "../../../typings/target.types";
+import type {
   ContainingScopeModifier,
   EveryScopeModifier,
 } from "../../../typings/targetDescriptor.types";
-import { ProcessedTargetsContext } from "../../../typings/Types";
-import { ModifierStage } from "../../PipelineStages.types";
-import LineTarget from "../../targets/LineTarget";
+import type { ProcessedTargetsContext } from "../../../typings/Types";
+import type { ModifierStage } from "../../PipelineStages.types";
+import { LineTarget } from "../../targets";
 
 export default class implements ModifierStage {
   constructor(private modifier: ContainingScopeModifier | EveryScopeModifier) {}

--- a/src/processTargets/modifiers/scopeTypeStages/NotebookCellStage.ts
+++ b/src/processTargets/modifiers/scopeTypeStages/NotebookCellStage.ts
@@ -1,11 +1,11 @@
-import { Target } from "../../../typings/target.types";
-import {
+import type { Target } from "../../../typings/target.types";
+import type {
   ContainingScopeModifier,
   EveryScopeModifier,
 } from "../../../typings/targetDescriptor.types";
-import NotebookCellTarget from "../../targets/NotebookCellTarget";
-import { ProcessedTargetsContext } from "../../../typings/Types";
-import { ModifierStage } from "../../PipelineStages.types";
+import type { ProcessedTargetsContext } from "../../../typings/Types";
+import type { ModifierStage } from "../../PipelineStages.types";
+import { NotebookCellTarget } from "../../targets";
 
 export default class implements ModifierStage {
   constructor(private modifier: ContainingScopeModifier | EveryScopeModifier) {}

--- a/src/processTargets/modifiers/scopeTypeStages/ParagraphStage.ts
+++ b/src/processTargets/modifiers/scopeTypeStages/ParagraphStage.ts
@@ -1,12 +1,12 @@
 import { Range } from "vscode";
-import { Target } from "../../../typings/target.types";
-import {
+import type { Target } from "../../../typings/target.types";
+import type {
   ContainingScopeModifier,
   EveryScopeModifier,
 } from "../../../typings/targetDescriptor.types";
-import { ProcessedTargetsContext } from "../../../typings/Types";
-import { ModifierStage } from "../../PipelineStages.types";
-import ParagraphTarget from "../../targets/ParagraphTarget";
+import type { ProcessedTargetsContext } from "../../../typings/Types";
+import type { ModifierStage } from "../../PipelineStages.types";
+import { ParagraphTarget } from "../../targets";
 import { fitRangeToLineContent } from "./LineStage";
 
 export default class implements ModifierStage {

--- a/src/processTargets/targetUtil/createContinuousRange.ts
+++ b/src/processTargets/targetUtil/createContinuousRange.ts
@@ -1,6 +1,6 @@
 import { Position, Range } from "vscode";
-import { Target } from "../../typings/target.types";
-import UntypedTarget from "../targets/UntypedTarget";
+import type { Target } from "../../typings/target.types";
+import { UntypedTarget } from "../targets";
 
 export function createContinuousRange(
   startTarget: Target,

--- a/src/processTargets/targetUtil/insertionRemovalBehaviors/TokenInsertionRemovalBehavior.ts
+++ b/src/processTargets/targetUtil/insertionRemovalBehaviors/TokenInsertionRemovalBehavior.ts
@@ -1,7 +1,7 @@
 import { Range } from "vscode";
-import { Target } from "../../../typings/target.types";
+import type { Target } from "../../../typings/target.types";
 import { isAtEndOfLine, isAtStartOfLine } from "../../../util/rangeUtils";
-import PlainTarget from "../../targets/PlainTarget";
+import { PlainTarget } from "../../targets";
 import { getDelimitedSequenceRemovalRange } from "./DelimitedSequenceInsertionRemovalBehavior";
 
 export function getTokenLeadingDelimiterTarget(

--- a/src/processTargets/targets/BaseTarget.ts
+++ b/src/processTargets/targets/BaseTarget.ts
@@ -1,9 +1,9 @@
 import { isEqual } from "lodash";
 import { Range, Selection, TextEditor } from "vscode";
 import { NoContainingScopeError } from "../../errors";
-import { EditNewContext, Target } from "../../typings/target.types";
-import { Position } from "../../typings/targetDescriptor.types";
-import { EditWithRangeUpdater } from "../../typings/Types";
+import type { EditNewContext, Target } from "../../typings/target.types";
+import type { Position } from "../../typings/targetDescriptor.types";
+import type { EditWithRangeUpdater } from "../../typings/Types";
 import { selectionFromRange } from "../../util/selectionUtils";
 import { isSameType } from "../../util/typeUtils";
 import { toPositionTarget } from "../modifiers/toPositionTarget";

--- a/src/processTargets/targets/UntypedTarget.ts
+++ b/src/processTargets/targets/UntypedTarget.ts
@@ -1,6 +1,6 @@
 import { Range } from "vscode";
 import { BaseTarget, CommonTargetParameters } from ".";
-import { Target } from "../../typings/target.types";
+import type { Target } from "../../typings/target.types";
 import { createContinuousRangeUntypedTarget } from "../targetUtil/createContinuousRange";
 import {
   getTokenLeadingDelimiterTarget,

--- a/src/scripts/transformRecordedTests/index.ts
+++ b/src/scripts/transformRecordedTests/index.ts
@@ -3,11 +3,12 @@ import { identity } from "./transformations/identity";
 import { upgrade } from "./transformations/upgrade";
 import { transformFile } from "./transformFile";
 import { FixtureTransformation } from "./types";
+import { upgradeThatMarks } from "./upgradeThatMarks";
 
 const AVAILABLE_TRANSFORMATIONS: Record<string, FixtureTransformation> = {
   upgrade,
   autoFormat: identity,
-  // custom: MY_CUSTOM_TRANSFORMER,
+  custom: upgradeThatMarks,
 };
 
 async function main(transformationName: string | undefined) {

--- a/src/scripts/transformRecordedTests/upgradeThatMarks.ts
+++ b/src/scripts/transformRecordedTests/upgradeThatMarks.ts
@@ -1,0 +1,48 @@
+import { TestCaseFixture } from "../../testUtil/TestCase";
+import {
+  SelectionPlainObject,
+  TargetPlainObject,
+} from "../../testUtil/toPlainObject";
+import { FixtureTransformation } from "./types";
+
+// FIXME: Remove this before merging the PR
+export const upgradeThatMarks: FixtureTransformation = (
+  fixture: TestCaseFixture
+) => {
+  fixture.initialState.thatMark = fixture.initialState.thatMark?.map(
+    (rangePlainObject) => fixRange(rangePlainObject as any)
+  );
+  fixture.initialState.sourceMark = fixture.initialState.sourceMark?.map(
+    (rangePlainObject) => fixRange(rangePlainObject as any)
+  );
+
+  if (fixture.finalState == null) {
+    return fixture;
+  }
+
+  fixture.finalState.thatMark = fixture.finalState.thatMark?.map(
+    (rangePlainObject) => fixRange(rangePlainObject as any)
+  );
+  fixture.finalState.sourceMark = fixture.finalState.sourceMark?.map(
+    (rangePlainObject) => fixRange(rangePlainObject as any)
+  );
+
+  return fixture;
+};
+
+function fixRange(plainObject: SelectionPlainObject): TargetPlainObject {
+  const { anchor, active } = plainObject;
+  const isReversed =
+    active.line < anchor.line ||
+    (active.line === anchor.line && active.character < anchor.character);
+  return {
+    type: "UntypedTarget",
+    contentRange: isReversed
+      ? { start: active, end: anchor }
+      : { start: anchor, end: active },
+    isReversed,
+    hasExplicitRange: !(
+      active.line === anchor.line && active.character === anchor.character
+    ),
+  };
+}

--- a/src/test/suite/fixtures/recorded/actions/bringAirAndBatAndCap.yml
+++ b/src/test/suite/fixtures/recorded/actions/bringAirAndBatAndCap.yml
@@ -43,13 +43,29 @@ finalState:
     - anchor: {line: 4, character: 5}
       active: {line: 4, character: 5}
   thatMark:
-    - anchor: {line: 4, character: 0}
-      active: {line: 4, character: 5}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 4, character: 0}
+        end: {line: 4, character: 5}
+      isReversed: false
+      hasExplicitRange: true
   sourceMark:
-    - anchor: {line: 0, character: 0}
-      active: {line: 0, character: 1}
-    - anchor: {line: 1, character: 0}
-      active: {line: 1, character: 1}
-    - anchor: {line: 2, character: 0}
-      active: {line: 2, character: 1}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 0}
+        end: {line: 0, character: 1}
+      isReversed: false
+      hasExplicitRange: true
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 0}
+        end: {line: 1, character: 1}
+      isReversed: false
+      hasExplicitRange: true
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 2, character: 0}
+        end: {line: 2, character: 1}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: list, elements: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: a}, selectionType: token, position: contents, insideOutsideType: null, modifier: {type: identity}}, {type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: b}, selectionType: token, position: contents, insideOutsideType: null, modifier: {type: identity}}, {type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: c}, selectionType: token, position: contents, insideOutsideType: null, modifier: {type: identity}}]}, {type: primitive, mark: {type: cursor}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: identity}}]

--- a/src/test/suite/fixtures/recorded/actions/bringAirAndBatAndCapToAfterDrum.yml
+++ b/src/test/suite/fixtures/recorded/actions/bringAirAndBatAndCapToAfterDrum.yml
@@ -49,13 +49,29 @@ finalState:
     - anchor: {line: 5, character: 0}
       active: {line: 5, character: 0}
   thatMark:
-    - anchor: {line: 4, character: 2}
-      active: {line: 4, character: 7}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 4, character: 2}
+        end: {line: 4, character: 7}
+      isReversed: false
+      hasExplicitRange: true
   sourceMark:
-    - anchor: {line: 0, character: 0}
-      active: {line: 0, character: 1}
-    - anchor: {line: 1, character: 0}
-      active: {line: 1, character: 1}
-    - anchor: {line: 2, character: 0}
-      active: {line: 2, character: 1}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 0}
+        end: {line: 0, character: 1}
+      isReversed: false
+      hasExplicitRange: true
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 0}
+        end: {line: 1, character: 1}
+      isReversed: false
+      hasExplicitRange: true
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 2, character: 0}
+        end: {line: 2, character: 1}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: list, elements: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: a}, selectionType: token, position: contents, insideOutsideType: null, modifier: {type: identity}}, {type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: b}, selectionType: token, position: contents, insideOutsideType: null, modifier: {type: identity}}, {type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: c}, selectionType: token, position: contents, insideOutsideType: null, modifier: {type: identity}}]}, {type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: d}, selectionType: token, position: after, insideOutsideType: null, modifier: {type: identity}}]

--- a/src/test/suite/fixtures/recorded/actions/bringAirAndBatAndCapToAfterItemEach.yml
+++ b/src/test/suite/fixtures/recorded/actions/bringAirAndBatAndCapToAfterItemEach.yml
@@ -50,13 +50,29 @@ finalState:
     - anchor: {line: 5, character: 0}
       active: {line: 5, character: 0}
   thatMark:
-    - anchor: {line: 4, character: 19}
-      active: {line: 4, character: 26}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 4, character: 19}
+        end: {line: 4, character: 26}
+      isReversed: false
+      hasExplicitRange: true
   sourceMark:
-    - anchor: {line: 0, character: 0}
-      active: {line: 0, character: 1}
-    - anchor: {line: 1, character: 0}
-      active: {line: 1, character: 1}
-    - anchor: {line: 2, character: 0}
-      active: {line: 2, character: 1}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 0}
+        end: {line: 0, character: 1}
+      isReversed: false
+      hasExplicitRange: true
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 0}
+        end: {line: 1, character: 1}
+      isReversed: false
+      hasExplicitRange: true
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 2, character: 0}
+        end: {line: 2, character: 1}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: list, elements: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: a}, selectionType: token, position: contents, insideOutsideType: null, modifier: {type: identity}}, {type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: b}, selectionType: token, position: contents, insideOutsideType: null, modifier: {type: identity}}, {type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: c}, selectionType: token, position: contents, insideOutsideType: null, modifier: {type: identity}}]}, {type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: e}, selectionType: token, position: after, insideOutsideType: null, modifier: {type: containingScope, scopeType: collectionItem, includeSiblings: false}}]

--- a/src/test/suite/fixtures/recorded/actions/bringAirAndBatAndCapToBeforeDrum.yml
+++ b/src/test/suite/fixtures/recorded/actions/bringAirAndBatAndCapToBeforeDrum.yml
@@ -49,13 +49,29 @@ finalState:
     - anchor: {line: 5, character: 0}
       active: {line: 5, character: 0}
   thatMark:
-    - anchor: {line: 4, character: 0}
-      active: {line: 4, character: 5}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 4, character: 0}
+        end: {line: 4, character: 5}
+      isReversed: false
+      hasExplicitRange: true
   sourceMark:
-    - anchor: {line: 0, character: 0}
-      active: {line: 0, character: 1}
-    - anchor: {line: 1, character: 0}
-      active: {line: 1, character: 1}
-    - anchor: {line: 2, character: 0}
-      active: {line: 2, character: 1}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 0}
+        end: {line: 0, character: 1}
+      isReversed: false
+      hasExplicitRange: true
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 0}
+        end: {line: 1, character: 1}
+      isReversed: false
+      hasExplicitRange: true
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 2, character: 0}
+        end: {line: 2, character: 1}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: list, elements: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: a}, selectionType: token, position: contents, insideOutsideType: null, modifier: {type: identity}}, {type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: b}, selectionType: token, position: contents, insideOutsideType: null, modifier: {type: identity}}, {type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: c}, selectionType: token, position: contents, insideOutsideType: null, modifier: {type: identity}}]}, {type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: d}, selectionType: token, position: before, insideOutsideType: null, modifier: {type: identity}}]

--- a/src/test/suite/fixtures/recorded/actions/bringAirAndBatAndCapToBeforeItemEach.yml
+++ b/src/test/suite/fixtures/recorded/actions/bringAirAndBatAndCapToBeforeItemEach.yml
@@ -50,13 +50,29 @@ finalState:
     - anchor: {line: 5, character: 0}
       active: {line: 5, character: 0}
   thatMark:
-    - anchor: {line: 4, character: 16}
-      active: {line: 4, character: 23}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 4, character: 16}
+        end: {line: 4, character: 23}
+      isReversed: false
+      hasExplicitRange: true
   sourceMark:
-    - anchor: {line: 0, character: 0}
-      active: {line: 0, character: 1}
-    - anchor: {line: 1, character: 0}
-      active: {line: 1, character: 1}
-    - anchor: {line: 2, character: 0}
-      active: {line: 2, character: 1}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 0}
+        end: {line: 0, character: 1}
+      isReversed: false
+      hasExplicitRange: true
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 0}
+        end: {line: 1, character: 1}
+      isReversed: false
+      hasExplicitRange: true
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 2, character: 0}
+        end: {line: 2, character: 1}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: list, elements: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: a}, selectionType: token, position: contents, insideOutsideType: null, modifier: {type: identity}}, {type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: b}, selectionType: token, position: contents, insideOutsideType: null, modifier: {type: identity}}, {type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: c}, selectionType: token, position: contents, insideOutsideType: null, modifier: {type: identity}}]}, {type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: e}, selectionType: token, position: before, insideOutsideType: null, modifier: {type: containingScope, scopeType: collectionItem, includeSiblings: false}}]

--- a/src/test/suite/fixtures/recorded/actions/bringArgMadeAfterLook.yml
+++ b/src/test/suite/fixtures/recorded/actions/bringArgMadeAfterLook.yml
@@ -43,9 +43,17 @@ finalState:
     - anchor: {line: 0, character: 0}
       active: {line: 0, character: 0}
   thatMark:
-    - anchor: {line: 3, character: 4}
-      active: {line: 3, character: 16}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 3, character: 4}
+        end: {line: 3, character: 16}
+      isReversed: false
+      hasExplicitRange: true
   sourceMark:
-    - anchor: {line: 1, character: 4}
-      active: {line: 1, character: 16}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 4}
+        end: {line: 1, character: 16}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: m}, modifiers: [&ref_0 {type: containingScope, scopeType: {type: argumentOrParameter}}]}, {type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: l}, modifiers: [{type: position, position: after}, *ref_0]}]

--- a/src/test/suite/fixtures/recorded/actions/bringArgMadeAfterVest.yml
+++ b/src/test/suite/fixtures/recorded/actions/bringArgMadeAfterVest.yml
@@ -41,9 +41,17 @@ finalState:
     - anchor: {line: 0, character: 0}
       active: {line: 0, character: 0}
   thatMark:
-    - anchor: {line: 3, character: 4}
-      active: {line: 3, character: 16}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 3, character: 4}
+        end: {line: 3, character: 16}
+      isReversed: false
+      hasExplicitRange: true
   sourceMark:
-    - anchor: {line: 1, character: 4}
-      active: {line: 1, character: 16}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 4}
+        end: {line: 1, character: 16}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: m}, modifiers: [&ref_0 {type: containingScope, scopeType: {type: argumentOrParameter}}]}, {type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: v}, modifiers: [{type: position, position: after}, *ref_0]}]

--- a/src/test/suite/fixtures/recorded/actions/bringArgWhaleBeforeLook.yml
+++ b/src/test/suite/fixtures/recorded/actions/bringArgWhaleBeforeLook.yml
@@ -43,9 +43,17 @@ finalState:
     - anchor: {line: 0, character: 0}
       active: {line: 0, character: 0}
   thatMark:
-    - anchor: {line: 2, character: 4}
-      active: {line: 2, character: 21}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 2, character: 4}
+        end: {line: 2, character: 21}
+      isReversed: false
+      hasExplicitRange: true
   sourceMark:
-    - anchor: {line: 4, character: 4}
-      active: {line: 4, character: 21}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 4, character: 4}
+        end: {line: 4, character: 21}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: w}, modifiers: [&ref_0 {type: containingScope, scopeType: {type: argumentOrParameter}}]}, {type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: l}, modifiers: [{type: position, position: before}, *ref_0]}]

--- a/src/test/suite/fixtures/recorded/actions/bringArgueFineAndZip.yml
+++ b/src/test/suite/fixtures/recorded/actions/bringArgueFineAndZip.yml
@@ -44,11 +44,23 @@ finalState:
     - anchor: {line: 4, character: 39}
       active: {line: 4, character: 39}
   thatMark:
-    - anchor: {line: 4, character: 15}
-      active: {line: 4, character: 39}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 4, character: 15}
+        end: {line: 4, character: 39}
+      isReversed: false
+      hasExplicitRange: true
   sourceMark:
-    - anchor: {line: 0, character: 20}
-      active: {line: 0, character: 31}
-    - anchor: {line: 0, character: 46}
-      active: {line: 0, character: 57}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 20}
+        end: {line: 0, character: 31}
+      isReversed: false
+      hasExplicitRange: true
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 46}
+        end: {line: 0, character: 57}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: list, elements: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: f}, selectionType: token, position: contents, insideOutsideType: null, modifier: {type: containingScope, scopeType: argumentOrParameter, includeSiblings: false}, isImplicit: false}, {type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: z}, selectionType: token, position: contents, insideOutsideType: null, modifier: {type: containingScope, scopeType: argumentOrParameter, includeSiblings: false}, isImplicit: false}]}, {type: primitive, mark: {type: cursor}, selectionType: token, position: contents, insideOutsideType: null, modifier: {type: identity}, isImplicit: true}]

--- a/src/test/suite/fixtures/recorded/actions/bringArgueOxAndZipToAfterJustLeper.yml
+++ b/src/test/suite/fixtures/recorded/actions/bringArgueOxAndZipToAfterJustLeper.yml
@@ -50,11 +50,23 @@ finalState:
     - anchor: {line: 3, character: 0}
       active: {line: 3, character: 0}
   thatMark:
-    - anchor: {line: 4, character: 15}
-      active: {line: 4, character: 39}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 4, character: 15}
+        end: {line: 4, character: 39}
+      isReversed: false
+      hasExplicitRange: true
   sourceMark:
-    - anchor: {line: 0, character: 20}
-      active: {line: 0, character: 31}
-    - anchor: {line: 0, character: 46}
-      active: {line: 0, character: 57}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 20}
+        end: {line: 0, character: 31}
+      isReversed: false
+      hasExplicitRange: true
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 46}
+        end: {line: 0, character: 57}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: list, elements: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: o}, selectionType: token, position: contents, insideOutsideType: null, modifier: {type: containingScope, scopeType: argumentOrParameter, includeSiblings: false}, isImplicit: false}, {type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: z}, selectionType: token, position: contents, insideOutsideType: null, modifier: {type: containingScope, scopeType: argumentOrParameter, includeSiblings: false}, isImplicit: false}]}, {type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: (}, selectionType: token, position: after, insideOutsideType: null, modifier: {type: toRawSelection}, isImplicit: false}]

--- a/src/test/suite/fixtures/recorded/actions/bringFineAfterLineVest.yml
+++ b/src/test/suite/fixtures/recorded/actions/bringFineAfterLineVest.yml
@@ -36,9 +36,17 @@ finalState:
     - anchor: {line: 0, character: 0}
       active: {line: 0, character: 0}
   thatMark:
-    - anchor: {line: 2, character: 4}
-      active: {line: 2, character: 7}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 2, character: 4}
+        end: {line: 2, character: 7}
+      isReversed: false
+      hasExplicitRange: true
   sourceMark:
-    - anchor: {line: 0, character: 0}
-      active: {line: 0, character: 3}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 0}
+        end: {line: 0, character: 3}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: f}, modifiers: []}, {type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: v}, modifiers: [{type: position, position: after}, {type: containingScope, scopeType: {type: line}}]}]

--- a/src/test/suite/fixtures/recorded/actions/bringFineBeforeLineVest.yml
+++ b/src/test/suite/fixtures/recorded/actions/bringFineBeforeLineVest.yml
@@ -38,9 +38,17 @@ finalState:
     - anchor: {line: 0, character: 0}
       active: {line: 0, character: 0}
   thatMark:
-    - anchor: {line: 1, character: 4}
-      active: {line: 1, character: 7}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 4}
+        end: {line: 1, character: 7}
+      isReversed: false
+      hasExplicitRange: true
   sourceMark:
-    - anchor: {line: 3, character: 0}
-      active: {line: 3, character: 3}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 3, character: 0}
+        end: {line: 3, character: 3}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: f}, modifiers: []}, {type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: v}, modifiers: [{type: position, position: before}, {type: containingScope, scopeType: {type: line}}]}]

--- a/src/test/suite/fixtures/recorded/actions/bringItemAirAfterCap.yml
+++ b/src/test/suite/fixtures/recorded/actions/bringItemAirAfterCap.yml
@@ -43,9 +43,17 @@ finalState:
     - anchor: {line: 0, character: 0}
       active: {line: 0, character: 0}
   thatMark:
-    - anchor: {line: 4, character: 4}
-      active: {line: 4, character: 5}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 4, character: 4}
+        end: {line: 4, character: 5}
+      isReversed: false
+      hasExplicitRange: true
   sourceMark:
-    - anchor: {line: 1, character: 4}
-      active: {line: 1, character: 5}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 4}
+        end: {line: 1, character: 5}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: a}, modifiers: [&ref_0 {type: containingScope, scopeType: {type: collectionItem}}]}, {type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: c}, modifiers: [{type: position, position: after}, *ref_0]}]

--- a/src/test/suite/fixtures/recorded/actions/bringLineAirAndBatAndCapToAfterDrum.yml
+++ b/src/test/suite/fixtures/recorded/actions/bringLineAirAndBatAndCapToAfterDrum.yml
@@ -53,13 +53,29 @@ finalState:
     - anchor: {line: 8, character: 0}
       active: {line: 8, character: 0}
   thatMark:
-    - anchor: {line: 5, character: 0}
-      active: {line: 7, character: 1}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 5, character: 0}
+        end: {line: 7, character: 1}
+      isReversed: false
+      hasExplicitRange: true
   sourceMark:
-    - anchor: {line: 0, character: 0}
-      active: {line: 0, character: 1}
-    - anchor: {line: 1, character: 0}
-      active: {line: 1, character: 1}
-    - anchor: {line: 2, character: 0}
-      active: {line: 2, character: 1}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 0}
+        end: {line: 0, character: 1}
+      isReversed: false
+      hasExplicitRange: true
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 0}
+        end: {line: 1, character: 1}
+      isReversed: false
+      hasExplicitRange: true
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 2, character: 0}
+        end: {line: 2, character: 1}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: list, elements: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: a}, selectionType: line, position: contents, insideOutsideType: null, modifier: {type: identity}}, {type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: b}, selectionType: line, position: contents, insideOutsideType: null, modifier: {type: identity}}, {type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: c}, selectionType: line, position: contents, insideOutsideType: null, modifier: {type: identity}}]}, {type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: d}, selectionType: line, position: after, insideOutsideType: null, modifier: {type: identity}}]

--- a/src/test/suite/fixtures/recorded/actions/bringLineAirAndBatAndCapToBeforeDrum.yml
+++ b/src/test/suite/fixtures/recorded/actions/bringLineAirAndBatAndCapToBeforeDrum.yml
@@ -53,13 +53,29 @@ finalState:
     - anchor: {line: 8, character: 0}
       active: {line: 8, character: 0}
   thatMark:
-    - anchor: {line: 4, character: 0}
-      active: {line: 6, character: 1}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 4, character: 0}
+        end: {line: 6, character: 1}
+      isReversed: false
+      hasExplicitRange: true
   sourceMark:
-    - anchor: {line: 0, character: 0}
-      active: {line: 0, character: 1}
-    - anchor: {line: 1, character: 0}
-      active: {line: 1, character: 1}
-    - anchor: {line: 2, character: 0}
-      active: {line: 2, character: 1}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 0}
+        end: {line: 0, character: 1}
+      isReversed: false
+      hasExplicitRange: true
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 0}
+        end: {line: 1, character: 1}
+      isReversed: false
+      hasExplicitRange: true
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 2, character: 0}
+        end: {line: 2, character: 1}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: list, elements: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: a}, selectionType: line, position: contents, insideOutsideType: null, modifier: {type: identity}}, {type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: b}, selectionType: line, position: contents, insideOutsideType: null, modifier: {type: identity}}, {type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: c}, selectionType: line, position: contents, insideOutsideType: null, modifier: {type: identity}}]}, {type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: d}, selectionType: line, position: before, insideOutsideType: null, modifier: {type: identity}}]

--- a/src/test/suite/fixtures/recorded/actions/bringLineHarpAndWhale.yml
+++ b/src/test/suite/fixtures/recorded/actions/bringLineHarpAndWhale.yml
@@ -40,11 +40,23 @@ finalState:
     - anchor: {line: 5, character: 8}
       active: {line: 5, character: 8}
   thatMark:
-    - anchor: {line: 4, character: 0}
-      active: {line: 5, character: 8}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 4, character: 0}
+        end: {line: 5, character: 8}
+      isReversed: false
+      hasExplicitRange: true
   sourceMark:
-    - anchor: {line: 0, character: 0}
-      active: {line: 0, character: 5}
-    - anchor: {line: 2, character: 0}
-      active: {line: 2, character: 8}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 0}
+        end: {line: 0, character: 5}
+      isReversed: false
+      hasExplicitRange: true
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 2, character: 0}
+        end: {line: 2, character: 8}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: list, elements: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: h}, selectionType: line, position: contents, insideOutsideType: null, modifier: {type: identity}, isImplicit: false}, {type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: w}, selectionType: line, position: contents, insideOutsideType: null, modifier: {type: identity}, isImplicit: false}]}, {type: primitive, mark: {type: cursor}, selectionType: token, position: contents, insideOutsideType: null, modifier: {type: identity}, isImplicit: true}]

--- a/src/test/suite/fixtures/recorded/actions/bringVest.yml
+++ b/src/test/suite/fixtures/recorded/actions/bringVest.yml
@@ -26,9 +26,17 @@ finalState:
     - anchor: {line: 0, character: 5}
       active: {line: 0, character: 5}
   thatMark:
-    - anchor: {line: 0, character: 0}
-      active: {line: 0, character: 5}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 0}
+        end: {line: 0, character: 5}
+      isReversed: false
+      hasExplicitRange: true
   sourceMark:
-    - anchor: {line: 1, character: 6}
-      active: {line: 1, character: 11}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 6}
+        end: {line: 1, character: 11}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: v}, selectionType: token, position: contents, modifier: {type: identity}, insideOutsideType: null}, {type: primitive, mark: {type: cursor}, selectionType: token, position: contents, modifier: {type: identity}, insideOutsideType: inside}]

--- a/src/test/suite/fixtures/recorded/actions/bringVestToCap.yml
+++ b/src/test/suite/fixtures/recorded/actions/bringVestToCap.yml
@@ -30,9 +30,17 @@ finalState:
     - anchor: {line: 0, character: 0}
       active: {line: 0, character: 0}
   thatMark:
-    - anchor: {line: 1, character: 0}
-      active: {line: 1, character: 5}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 0}
+        end: {line: 1, character: 5}
+      isReversed: false
+      hasExplicitRange: true
   sourceMark:
-    - anchor: {line: 1, character: 6}
-      active: {line: 1, character: 11}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 6}
+        end: {line: 1, character: 11}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: v}, selectionType: token, position: contents, modifier: {type: identity}, insideOutsideType: null}, {type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: c}, selectionType: token, position: contents, modifier: {type: identity}, insideOutsideType: null}]

--- a/src/test/suite/fixtures/recorded/actions/callFine.yml
+++ b/src/test/suite/fixtures/recorded/actions/callFine.yml
@@ -32,8 +32,16 @@ finalState:
     - anchor: {line: 2, character: 4}
       active: {line: 2, character: 7}
   thatMark:
-    - anchor: {line: 1, character: 0}
-      active: {line: 1, character: 8}
-    - anchor: {line: 2, character: 0}
-      active: {line: 2, character: 8}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 0}
+        end: {line: 1, character: 8}
+      isReversed: false
+      hasExplicitRange: true
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 2, character: 0}
+        end: {line: 2, character: 8}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: f}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: identity}}, {type: primitive, mark: {type: cursor}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: identity}}]

--- a/src/test/suite/fixtures/recorded/actions/callVest.yml
+++ b/src/test/suite/fixtures/recorded/actions/callVest.yml
@@ -26,6 +26,10 @@ finalState:
     - anchor: {line: 0, character: 6}
       active: {line: 0, character: 6}
   thatMark:
-    - anchor: {line: 0, character: 0}
-      active: {line: 0, character: 7}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 0}
+        end: {line: 0, character: 7}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: v}, selectionType: token, position: contents, modifier: {type: identity}, insideOutsideType: inside}, {type: primitive, mark: {type: cursor}, selectionType: token, position: contents, modifier: {type: identity}, insideOutsideType: inside}]

--- a/src/test/suite/fixtures/recorded/actions/callVestOnCap.yml
+++ b/src/test/suite/fixtures/recorded/actions/callVestOnCap.yml
@@ -30,6 +30,10 @@ finalState:
     - anchor: {line: 0, character: 0}
       active: {line: 0, character: 0}
   thatMark:
-    - anchor: {line: 1, character: 0}
-      active: {line: 1, character: 12}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 0}
+        end: {line: 1, character: 12}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: v}, selectionType: token, position: contents, modifier: {type: identity}, insideOutsideType: inside}, {type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: c}, selectionType: token, position: contents, modifier: {type: identity}, insideOutsideType: inside}]

--- a/src/test/suite/fixtures/recorded/actions/carveVest.yml
+++ b/src/test/suite/fixtures/recorded/actions/carveVest.yml
@@ -25,6 +25,10 @@ finalState:
     - anchor: {line: 0, character: 0}
       active: {line: 0, character: 0}
   thatMark:
-    - anchor: {line: 1, character: 6}
-      active: {line: 1, character: 6}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 6}
+        end: {line: 1, character: 6}
+      isReversed: false
+      hasExplicitRange: false
 fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: v}, selectionType: token, position: contents, modifier: {type: identity}, insideOutsideType: null}]

--- a/src/test/suite/fixtures/recorded/actions/chuckArgMadeAndAir.yml
+++ b/src/test/suite/fixtures/recorded/actions/chuckArgMadeAndAir.yml
@@ -29,6 +29,10 @@ finalState:
     - anchor: {line: 0, character: 0}
       active: {line: 0, character: 0}
   thatMark:
-    - anchor: {line: 0, character: 29}
-      active: {line: 0, character: 29}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 29}
+        end: {line: 0, character: 29}
+      isReversed: false
+      hasExplicitRange: false
 fullTargets: [{type: list, elements: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: m}, selectionType: token, position: contents, insideOutsideType: outside, modifier: {type: containingScope, scopeType: argumentOrParameter, includeSiblings: false}, isImplicit: false}, {type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: a}, selectionType: token, position: contents, insideOutsideType: outside, modifier: {type: containingScope, scopeType: argumentOrParameter, includeSiblings: false}, isImplicit: false}]}]

--- a/src/test/suite/fixtures/recorded/actions/chuckArgMadeAndAirAndJustSoon.yml
+++ b/src/test/suite/fixtures/recorded/actions/chuckArgMadeAndAirAndJustSoon.yml
@@ -35,6 +35,10 @@ finalState:
     - anchor: {line: 0, character: 0}
       active: {line: 0, character: 0}
   thatMark:
-    - anchor: {line: 0, character: 23}
-      active: {line: 0, character: 23}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 23}
+        end: {line: 0, character: 23}
+      isReversed: false
+      hasExplicitRange: false
 fullTargets: [{type: list, elements: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: m}, selectionType: token, position: contents, insideOutsideType: outside, modifier: {type: containingScope, scopeType: argumentOrParameter, includeSiblings: false}, isImplicit: false}, {type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: a}, selectionType: token, position: contents, insideOutsideType: outside, modifier: {type: containingScope, scopeType: argumentOrParameter, includeSiblings: false}, isImplicit: false}, {type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: s}, selectionType: token, position: contents, insideOutsideType: outside, modifier: {type: toRawSelection}, isImplicit: false}]}]

--- a/src/test/suite/fixtures/recorded/actions/chuckEveryArgMade.yml
+++ b/src/test/suite/fixtures/recorded/actions/chuckEveryArgMade.yml
@@ -22,6 +22,10 @@ finalState:
     - anchor: {line: 0, character: 0}
       active: {line: 0, character: 0}
   thatMark:
-    - anchor: {line: 0, character: 16}
-      active: {line: 0, character: 16}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 16}
+        end: {line: 0, character: 16}
+      isReversed: false
+      hasExplicitRange: false
 fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: m}, selectionType: token, position: contents, insideOutsideType: outside, modifier: {type: containingScope, scopeType: argumentOrParameter, includeSiblings: true}, isImplicit: false}]

--- a/src/test/suite/fixtures/recorded/actions/chuckVest.yml
+++ b/src/test/suite/fixtures/recorded/actions/chuckVest.yml
@@ -25,6 +25,10 @@ finalState:
     - anchor: {line: 0, character: 0}
       active: {line: 0, character: 0}
   thatMark:
-    - anchor: {line: 1, character: 6}
-      active: {line: 1, character: 6}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 6}
+        end: {line: 1, character: 6}
+      isReversed: false
+      hasExplicitRange: false
 fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: v}, selectionType: token, position: contents, modifier: {type: identity}, insideOutsideType: outside}]

--- a/src/test/suite/fixtures/recorded/actions/clearVest.yml
+++ b/src/test/suite/fixtures/recorded/actions/clearVest.yml
@@ -25,6 +25,10 @@ finalState:
     - anchor: {line: 1, character: 6}
       active: {line: 1, character: 6}
   thatMark:
-    - anchor: {line: 1, character: 6}
-      active: {line: 1, character: 6}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 6}
+        end: {line: 1, character: 6}
+      isReversed: false
+      hasExplicitRange: false
 fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: v}, selectionType: token, position: contents, modifier: {type: identity}, insideOutsideType: inside}]

--- a/src/test/suite/fixtures/recorded/actions/cloneArgue.yml
+++ b/src/test/suite/fixtures/recorded/actions/cloneArgue.yml
@@ -31,11 +31,19 @@ finalState:
     - anchor: {line: 0, character: 33}
       active: {line: 0, character: 33}
   thatMark:
-    - anchor: {line: 0, character: 26}
-      active: {line: 0, character: 37}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 26}
+        end: {line: 0, character: 37}
+      isReversed: false
+      hasExplicitRange: true
   sourceMark:
-    - anchor: {line: 0, character: 13}
-      active: {line: 0, character: 24}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 13}
+        end: {line: 0, character: 24}
+      isReversed: false
+      hasExplicitRange: true
 decorations:
   - name: justAddedBackground
     type: token

--- a/src/test/suite/fixtures/recorded/actions/cloneArgue2.yml
+++ b/src/test/suite/fixtures/recorded/actions/cloneArgue2.yml
@@ -27,9 +27,17 @@ finalState:
     - anchor: {line: 0, character: 37}
       active: {line: 0, character: 37}
   thatMark:
-    - anchor: {line: 0, character: 26}
-      active: {line: 0, character: 37}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 26}
+        end: {line: 0, character: 37}
+      isReversed: false
+      hasExplicitRange: true
   sourceMark:
-    - anchor: {line: 0, character: 13}
-      active: {line: 0, character: 24}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 13}
+        end: {line: 0, character: 24}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: [{type: containingScope, scopeType: {type: argumentOrParameter}}]}]

--- a/src/test/suite/fixtures/recorded/actions/cloneEveryArg.yml
+++ b/src/test/suite/fixtures/recorded/actions/cloneEveryArg.yml
@@ -21,13 +21,29 @@ finalState:
     - anchor: {line: 0, character: 31}
       active: {line: 0, character: 31}
   thatMark:
-    - anchor: {line: 0, character: 27}
-      active: {line: 0, character: 36}
-    - anchor: {line: 0, character: 49}
-      active: {line: 0, character: 58}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 27}
+        end: {line: 0, character: 36}
+      isReversed: false
+      hasExplicitRange: true
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 49}
+        end: {line: 0, character: 58}
+      isReversed: false
+      hasExplicitRange: true
   sourceMark:
-    - anchor: {line: 0, character: 16}
-      active: {line: 0, character: 25}
-    - anchor: {line: 0, character: 38}
-      active: {line: 0, character: 47}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 16}
+        end: {line: 0, character: 25}
+      isReversed: false
+      hasExplicitRange: true
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 38}
+        end: {line: 0, character: 47}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: [{type: everyScope, scopeType: {type: argumentOrParameter}}]}]

--- a/src/test/suite/fixtures/recorded/actions/cloneHarp.yml
+++ b/src/test/suite/fixtures/recorded/actions/cloneHarp.yml
@@ -23,9 +23,17 @@ finalState:
     - anchor: {line: 1, character: 5}
       active: {line: 1, character: 5}
   thatMark:
-    - anchor: {line: 1, character: 0}
-      active: {line: 1, character: 5}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 0}
+        end: {line: 1, character: 5}
+      isReversed: false
+      hasExplicitRange: true
   sourceMark:
-    - anchor: {line: 0, character: 0}
-      active: {line: 0, character: 5}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 0}
+        end: {line: 0, character: 5}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: h}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: identity}}]

--- a/src/test/suite/fixtures/recorded/actions/cloneHarp2.yml
+++ b/src/test/suite/fixtures/recorded/actions/cloneHarp2.yml
@@ -23,9 +23,17 @@ finalState:
     - anchor: {line: 1, character: 0}
       active: {line: 1, character: 0}
   thatMark:
-    - anchor: {line: 1, character: 0}
-      active: {line: 1, character: 5}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 0}
+        end: {line: 1, character: 5}
+      isReversed: false
+      hasExplicitRange: true
   sourceMark:
-    - anchor: {line: 0, character: 0}
-      active: {line: 0, character: 5}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 0}
+        end: {line: 0, character: 5}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: h}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: identity}}]

--- a/src/test/suite/fixtures/recorded/actions/cloneToken.yml
+++ b/src/test/suite/fixtures/recorded/actions/cloneToken.yml
@@ -21,11 +21,19 @@ finalState:
     - anchor: {line: 0, character: 14}
       active: {line: 0, character: 14}
   thatMark:
-    - anchor: {line: 0, character: 12}
-      active: {line: 0, character: 17}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 12}
+        end: {line: 0, character: 17}
+      isReversed: false
+      hasExplicitRange: true
   sourceMark:
-    - anchor: {line: 0, character: 6}
-      active: {line: 0, character: 11}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 6}
+        end: {line: 0, character: 11}
+      isReversed: false
+      hasExplicitRange: true
 decorations:
   - name: justAddedBackground
     type: token

--- a/src/test/suite/fixtures/recorded/actions/cloneToken2.yml
+++ b/src/test/suite/fixtures/recorded/actions/cloneToken2.yml
@@ -21,11 +21,19 @@ finalState:
     - anchor: {line: 0, character: 9}
       active: {line: 0, character: 9}
   thatMark:
-    - anchor: {line: 0, character: 6}
-      active: {line: 0, character: 11}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 6}
+        end: {line: 0, character: 11}
+      isReversed: false
+      hasExplicitRange: true
   sourceMark:
-    - anchor: {line: 0, character: 0}
-      active: {line: 0, character: 5}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 0}
+        end: {line: 0, character: 5}
+      isReversed: false
+      hasExplicitRange: true
 decorations:
   - name: justAddedBackground
     type: token

--- a/src/test/suite/fixtures/recorded/actions/cloneToken3.yml
+++ b/src/test/suite/fixtures/recorded/actions/cloneToken3.yml
@@ -21,9 +21,17 @@ finalState:
     - anchor: {line: 0, character: 11}
       active: {line: 0, character: 11}
   thatMark:
-    - anchor: {line: 0, character: 6}
-      active: {line: 0, character: 11}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 6}
+        end: {line: 0, character: 11}
+      isReversed: false
+      hasExplicitRange: true
   sourceMark:
-    - anchor: {line: 0, character: 0}
-      active: {line: 0, character: 5}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 0}
+        end: {line: 0, character: 5}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: [{type: containingScope, scopeType: {type: token}}]}]

--- a/src/test/suite/fixtures/recorded/actions/cloneToken4.yml
+++ b/src/test/suite/fixtures/recorded/actions/cloneToken4.yml
@@ -21,9 +21,17 @@ finalState:
     - anchor: {line: 0, character: 6}
       active: {line: 0, character: 6}
   thatMark:
-    - anchor: {line: 0, character: 6}
-      active: {line: 0, character: 11}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 6}
+        end: {line: 0, character: 11}
+      isReversed: false
+      hasExplicitRange: true
   sourceMark:
-    - anchor: {line: 0, character: 0}
-      active: {line: 0, character: 5}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 0}
+        end: {line: 0, character: 5}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: [{type: containingScope, scopeType: {type: token}}]}]

--- a/src/test/suite/fixtures/recorded/actions/cloneToken5.yml
+++ b/src/test/suite/fixtures/recorded/actions/cloneToken5.yml
@@ -21,9 +21,17 @@ finalState:
     - anchor: {line: 0, character: 6}
       active: {line: 0, character: 11}
   thatMark:
-    - anchor: {line: 0, character: 6}
-      active: {line: 0, character: 11}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 6}
+        end: {line: 0, character: 11}
+      isReversed: false
+      hasExplicitRange: true
   sourceMark:
-    - anchor: {line: 0, character: 0}
-      active: {line: 0, character: 5}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 0}
+        end: {line: 0, character: 5}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: [{type: containingScope, scopeType: {type: token}}]}]

--- a/src/test/suite/fixtures/recorded/actions/cloneUpArgue.yml
+++ b/src/test/suite/fixtures/recorded/actions/cloneUpArgue.yml
@@ -31,11 +31,19 @@ finalState:
     - anchor: {line: 0, character: 20}
       active: {line: 0, character: 20}
   thatMark:
-    - anchor: {line: 0, character: 13}
-      active: {line: 0, character: 24}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 13}
+        end: {line: 0, character: 24}
+      isReversed: false
+      hasExplicitRange: true
   sourceMark:
-    - anchor: {line: 0, character: 26}
-      active: {line: 0, character: 37}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 26}
+        end: {line: 0, character: 37}
+      isReversed: false
+      hasExplicitRange: true
 decorations:
   - name: justAddedBackground
     type: token

--- a/src/test/suite/fixtures/recorded/actions/cloneUpArgue2.yml
+++ b/src/test/suite/fixtures/recorded/actions/cloneUpArgue2.yml
@@ -27,9 +27,17 @@ finalState:
     - anchor: {line: 0, character: 13}
       active: {line: 0, character: 13}
   thatMark:
-    - anchor: {line: 0, character: 13}
-      active: {line: 0, character: 24}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 13}
+        end: {line: 0, character: 24}
+      isReversed: false
+      hasExplicitRange: true
   sourceMark:
-    - anchor: {line: 0, character: 26}
-      active: {line: 0, character: 37}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 26}
+        end: {line: 0, character: 37}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: [{type: containingScope, scopeType: {type: argumentOrParameter}}]}]

--- a/src/test/suite/fixtures/recorded/actions/cloneUpEveryArg.yml
+++ b/src/test/suite/fixtures/recorded/actions/cloneUpEveryArg.yml
@@ -21,13 +21,29 @@ finalState:
     - anchor: {line: 0, character: 20}
       active: {line: 0, character: 20}
   thatMark:
-    - anchor: {line: 0, character: 16}
-      active: {line: 0, character: 25}
-    - anchor: {line: 0, character: 38}
-      active: {line: 0, character: 47}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 16}
+        end: {line: 0, character: 25}
+      isReversed: false
+      hasExplicitRange: true
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 38}
+        end: {line: 0, character: 47}
+      isReversed: false
+      hasExplicitRange: true
   sourceMark:
-    - anchor: {line: 0, character: 27}
-      active: {line: 0, character: 36}
-    - anchor: {line: 0, character: 49}
-      active: {line: 0, character: 58}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 27}
+        end: {line: 0, character: 36}
+      isReversed: false
+      hasExplicitRange: true
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 49}
+        end: {line: 0, character: 58}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: [{type: everyScope, scopeType: {type: argumentOrParameter}}]}]

--- a/src/test/suite/fixtures/recorded/actions/cloneUpHarp.yml
+++ b/src/test/suite/fixtures/recorded/actions/cloneUpHarp.yml
@@ -23,9 +23,17 @@ finalState:
     - anchor: {line: 0, character: 5}
       active: {line: 0, character: 5}
   thatMark:
-    - anchor: {line: 0, character: 0}
-      active: {line: 0, character: 5}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 0}
+        end: {line: 0, character: 5}
+      isReversed: false
+      hasExplicitRange: true
   sourceMark:
-    - anchor: {line: 1, character: 0}
-      active: {line: 1, character: 5}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 0}
+        end: {line: 1, character: 5}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: h}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: identity}}]

--- a/src/test/suite/fixtures/recorded/actions/cloneUpHarp2.yml
+++ b/src/test/suite/fixtures/recorded/actions/cloneUpHarp2.yml
@@ -23,9 +23,17 @@ finalState:
     - anchor: {line: 0, character: 0}
       active: {line: 0, character: 0}
   thatMark:
-    - anchor: {line: 0, character: 0}
-      active: {line: 0, character: 5}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 0}
+        end: {line: 0, character: 5}
+      isReversed: false
+      hasExplicitRange: true
   sourceMark:
-    - anchor: {line: 1, character: 0}
-      active: {line: 1, character: 5}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 0}
+        end: {line: 1, character: 5}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: h}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: identity}}]

--- a/src/test/suite/fixtures/recorded/actions/cloneUpToken.yml
+++ b/src/test/suite/fixtures/recorded/actions/cloneUpToken.yml
@@ -21,11 +21,19 @@ finalState:
     - anchor: {line: 0, character: 8}
       active: {line: 0, character: 8}
   thatMark:
-    - anchor: {line: 0, character: 6}
-      active: {line: 0, character: 11}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 6}
+        end: {line: 0, character: 11}
+      isReversed: false
+      hasExplicitRange: true
   sourceMark:
-    - anchor: {line: 0, character: 12}
-      active: {line: 0, character: 17}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 12}
+        end: {line: 0, character: 17}
+      isReversed: false
+      hasExplicitRange: true
 decorations:
   - name: justAddedBackground
     type: token

--- a/src/test/suite/fixtures/recorded/actions/cloneUpToken2.yml
+++ b/src/test/suite/fixtures/recorded/actions/cloneUpToken2.yml
@@ -21,11 +21,19 @@ finalState:
     - anchor: {line: 0, character: 3}
       active: {line: 0, character: 3}
   thatMark:
-    - anchor: {line: 0, character: 0}
-      active: {line: 0, character: 5}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 0}
+        end: {line: 0, character: 5}
+      isReversed: false
+      hasExplicitRange: true
   sourceMark:
-    - anchor: {line: 0, character: 6}
-      active: {line: 0, character: 11}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 6}
+        end: {line: 0, character: 11}
+      isReversed: false
+      hasExplicitRange: true
 decorations:
   - name: justAddedBackground
     type: token

--- a/src/test/suite/fixtures/recorded/actions/cloneUpToken3.yml
+++ b/src/test/suite/fixtures/recorded/actions/cloneUpToken3.yml
@@ -21,9 +21,17 @@ finalState:
     - anchor: {line: 0, character: 0}
       active: {line: 0, character: 0}
   thatMark:
-    - anchor: {line: 0, character: 0}
-      active: {line: 0, character: 5}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 0}
+        end: {line: 0, character: 5}
+      isReversed: false
+      hasExplicitRange: true
   sourceMark:
-    - anchor: {line: 0, character: 6}
-      active: {line: 0, character: 11}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 6}
+        end: {line: 0, character: 11}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: [{type: containingScope, scopeType: {type: token}}]}]

--- a/src/test/suite/fixtures/recorded/actions/cloneUpToken4.yml
+++ b/src/test/suite/fixtures/recorded/actions/cloneUpToken4.yml
@@ -21,9 +21,17 @@ finalState:
     - anchor: {line: 0, character: 5}
       active: {line: 0, character: 5}
   thatMark:
-    - anchor: {line: 0, character: 0}
-      active: {line: 0, character: 5}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 0}
+        end: {line: 0, character: 5}
+      isReversed: false
+      hasExplicitRange: true
   sourceMark:
-    - anchor: {line: 0, character: 6}
-      active: {line: 0, character: 11}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 6}
+        end: {line: 0, character: 11}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: [{type: containingScope, scopeType: {type: token}}]}]

--- a/src/test/suite/fixtures/recorded/actions/cloneUpToken5.yml
+++ b/src/test/suite/fixtures/recorded/actions/cloneUpToken5.yml
@@ -21,9 +21,17 @@ finalState:
     - anchor: {line: 0, character: 0}
       active: {line: 0, character: 5}
   thatMark:
-    - anchor: {line: 0, character: 0}
-      active: {line: 0, character: 5}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 0}
+        end: {line: 0, character: 5}
+      isReversed: false
+      hasExplicitRange: true
   sourceMark:
-    - anchor: {line: 0, character: 6}
-      active: {line: 0, character: 11}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 6}
+        end: {line: 0, character: 11}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: [{type: containingScope, scopeType: {type: token}}]}]

--- a/src/test/suite/fixtures/recorded/actions/cloneUpVest.yml
+++ b/src/test/suite/fixtures/recorded/actions/cloneUpVest.yml
@@ -23,9 +23,17 @@ finalState:
     - anchor: {line: 0, character: 15}
       active: {line: 0, character: 15}
   thatMark:
-    - anchor: {line: 0, character: 4}
-      active: {line: 0, character: 32}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 4}
+        end: {line: 0, character: 32}
+      isReversed: false
+      hasExplicitRange: true
   sourceMark:
-    - anchor: {line: 1, character: 4}
-      active: {line: 1, character: 32}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 4}
+        end: {line: 1, character: 32}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: v}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: identity}}]

--- a/src/test/suite/fixtures/recorded/actions/cloneVest.yml
+++ b/src/test/suite/fixtures/recorded/actions/cloneVest.yml
@@ -23,9 +23,17 @@ finalState:
     - anchor: {line: 1, character: 15}
       active: {line: 1, character: 15}
   thatMark:
-    - anchor: {line: 1, character: 4}
-      active: {line: 1, character: 32}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 4}
+        end: {line: 1, character: 32}
+      isReversed: false
+      hasExplicitRange: true
   sourceMark:
-    - anchor: {line: 0, character: 4}
-      active: {line: 0, character: 32}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 4}
+        end: {line: 0, character: 32}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: v}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: identity}}]

--- a/src/test/suite/fixtures/recorded/actions/commentVest.yml
+++ b/src/test/suite/fixtures/recorded/actions/commentVest.yml
@@ -25,6 +25,10 @@ finalState:
     - anchor: {line: 0, character: 0}
       active: {line: 0, character: 0}
   thatMark:
-    - anchor: {line: 1, character: 9}
-      active: {line: 1, character: 14}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 9}
+        end: {line: 1, character: 14}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: v}, selectionType: token, position: contents, modifier: {type: identity}, insideOutsideType: inside}]

--- a/src/test/suite/fixtures/recorded/actions/copyVest.yml
+++ b/src/test/suite/fixtures/recorded/actions/copyVest.yml
@@ -27,6 +27,10 @@ finalState:
       active: {line: 0, character: 0}
   clipboard: value
   thatMark:
-    - anchor: {line: 1, character: 6}
-      active: {line: 1, character: 11}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 6}
+        end: {line: 1, character: 11}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: v}, selectionType: token, position: contents, modifier: {type: identity}, insideOutsideType: inside}]

--- a/src/test/suite/fixtures/recorded/actions/curlyRepackRound.yml
+++ b/src/test/suite/fixtures/recorded/actions/curlyRepackRound.yml
@@ -27,13 +27,29 @@ finalState:
     - anchor: {line: 1, character: 5}
       active: {line: 1, character: 5}
   thatMark:
-    - anchor: {line: 0, character: 0}
-      active: {line: 0, character: 9}
-    - anchor: {line: 1, character: 0}
-      active: {line: 1, character: 7}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 0}
+        end: {line: 0, character: 9}
+      isReversed: false
+      hasExplicitRange: true
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 0}
+        end: {line: 1, character: 7}
+      isReversed: false
+      hasExplicitRange: true
   sourceMark:
-    - anchor: {line: 0, character: 0}
-      active: {line: 0, character: 9}
-    - anchor: {line: 1, character: 0}
-      active: {line: 1, character: 7}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 0}
+        end: {line: 0, character: 9}
+      isReversed: false
+      hasExplicitRange: true
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 0}
+        end: {line: 1, character: 7}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: cursor}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: surroundingPair, delimiter: parentheses}}]

--- a/src/test/suite/fixtures/recorded/actions/customHarp.yml
+++ b/src/test/suite/fixtures/recorded/actions/customHarp.yml
@@ -26,6 +26,10 @@ finalState:
     - anchor: {line: 1, character: 0}
       active: {line: 1, character: 0}
   thatMark:
-    - anchor: {line: 0, character: 5}
-      active: {line: 0, character: 10}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 5}
+        end: {line: 0, character: 10}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: h}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: identity}}]

--- a/src/test/suite/fixtures/recorded/actions/cutEveryArgMade.yml
+++ b/src/test/suite/fixtures/recorded/actions/cutEveryArgMade.yml
@@ -22,6 +22,10 @@ finalState:
     - anchor: {line: 0, character: 0}
       active: {line: 0, character: 0}
   thatMark:
-    - anchor: {line: 0, character: 16}
-      active: {line: 0, character: 16}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 16}
+        end: {line: 0, character: 16}
+      isReversed: false
+      hasExplicitRange: false
 fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: m}, selectionType: token, position: contents, insideOutsideType: null, modifier: {type: containingScope, scopeType: argumentOrParameter, includeSiblings: true}, isImplicit: false}]

--- a/src/test/suite/fixtures/recorded/actions/dedentVest.yml
+++ b/src/test/suite/fixtures/recorded/actions/dedentVest.yml
@@ -25,6 +25,10 @@ finalState:
     - anchor: {line: 0, character: 0}
       active: {line: 0, character: 0}
   thatMark:
-    - anchor: {line: 1, character: 6}
-      active: {line: 1, character: 11}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 6}
+        end: {line: 1, character: 11}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: v}, selectionType: token, position: contents, modifier: {type: identity}, insideOutsideType: inside}]

--- a/src/test/suite/fixtures/recorded/actions/defineVest.yml
+++ b/src/test/suite/fixtures/recorded/actions/defineVest.yml
@@ -30,6 +30,10 @@ finalState:
     - anchor: {line: 0, character: 6}
       active: {line: 0, character: 6}
   thatMark:
-    - anchor: {line: 2, character: 12}
-      active: {line: 2, character: 17}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 2, character: 12}
+        end: {line: 2, character: 17}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: v}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: identity}}]

--- a/src/test/suite/fixtures/recorded/actions/drinkArg.yml
+++ b/src/test/suite/fixtures/recorded/actions/drinkArg.yml
@@ -23,6 +23,10 @@ finalState:
     - anchor: {line: 0, character: 33}
       active: {line: 0, character: 33}
   thatMark:
-    - anchor: {line: 0, character: 35}
-      active: {line: 0, character: 46}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 35}
+        end: {line: 0, character: 46}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: [{type: containingScope, scopeType: argumentOrParameter}]}]

--- a/src/test/suite/fixtures/recorded/actions/drinkArg2.yml
+++ b/src/test/suite/fixtures/recorded/actions/drinkArg2.yml
@@ -30,6 +30,10 @@ finalState:
     - anchor: {line: 2, character: 4}
       active: {line: 2, character: 4}
   thatMark:
-    - anchor: {line: 3, character: 4}
-      active: {line: 3, character: 17}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 3, character: 4}
+        end: {line: 3, character: 17}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: [{type: containingScope, scopeType: {type: argumentOrParameter}}]}]

--- a/src/test/suite/fixtures/recorded/actions/drinkArg3.yml
+++ b/src/test/suite/fixtures/recorded/actions/drinkArg3.yml
@@ -30,6 +30,10 @@ finalState:
     - anchor: {line: 2, character: 4}
       active: {line: 2, character: 4}
   thatMark:
-    - anchor: {line: 3, character: 4}
-      active: {line: 3, character: 17}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 3, character: 4}
+        end: {line: 3, character: 17}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: [{type: containingScope, scopeType: {type: argumentOrParameter}}]}]

--- a/src/test/suite/fixtures/recorded/actions/drinkArg4.yml
+++ b/src/test/suite/fixtures/recorded/actions/drinkArg4.yml
@@ -30,6 +30,10 @@ finalState:
     - anchor: {line: 1, character: 4}
       active: {line: 1, character: 4}
   thatMark:
-    - anchor: {line: 2, character: 4}
-      active: {line: 2, character: 16}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 2, character: 4}
+        end: {line: 2, character: 16}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: [{type: containingScope, scopeType: {type: argumentOrParameter}}]}]

--- a/src/test/suite/fixtures/recorded/actions/drinkArg5.yml
+++ b/src/test/suite/fixtures/recorded/actions/drinkArg5.yml
@@ -32,6 +32,10 @@ finalState:
     - anchor: {line: 2, character: 4}
       active: {line: 2, character: 4}
   thatMark:
-    - anchor: {line: 3, character: 4}
-      active: {line: 3, character: 17}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 3, character: 4}
+        end: {line: 3, character: 17}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: [{type: containingScope, scopeType: {type: argumentOrParameter}}]}]

--- a/src/test/suite/fixtures/recorded/actions/drinkBlock.yml
+++ b/src/test/suite/fixtures/recorded/actions/drinkBlock.yml
@@ -25,6 +25,10 @@ finalState:
     - anchor: {line: 0, character: 0}
       active: {line: 0, character: 0}
   thatMark:
-    - anchor: {line: 2, character: 0}
-      active: {line: 2, character: 61}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 2, character: 0}
+        end: {line: 2, character: 61}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: [{type: containingScope, scopeType: paragraph}]}]

--- a/src/test/suite/fixtures/recorded/actions/drinkDrumAndSpunAndTrap.yml
+++ b/src/test/suite/fixtures/recorded/actions/drinkDrumAndSpunAndTrap.yml
@@ -44,8 +44,16 @@ finalState:
     - anchor: {line: 3, character: 0}
       active: {line: 3, character: 0}
   thatMark:
-    - anchor: {line: 1, character: 6}
-      active: {line: 1, character: 11}
-    - anchor: {line: 4, character: 0}
-      active: {line: 4, character: 7}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 6}
+        end: {line: 1, character: 11}
+      isReversed: false
+      hasExplicitRange: true
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 4, character: 0}
+        end: {line: 4, character: 7}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: list, elements: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: d}, modifiers: []}, {type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: s}, modifiers: []}, {type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: t}, modifiers: []}]}]

--- a/src/test/suite/fixtures/recorded/actions/drinkHarpAndLookAndTrap.yml
+++ b/src/test/suite/fixtures/recorded/actions/drinkHarpAndLookAndTrap.yml
@@ -37,6 +37,10 @@ finalState:
     - anchor: {line: 0, character: 0}
       active: {line: 0, character: 0}
   thatMark:
-    - anchor: {line: 1, character: 0}
-      active: {line: 1, character: 5}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 0}
+        end: {line: 1, character: 5}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: list, elements: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: h}, modifiers: []}, {type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: l}, modifiers: []}, {type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: t}, modifiers: []}]}]

--- a/src/test/suite/fixtures/recorded/actions/drinkItem.yml
+++ b/src/test/suite/fixtures/recorded/actions/drinkItem.yml
@@ -32,6 +32,10 @@ finalState:
     - anchor: {line: 3, character: 4}
       active: {line: 3, character: 4}
   thatMark:
-    - anchor: {line: 4, character: 4}
-      active: {line: 4, character: 5}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 4, character: 4}
+        end: {line: 4, character: 5}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: [{type: containingScope, scopeType: {type: collectionItem}}]}]

--- a/src/test/suite/fixtures/recorded/actions/drinkItem2.yml
+++ b/src/test/suite/fixtures/recorded/actions/drinkItem2.yml
@@ -32,6 +32,10 @@ finalState:
     - anchor: {line: 3, character: 4}
       active: {line: 3, character: 4}
   thatMark:
-    - anchor: {line: 4, character: 4}
-      active: {line: 4, character: 5}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 4, character: 4}
+        end: {line: 4, character: 5}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: [{type: containingScope, scopeType: {type: collectionItem}}]}]

--- a/src/test/suite/fixtures/recorded/actions/drinkItem3.yml
+++ b/src/test/suite/fixtures/recorded/actions/drinkItem3.yml
@@ -32,6 +32,10 @@ finalState:
     - anchor: {line: 1, character: 4}
       active: {line: 1, character: 4}
   thatMark:
-    - anchor: {line: 2, character: 4}
-      active: {line: 2, character: 5}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 2, character: 4}
+        end: {line: 2, character: 5}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: [{type: containingScope, scopeType: {type: collectionItem}}]}]

--- a/src/test/suite/fixtures/recorded/actions/drinkLine.yml
+++ b/src/test/suite/fixtures/recorded/actions/drinkLine.yml
@@ -28,6 +28,10 @@ finalState:
     - anchor: {line: 1, character: 4}
       active: {line: 1, character: 4}
   thatMark:
-    - anchor: {line: 2, character: 4}
-      active: {line: 2, character: 18}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 2, character: 4}
+        end: {line: 2, character: 18}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: [{type: containingScope, scopeType: {type: line}}]}]

--- a/src/test/suite/fixtures/recorded/actions/drinkThis.yml
+++ b/src/test/suite/fixtures/recorded/actions/drinkThis.yml
@@ -25,6 +25,10 @@ finalState:
     - anchor: {line: 0, character: 0}
       active: {line: 0, character: 0}
   thatMark:
-    - anchor: {line: 1, character: 2}
-      active: {line: 1, character: 2}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 2}
+        end: {line: 1, character: 2}
+      isReversed: false
+      hasExplicitRange: false
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: []}]

--- a/src/test/suite/fixtures/recorded/actions/drinkVest.yml
+++ b/src/test/suite/fixtures/recorded/actions/drinkVest.yml
@@ -26,6 +26,10 @@ finalState:
     - anchor: {line: 1, character: 0}
       active: {line: 1, character: 0}
   thatMark:
-    - anchor: {line: 2, character: 6}
-      active: {line: 2, character: 11}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 2, character: 6}
+        end: {line: 2, character: 11}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: v}, selectionType: token, position: contents, modifier: {type: identity}, insideOutsideType: outside}]

--- a/src/test/suite/fixtures/recorded/actions/drinkVest2.yml
+++ b/src/test/suite/fixtures/recorded/actions/drinkVest2.yml
@@ -27,6 +27,10 @@ finalState:
     - anchor: {line: 1, character: 4}
       active: {line: 1, character: 4}
   thatMark:
-    - anchor: {line: 2, character: 10}
-      active: {line: 2, character: 15}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 2, character: 10}
+        end: {line: 2, character: 15}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: v}, modifiers: []}]

--- a/src/test/suite/fixtures/recorded/actions/findVest.yml
+++ b/src/test/suite/fixtures/recorded/actions/findVest.yml
@@ -27,7 +27,11 @@ finalState:
     - anchor: {line: 0, character: 0}
       active: {line: 0, character: 0}
   thatMark:
-    - anchor: {line: 1, character: 6}
-      active: {line: 1, character: 11}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 6}
+        end: {line: 1, character: 11}
+      isReversed: false
+      hasExplicitRange: true
 returnValue: [value]
 fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: v}, selectionType: token, position: contents, modifier: {type: identity}, insideOutsideType: inside}]

--- a/src/test/suite/fixtures/recorded/actions/giveAfterDot.yml
+++ b/src/test/suite/fixtures/recorded/actions/giveAfterDot.yml
@@ -28,6 +28,10 @@ finalState:
     - anchor: {line: 0, character: 3}
       active: {line: 0, character: 3}
   thatMark:
-    - anchor: {line: 0, character: 4}
-      active: {line: 0, character: 4}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 4}
+        end: {line: 0, character: 4}
+      isReversed: false
+      hasExplicitRange: false
 fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: .}, selectionType: token, position: after, insideOutsideType: inside, modifier: {type: identity}}]

--- a/src/test/suite/fixtures/recorded/actions/giveAirAndBang.yml
+++ b/src/test/suite/fixtures/recorded/actions/giveAirAndBang.yml
@@ -34,8 +34,16 @@ finalState:
     - anchor: {line: 0, character: 0}
       active: {line: 0, character: 1}
   thatMark:
-    - anchor: {line: 0, character: 1}
-      active: {line: 0, character: 2}
-    - anchor: {line: 0, character: 2}
-      active: {line: 0, character: 3}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 1}
+        end: {line: 0, character: 2}
+      isReversed: false
+      hasExplicitRange: true
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 2}
+        end: {line: 0, character: 3}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: list, elements: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: a}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: identity}}, {type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: '!'}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: identity}}]}]

--- a/src/test/suite/fixtures/recorded/actions/giveBat.yml
+++ b/src/test/suite/fixtures/recorded/actions/giveBat.yml
@@ -23,6 +23,10 @@ finalState:
     - anchor: {line: 0, character: 0}
       active: {line: 0, character: 1}
   thatMark:
-    - anchor: {line: 0, character: 2}
-      active: {line: 0, character: 3}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 2}
+        end: {line: 0, character: 3}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: b}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: identity}}]

--- a/src/test/suite/fixtures/recorded/actions/giveBat2.yml
+++ b/src/test/suite/fixtures/recorded/actions/giveBat2.yml
@@ -23,6 +23,10 @@ finalState:
     - anchor: {line: 0, character: 1}
       active: {line: 0, character: 1}
   thatMark:
-    - anchor: {line: 0, character: 2}
-      active: {line: 0, character: 3}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 2}
+        end: {line: 0, character: 3}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: b}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: identity}}]

--- a/src/test/suite/fixtures/recorded/actions/giveBeforeDot.yml
+++ b/src/test/suite/fixtures/recorded/actions/giveBeforeDot.yml
@@ -28,6 +28,10 @@ finalState:
     - anchor: {line: 0, character: 4}
       active: {line: 0, character: 4}
   thatMark:
-    - anchor: {line: 0, character: 3}
-      active: {line: 0, character: 3}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 3}
+        end: {line: 0, character: 3}
+      isReversed: false
+      hasExplicitRange: false
 fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: .}, selectionType: token, position: before, insideOutsideType: inside, modifier: {type: identity}}]

--- a/src/test/suite/fixtures/recorded/actions/giveBlueQuote.yml
+++ b/src/test/suite/fixtures/recorded/actions/giveBlueQuote.yml
@@ -29,6 +29,10 @@ finalState:
     - anchor: {line: 0, character: 1}
       active: {line: 0, character: 6}
   thatMark:
-    - anchor: {line: 0, character: 6}
-      active: {line: 0, character: 7}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 6}
+        end: {line: 0, character: 7}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: blue, character: '"'}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: identity}}]

--- a/src/test/suite/fixtures/recorded/actions/giveBlueQuoteAndQuote.yml
+++ b/src/test/suite/fixtures/recorded/actions/giveBlueQuoteAndQuote.yml
@@ -34,8 +34,16 @@ finalState:
     - anchor: {line: 0, character: 1}
       active: {line: 0, character: 6}
   thatMark:
-    - anchor: {line: 0, character: 6}
-      active: {line: 0, character: 7}
-    - anchor: {line: 0, character: 0}
-      active: {line: 0, character: 1}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 6}
+        end: {line: 0, character: 7}
+      isReversed: false
+      hasExplicitRange: true
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 0}
+        end: {line: 0, character: 1}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: list, elements: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: blue, character: '"'}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: identity}}, {type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: '"'}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: identity}}]}]

--- a/src/test/suite/fixtures/recorded/actions/giveCap.yml
+++ b/src/test/suite/fixtures/recorded/actions/giveCap.yml
@@ -23,6 +23,10 @@ finalState:
     - anchor: {line: 0, character: 0}
       active: {line: 0, character: 1}
   thatMark:
-    - anchor: {line: 0, character: 4}
-      active: {line: 0, character: 5}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 4}
+        end: {line: 0, character: 5}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: c}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: identity}}]

--- a/src/test/suite/fixtures/recorded/actions/giveDot.yml
+++ b/src/test/suite/fixtures/recorded/actions/giveDot.yml
@@ -23,6 +23,10 @@ finalState:
     - anchor: {line: 0, character: 1}
       active: {line: 0, character: 1}
   thatMark:
-    - anchor: {line: 0, character: 3}
-      active: {line: 0, character: 4}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 3}
+        end: {line: 0, character: 4}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: .}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: identity}}]

--- a/src/test/suite/fixtures/recorded/actions/giveDot2.yml
+++ b/src/test/suite/fixtures/recorded/actions/giveDot2.yml
@@ -25,6 +25,10 @@ finalState:
     - anchor: {line: 0, character: 0}
       active: {line: 0, character: 1}
   thatMark:
-    - anchor: {line: 0, character: 3}
-      active: {line: 0, character: 4}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 3}
+        end: {line: 0, character: 4}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: .}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: identity}}]

--- a/src/test/suite/fixtures/recorded/actions/giveDrum.yml
+++ b/src/test/suite/fixtures/recorded/actions/giveDrum.yml
@@ -23,6 +23,10 @@ finalState:
     - anchor: {line: 0, character: 0}
       active: {line: 0, character: 1}
   thatMark:
-    - anchor: {line: 0, character: 6}
-      active: {line: 0, character: 7}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 6}
+        end: {line: 0, character: 7}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: d}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: identity}}]

--- a/src/test/suite/fixtures/recorded/actions/giveEqualsPastColon.yml
+++ b/src/test/suite/fixtures/recorded/actions/giveEqualsPastColon.yml
@@ -43,6 +43,10 @@ finalState:
     - anchor: {line: 0, character: 24}
       active: {line: 0, character: 29}
   thatMark:
-    - anchor: {line: 0, character: 22}
-      active: {line: 0, character: 12}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 12}
+        end: {line: 0, character: 22}
+      isReversed: true
+      hasExplicitRange: true
 fullTargets: [{type: range, excludeAnchor: false, excludeActive: false, anchor: {type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: '='}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: identity}}, active: {type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: ':'}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: identity}}}]

--- a/src/test/suite/fixtures/recorded/actions/giveHarp.yml
+++ b/src/test/suite/fixtures/recorded/actions/giveHarp.yml
@@ -29,6 +29,10 @@ finalState:
     - anchor: {line: 0, character: 6}
       active: {line: 0, character: 7}
   thatMark:
-    - anchor: {line: 0, character: 1}
-      active: {line: 0, character: 6}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 1}
+        end: {line: 0, character: 6}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: h}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: identity}}]

--- a/src/test/suite/fixtures/recorded/actions/giveHarpAndWhale.yml
+++ b/src/test/suite/fixtures/recorded/actions/giveHarpAndWhale.yml
@@ -30,8 +30,16 @@ finalState:
     - anchor: {line: 0, character: 5}
       active: {line: 0, character: 5}
   thatMark:
-    - anchor: {line: 0, character: 0}
-      active: {line: 0, character: 5}
-    - anchor: {line: 0, character: 6}
-      active: {line: 0, character: 11}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 0}
+        end: {line: 0, character: 5}
+      isReversed: false
+      hasExplicitRange: true
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 6}
+        end: {line: 0, character: 11}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: list, elements: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: h}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: identity}}, {type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: w}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: identity}}]}]

--- a/src/test/suite/fixtures/recorded/actions/giveQuote.yml
+++ b/src/test/suite/fixtures/recorded/actions/giveQuote.yml
@@ -29,6 +29,10 @@ finalState:
     - anchor: {line: 0, character: 6}
       active: {line: 0, character: 7}
   thatMark:
-    - anchor: {line: 0, character: 0}
-      active: {line: 0, character: 1}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 0}
+        end: {line: 0, character: 1}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: '"'}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: identity}}]

--- a/src/test/suite/fixtures/recorded/actions/giveQuoteAndAir.yml
+++ b/src/test/suite/fixtures/recorded/actions/giveQuoteAndAir.yml
@@ -34,8 +34,16 @@ finalState:
     - anchor: {line: 0, character: 2}
       active: {line: 0, character: 3}
   thatMark:
-    - anchor: {line: 0, character: 0}
-      active: {line: 0, character: 1}
-    - anchor: {line: 0, character: 1}
-      active: {line: 0, character: 2}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 0}
+        end: {line: 0, character: 1}
+      isReversed: false
+      hasExplicitRange: true
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 1}
+        end: {line: 0, character: 2}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: list, elements: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: '"'}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: identity}}, {type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: a}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: identity}}]}]

--- a/src/test/suite/fixtures/recorded/actions/giveQuoteAndBang.yml
+++ b/src/test/suite/fixtures/recorded/actions/giveQuoteAndBang.yml
@@ -34,8 +34,16 @@ finalState:
     - anchor: {line: 0, character: 1}
       active: {line: 0, character: 2}
   thatMark:
-    - anchor: {line: 0, character: 0}
-      active: {line: 0, character: 1}
-    - anchor: {line: 0, character: 2}
-      active: {line: 0, character: 3}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 0}
+        end: {line: 0, character: 1}
+      isReversed: false
+      hasExplicitRange: true
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 2}
+        end: {line: 0, character: 3}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: list, elements: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: '"'}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: identity}}, {type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: '!'}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: identity}}]}]

--- a/src/test/suite/fixtures/recorded/actions/giveVestAndHarp.yml
+++ b/src/test/suite/fixtures/recorded/actions/giveVestAndHarp.yml
@@ -38,8 +38,16 @@ finalState:
     - anchor: {line: 0, character: 14}
       active: {line: 0, character: 20}
   thatMark:
-    - anchor: {line: 0, character: 6}
-      active: {line: 0, character: 12}
-    - anchor: {line: 0, character: 24}
-      active: {line: 0, character: 29}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 6}
+        end: {line: 0, character: 12}
+      isReversed: false
+      hasExplicitRange: true
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 24}
+        end: {line: 0, character: 29}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: list, elements: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: v}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: identity}}, {type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: h}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: identity}}]}]

--- a/src/test/suite/fixtures/recorded/actions/indentVest.yml
+++ b/src/test/suite/fixtures/recorded/actions/indentVest.yml
@@ -25,6 +25,10 @@ finalState:
     - anchor: {line: 0, character: 0}
       active: {line: 0, character: 0}
   thatMark:
-    - anchor: {line: 1, character: 10}
-      active: {line: 1, character: 15}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 10}
+        end: {line: 1, character: 15}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: v}, selectionType: token, position: contents, modifier: {type: identity}, insideOutsideType: inside}]

--- a/src/test/suite/fixtures/recorded/actions/insertEmptyLines/dropThis.yml
+++ b/src/test/suite/fixtures/recorded/actions/insertEmptyLines/dropThis.yml
@@ -20,8 +20,12 @@ finalState:
     - anchor: {line: 1, character: 0}
       active: {line: 1, character: 0}
   thatMark:
-    - anchor: {line: 1, character: 0}
-      active: {line: 1, character: 0}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 0}
+        end: {line: 1, character: 0}
+      isReversed: false
+      hasExplicitRange: false
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: []}]
 decorations:
   - name: justAddedBackground

--- a/src/test/suite/fixtures/recorded/actions/insertEmptyLines/dropThis10.yml
+++ b/src/test/suite/fixtures/recorded/actions/insertEmptyLines/dropThis10.yml
@@ -24,8 +24,12 @@ finalState:
     - anchor: {line: 2, character: 0}
       active: {line: 2, character: 0}
   thatMark:
-    - anchor: {line: 2, character: 0}
-      active: {line: 2, character: 0}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 2, character: 0}
+        end: {line: 2, character: 0}
+      isReversed: false
+      hasExplicitRange: false
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: []}]
 decorations:
   - name: justAddedBackground

--- a/src/test/suite/fixtures/recorded/actions/insertEmptyLines/dropThis11.yml
+++ b/src/test/suite/fixtures/recorded/actions/insertEmptyLines/dropThis11.yml
@@ -24,8 +24,12 @@ finalState:
     - anchor: {line: 2, character: 0}
       active: {line: 2, character: 0}
   thatMark:
-    - anchor: {line: 2, character: 0}
-      active: {line: 2, character: 0}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 2, character: 0}
+        end: {line: 2, character: 0}
+      isReversed: false
+      hasExplicitRange: false
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: []}]
 decorations:
   - name: justAddedBackground

--- a/src/test/suite/fixtures/recorded/actions/insertEmptyLines/dropThis12.yml
+++ b/src/test/suite/fixtures/recorded/actions/insertEmptyLines/dropThis12.yml
@@ -24,8 +24,12 @@ finalState:
     - anchor: {line: 2, character: 0}
       active: {line: 2, character: 0}
   thatMark:
-    - anchor: {line: 2, character: 0}
-      active: {line: 2, character: 0}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 2, character: 0}
+        end: {line: 2, character: 0}
+      isReversed: false
+      hasExplicitRange: false
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: []}]
 decorations:
   - name: justAddedBackground

--- a/src/test/suite/fixtures/recorded/actions/insertEmptyLines/dropThis2.yml
+++ b/src/test/suite/fixtures/recorded/actions/insertEmptyLines/dropThis2.yml
@@ -21,8 +21,12 @@ finalState:
     - anchor: {line: 1, character: 5}
       active: {line: 1, character: 5}
   thatMark:
-    - anchor: {line: 1, character: 5}
-      active: {line: 1, character: 5}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 5}
+        end: {line: 1, character: 5}
+      isReversed: false
+      hasExplicitRange: false
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: []}]
 decorations:
   - name: justAddedBackground

--- a/src/test/suite/fixtures/recorded/actions/insertEmptyLines/dropThis3.yml
+++ b/src/test/suite/fixtures/recorded/actions/insertEmptyLines/dropThis3.yml
@@ -21,8 +21,12 @@ finalState:
     - anchor: {line: 1, character: 0}
       active: {line: 1, character: 0}
   thatMark:
-    - anchor: {line: 1, character: 0}
-      active: {line: 1, character: 0}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 0}
+        end: {line: 1, character: 0}
+      isReversed: false
+      hasExplicitRange: false
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: []}]
 decorations:
   - name: justAddedBackground

--- a/src/test/suite/fixtures/recorded/actions/insertEmptyLines/dropThis4.yml
+++ b/src/test/suite/fixtures/recorded/actions/insertEmptyLines/dropThis4.yml
@@ -21,8 +21,12 @@ finalState:
     - anchor: {line: 1, character: 4}
       active: {line: 1, character: 4}
   thatMark:
-    - anchor: {line: 1, character: 4}
-      active: {line: 1, character: 4}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 4}
+        end: {line: 1, character: 4}
+      isReversed: false
+      hasExplicitRange: false
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: []}]
 decorations:
   - name: justAddedBackground

--- a/src/test/suite/fixtures/recorded/actions/insertEmptyLines/dropThis5.yml
+++ b/src/test/suite/fixtures/recorded/actions/insertEmptyLines/dropThis5.yml
@@ -21,8 +21,12 @@ finalState:
     - anchor: {line: 1, character: 0}
       active: {line: 1, character: 0}
   thatMark:
-    - anchor: {line: 1, character: 0}
-      active: {line: 1, character: 0}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 0}
+        end: {line: 1, character: 0}
+      isReversed: false
+      hasExplicitRange: false
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: []}]
 decorations:
   - name: justAddedBackground

--- a/src/test/suite/fixtures/recorded/actions/insertEmptyLines/dropThis6.yml
+++ b/src/test/suite/fixtures/recorded/actions/insertEmptyLines/dropThis6.yml
@@ -21,8 +21,12 @@ finalState:
     - anchor: {line: 1, character: 9}
       active: {line: 1, character: 9}
   thatMark:
-    - anchor: {line: 1, character: 9}
-      active: {line: 1, character: 9}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 9}
+        end: {line: 1, character: 9}
+      isReversed: false
+      hasExplicitRange: false
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: []}]
 decorations:
   - name: justAddedBackground

--- a/src/test/suite/fixtures/recorded/actions/insertEmptyLines/dropThis7.yml
+++ b/src/test/suite/fixtures/recorded/actions/insertEmptyLines/dropThis7.yml
@@ -21,8 +21,12 @@ finalState:
     - anchor: {line: 1, character: 4}
       active: {line: 1, character: 4}
   thatMark:
-    - anchor: {line: 1, character: 4}
-      active: {line: 1, character: 4}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 4}
+        end: {line: 1, character: 4}
+      isReversed: false
+      hasExplicitRange: false
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: []}]
 decorations:
   - name: justAddedBackground

--- a/src/test/suite/fixtures/recorded/actions/insertEmptyLines/dropThis8.yml
+++ b/src/test/suite/fixtures/recorded/actions/insertEmptyLines/dropThis8.yml
@@ -21,8 +21,12 @@ finalState:
     - anchor: {line: 1, character: 0}
       active: {line: 1, character: 0}
   thatMark:
-    - anchor: {line: 1, character: 0}
-      active: {line: 1, character: 0}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 0}
+        end: {line: 1, character: 0}
+      isReversed: false
+      hasExplicitRange: false
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: []}]
 decorations:
   - name: justAddedBackground

--- a/src/test/suite/fixtures/recorded/actions/insertEmptyLines/dropThis9.yml
+++ b/src/test/suite/fixtures/recorded/actions/insertEmptyLines/dropThis9.yml
@@ -24,8 +24,12 @@ finalState:
     - anchor: {line: 2, character: 5}
       active: {line: 2, character: 5}
   thatMark:
-    - anchor: {line: 2, character: 5}
-      active: {line: 2, character: 5}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 2, character: 5}
+        end: {line: 2, character: 5}
+      isReversed: false
+      hasExplicitRange: false
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: []}]
 decorations:
   - name: justAddedBackground

--- a/src/test/suite/fixtures/recorded/actions/insertEmptyLines/dropVest.yml
+++ b/src/test/suite/fixtures/recorded/actions/insertEmptyLines/dropVest.yml
@@ -26,6 +26,10 @@ finalState:
     - anchor: {line: 0, character: 0}
       active: {line: 0, character: 0}
   thatMark:
-    - anchor: {line: 2, character: 6}
-      active: {line: 2, character: 11}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 2, character: 6}
+        end: {line: 2, character: 11}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: v}, selectionType: token, position: contents, modifier: {type: identity}, insideOutsideType: inside}]

--- a/src/test/suite/fixtures/recorded/actions/insertEmptyLines/dropVest2.yml
+++ b/src/test/suite/fixtures/recorded/actions/insertEmptyLines/dropVest2.yml
@@ -27,6 +27,10 @@ finalState:
     - anchor: {line: 0, character: 0}
       active: {line: 0, character: 0}
   thatMark:
-    - anchor: {line: 2, character: 10}
-      active: {line: 2, character: 15}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 2, character: 10}
+        end: {line: 2, character: 15}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: v}, modifiers: []}]

--- a/src/test/suite/fixtures/recorded/actions/insertEmptyLines/floatThis.yml
+++ b/src/test/suite/fixtures/recorded/actions/insertEmptyLines/floatThis.yml
@@ -20,8 +20,12 @@ finalState:
     - anchor: {line: 1, character: 0}
       active: {line: 1, character: 0}
   thatMark:
-    - anchor: {line: 1, character: 0}
-      active: {line: 1, character: 0}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 0}
+        end: {line: 1, character: 0}
+      isReversed: false
+      hasExplicitRange: false
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: []}]
 decorations:
   - name: justAddedBackground

--- a/src/test/suite/fixtures/recorded/actions/insertEmptyLines/floatThis10.yml
+++ b/src/test/suite/fixtures/recorded/actions/insertEmptyLines/floatThis10.yml
@@ -23,8 +23,12 @@ finalState:
     - anchor: {line: 2, character: 0}
       active: {line: 2, character: 0}
   thatMark:
-    - anchor: {line: 2, character: 0}
-      active: {line: 2, character: 0}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 2, character: 0}
+        end: {line: 2, character: 0}
+      isReversed: false
+      hasExplicitRange: false
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: []}]
 decorations:
   - name: justAddedBackground

--- a/src/test/suite/fixtures/recorded/actions/insertEmptyLines/floatThis11.yml
+++ b/src/test/suite/fixtures/recorded/actions/insertEmptyLines/floatThis11.yml
@@ -22,8 +22,12 @@ finalState:
     - anchor: {line: 0, character: 5}
       active: {line: 0, character: 5}
   thatMark:
-    - anchor: {line: 0, character: 5}
-      active: {line: 0, character: 5}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 5}
+        end: {line: 0, character: 5}
+      isReversed: false
+      hasExplicitRange: false
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: []}]
 decorations:
   - name: justAddedBackground

--- a/src/test/suite/fixtures/recorded/actions/insertEmptyLines/floatThis12.yml
+++ b/src/test/suite/fixtures/recorded/actions/insertEmptyLines/floatThis12.yml
@@ -22,8 +22,12 @@ finalState:
     - anchor: {line: 0, character: 4}
       active: {line: 0, character: 4}
   thatMark:
-    - anchor: {line: 0, character: 4}
-      active: {line: 0, character: 4}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 4}
+        end: {line: 0, character: 4}
+      isReversed: false
+      hasExplicitRange: false
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: []}]
 decorations:
   - name: justAddedBackground

--- a/src/test/suite/fixtures/recorded/actions/insertEmptyLines/floatThis13.yml
+++ b/src/test/suite/fixtures/recorded/actions/insertEmptyLines/floatThis13.yml
@@ -22,8 +22,12 @@ finalState:
     - anchor: {line: 0, character: 9}
       active: {line: 0, character: 9}
   thatMark:
-    - anchor: {line: 0, character: 9}
-      active: {line: 0, character: 9}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 9}
+        end: {line: 0, character: 9}
+      isReversed: false
+      hasExplicitRange: false
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: []}]
 decorations:
   - name: justAddedBackground

--- a/src/test/suite/fixtures/recorded/actions/insertEmptyLines/floatThis2.yml
+++ b/src/test/suite/fixtures/recorded/actions/insertEmptyLines/floatThis2.yml
@@ -20,8 +20,12 @@ finalState:
     - anchor: {line: 1, character: 0}
       active: {line: 1, character: 0}
   thatMark:
-    - anchor: {line: 1, character: 0}
-      active: {line: 1, character: 0}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 0}
+        end: {line: 1, character: 0}
+      isReversed: false
+      hasExplicitRange: false
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: []}]
 decorations:
   - name: justAddedBackground

--- a/src/test/suite/fixtures/recorded/actions/insertEmptyLines/floatThis3.yml
+++ b/src/test/suite/fixtures/recorded/actions/insertEmptyLines/floatThis3.yml
@@ -20,8 +20,12 @@ finalState:
     - anchor: {line: 1, character: 0}
       active: {line: 1, character: 0}
   thatMark:
-    - anchor: {line: 1, character: 0}
-      active: {line: 1, character: 0}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 0}
+        end: {line: 1, character: 0}
+      isReversed: false
+      hasExplicitRange: false
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: []}]
 decorations:
   - name: justAddedBackground

--- a/src/test/suite/fixtures/recorded/actions/insertEmptyLines/floatThis4.yml
+++ b/src/test/suite/fixtures/recorded/actions/insertEmptyLines/floatThis4.yml
@@ -20,8 +20,12 @@ finalState:
     - anchor: {line: 1, character: 0}
       active: {line: 1, character: 0}
   thatMark:
-    - anchor: {line: 1, character: 0}
-      active: {line: 1, character: 0}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 0}
+        end: {line: 1, character: 0}
+      isReversed: false
+      hasExplicitRange: false
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: []}]
 decorations:
   - name: justAddedBackground

--- a/src/test/suite/fixtures/recorded/actions/insertEmptyLines/floatThis5.yml
+++ b/src/test/suite/fixtures/recorded/actions/insertEmptyLines/floatThis5.yml
@@ -23,8 +23,12 @@ finalState:
     - anchor: {line: 2, character: 0}
       active: {line: 2, character: 0}
   thatMark:
-    - anchor: {line: 2, character: 0}
-      active: {line: 2, character: 0}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 2, character: 0}
+        end: {line: 2, character: 0}
+      isReversed: false
+      hasExplicitRange: false
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: []}]
 decorations:
   - name: justAddedBackground

--- a/src/test/suite/fixtures/recorded/actions/insertEmptyLines/floatThis6.yml
+++ b/src/test/suite/fixtures/recorded/actions/insertEmptyLines/floatThis6.yml
@@ -23,8 +23,12 @@ finalState:
     - anchor: {line: 2, character: 0}
       active: {line: 2, character: 0}
   thatMark:
-    - anchor: {line: 2, character: 0}
-      active: {line: 2, character: 0}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 2, character: 0}
+        end: {line: 2, character: 0}
+      isReversed: false
+      hasExplicitRange: false
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: []}]
 decorations:
   - name: justAddedBackground

--- a/src/test/suite/fixtures/recorded/actions/insertEmptyLines/floatThis7.yml
+++ b/src/test/suite/fixtures/recorded/actions/insertEmptyLines/floatThis7.yml
@@ -22,8 +22,12 @@ finalState:
     - anchor: {line: 2, character: 0}
       active: {line: 2, character: 0}
   thatMark:
-    - anchor: {line: 2, character: 0}
-      active: {line: 2, character: 0}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 2, character: 0}
+        end: {line: 2, character: 0}
+      isReversed: false
+      hasExplicitRange: false
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: []}]
 decorations:
   - name: justAddedBackground

--- a/src/test/suite/fixtures/recorded/actions/insertEmptyLines/floatThis8.yml
+++ b/src/test/suite/fixtures/recorded/actions/insertEmptyLines/floatThis8.yml
@@ -22,8 +22,12 @@ finalState:
     - anchor: {line: 2, character: 0}
       active: {line: 2, character: 0}
   thatMark:
-    - anchor: {line: 2, character: 0}
-      active: {line: 2, character: 0}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 2, character: 0}
+        end: {line: 2, character: 0}
+      isReversed: false
+      hasExplicitRange: false
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: []}]
 decorations:
   - name: justAddedBackground

--- a/src/test/suite/fixtures/recorded/actions/insertEmptyLines/floatThis9.yml
+++ b/src/test/suite/fixtures/recorded/actions/insertEmptyLines/floatThis9.yml
@@ -23,8 +23,12 @@ finalState:
     - anchor: {line: 2, character: 0}
       active: {line: 2, character: 0}
   thatMark:
-    - anchor: {line: 2, character: 0}
-      active: {line: 2, character: 0}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 2, character: 0}
+        end: {line: 2, character: 0}
+      isReversed: false
+      hasExplicitRange: false
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: []}]
 decorations:
   - name: justAddedBackground

--- a/src/test/suite/fixtures/recorded/actions/insertEmptyLines/floatVest.yml
+++ b/src/test/suite/fixtures/recorded/actions/insertEmptyLines/floatVest.yml
@@ -26,8 +26,12 @@ finalState:
     - anchor: {line: 0, character: 0}
       active: {line: 0, character: 0}
   thatMark:
-    - anchor: {line: 1, character: 6}
-      active: {line: 1, character: 11}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 6}
+        end: {line: 1, character: 11}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: v}, selectionType: token, position: contents, modifier: {type: identity}, insideOutsideType: inside}]
 decorations:
   - name: justAddedBackground

--- a/src/test/suite/fixtures/recorded/actions/insertEmptyLines/floatVest2.yml
+++ b/src/test/suite/fixtures/recorded/actions/insertEmptyLines/floatVest2.yml
@@ -27,8 +27,12 @@ finalState:
     - anchor: {line: 0, character: 0}
       active: {line: 0, character: 0}
   thatMark:
-    - anchor: {line: 1, character: 10}
-      active: {line: 1, character: 15}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 10}
+        end: {line: 1, character: 15}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: v}, modifiers: []}]
 decorations:
   - name: justAddedBackground

--- a/src/test/suite/fixtures/recorded/actions/insertEmptyLines/puffThis.yml
+++ b/src/test/suite/fixtures/recorded/actions/insertEmptyLines/puffThis.yml
@@ -21,8 +21,12 @@ finalState:
     - anchor: {line: 2, character: 0}
       active: {line: 2, character: 0}
   thatMark:
-    - anchor: {line: 2, character: 0}
-      active: {line: 2, character: 0}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 2, character: 0}
+        end: {line: 2, character: 0}
+      isReversed: false
+      hasExplicitRange: false
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: []}]
 decorations:
   - name: justAddedBackground

--- a/src/test/suite/fixtures/recorded/actions/insertEmptyLines/puffThis10.yml
+++ b/src/test/suite/fixtures/recorded/actions/insertEmptyLines/puffThis10.yml
@@ -24,8 +24,12 @@ finalState:
     - anchor: {line: 3, character: 0}
       active: {line: 3, character: 0}
   thatMark:
-    - anchor: {line: 3, character: 0}
-      active: {line: 3, character: 0}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 3, character: 0}
+        end: {line: 3, character: 0}
+      isReversed: false
+      hasExplicitRange: false
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: []}]
 decorations:
   - name: justAddedBackground

--- a/src/test/suite/fixtures/recorded/actions/insertEmptyLines/puffThis11.yml
+++ b/src/test/suite/fixtures/recorded/actions/insertEmptyLines/puffThis11.yml
@@ -24,8 +24,12 @@ finalState:
     - anchor: {line: 3, character: 0}
       active: {line: 3, character: 0}
   thatMark:
-    - anchor: {line: 3, character: 0}
-      active: {line: 3, character: 0}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 3, character: 0}
+        end: {line: 3, character: 0}
+      isReversed: false
+      hasExplicitRange: false
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: []}]
 decorations:
   - name: justAddedBackground

--- a/src/test/suite/fixtures/recorded/actions/insertEmptyLines/puffThis12.yml
+++ b/src/test/suite/fixtures/recorded/actions/insertEmptyLines/puffThis12.yml
@@ -23,8 +23,12 @@ finalState:
     - anchor: {line: 1, character: 5}
       active: {line: 1, character: 5}
   thatMark:
-    - anchor: {line: 1, character: 5}
-      active: {line: 1, character: 5}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 5}
+        end: {line: 1, character: 5}
+      isReversed: false
+      hasExplicitRange: false
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: []}]
 decorations:
   - name: justAddedBackground

--- a/src/test/suite/fixtures/recorded/actions/insertEmptyLines/puffThis13.yml
+++ b/src/test/suite/fixtures/recorded/actions/insertEmptyLines/puffThis13.yml
@@ -23,8 +23,12 @@ finalState:
     - anchor: {line: 1, character: 0}
       active: {line: 1, character: 0}
   thatMark:
-    - anchor: {line: 1, character: 0}
-      active: {line: 1, character: 0}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 0}
+        end: {line: 1, character: 0}
+      isReversed: false
+      hasExplicitRange: false
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: []}]
 decorations:
   - name: justAddedBackground

--- a/src/test/suite/fixtures/recorded/actions/insertEmptyLines/puffThis14.yml
+++ b/src/test/suite/fixtures/recorded/actions/insertEmptyLines/puffThis14.yml
@@ -23,8 +23,12 @@ finalState:
     - anchor: {line: 1, character: 0}
       active: {line: 1, character: 0}
   thatMark:
-    - anchor: {line: 1, character: 0}
-      active: {line: 1, character: 0}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 0}
+        end: {line: 1, character: 0}
+      isReversed: false
+      hasExplicitRange: false
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: []}]
 decorations:
   - name: justAddedBackground

--- a/src/test/suite/fixtures/recorded/actions/insertEmptyLines/puffThis15.yml
+++ b/src/test/suite/fixtures/recorded/actions/insertEmptyLines/puffThis15.yml
@@ -23,8 +23,12 @@ finalState:
     - anchor: {line: 1, character: 9}
       active: {line: 1, character: 9}
   thatMark:
-    - anchor: {line: 1, character: 9}
-      active: {line: 1, character: 9}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 9}
+        end: {line: 1, character: 9}
+      isReversed: false
+      hasExplicitRange: false
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: []}]
 decorations:
   - name: justAddedBackground

--- a/src/test/suite/fixtures/recorded/actions/insertEmptyLines/puffThis16.yml
+++ b/src/test/suite/fixtures/recorded/actions/insertEmptyLines/puffThis16.yml
@@ -23,8 +23,12 @@ finalState:
     - anchor: {line: 1, character: 4}
       active: {line: 1, character: 4}
   thatMark:
-    - anchor: {line: 1, character: 4}
-      active: {line: 1, character: 4}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 4}
+        end: {line: 1, character: 4}
+      isReversed: false
+      hasExplicitRange: false
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: []}]
 decorations:
   - name: justAddedBackground

--- a/src/test/suite/fixtures/recorded/actions/insertEmptyLines/puffThis17.yml
+++ b/src/test/suite/fixtures/recorded/actions/insertEmptyLines/puffThis17.yml
@@ -23,8 +23,12 @@ finalState:
     - anchor: {line: 1, character: 0}
       active: {line: 1, character: 0}
   thatMark:
-    - anchor: {line: 1, character: 0}
-      active: {line: 1, character: 0}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 0}
+        end: {line: 1, character: 0}
+      isReversed: false
+      hasExplicitRange: false
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: []}]
 decorations:
   - name: justAddedBackground

--- a/src/test/suite/fixtures/recorded/actions/insertEmptyLines/puffThis18.yml
+++ b/src/test/suite/fixtures/recorded/actions/insertEmptyLines/puffThis18.yml
@@ -25,8 +25,12 @@ finalState:
     - anchor: {line: 2, character: 5}
       active: {line: 2, character: 5}
   thatMark:
-    - anchor: {line: 2, character: 5}
-      active: {line: 2, character: 5}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 2, character: 5}
+        end: {line: 2, character: 5}
+      isReversed: false
+      hasExplicitRange: false
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: []}]
 decorations:
   - name: justAddedBackground

--- a/src/test/suite/fixtures/recorded/actions/insertEmptyLines/puffThis19.yml
+++ b/src/test/suite/fixtures/recorded/actions/insertEmptyLines/puffThis19.yml
@@ -25,8 +25,12 @@ finalState:
     - anchor: {line: 2, character: 0}
       active: {line: 2, character: 0}
   thatMark:
-    - anchor: {line: 2, character: 0}
-      active: {line: 2, character: 0}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 2, character: 0}
+        end: {line: 2, character: 0}
+      isReversed: false
+      hasExplicitRange: false
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: []}]
 decorations:
   - name: justAddedBackground

--- a/src/test/suite/fixtures/recorded/actions/insertEmptyLines/puffThis2.yml
+++ b/src/test/suite/fixtures/recorded/actions/insertEmptyLines/puffThis2.yml
@@ -21,8 +21,12 @@ finalState:
     - anchor: {line: 2, character: 0}
       active: {line: 2, character: 0}
   thatMark:
-    - anchor: {line: 2, character: 0}
-      active: {line: 2, character: 0}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 2, character: 0}
+        end: {line: 2, character: 0}
+      isReversed: false
+      hasExplicitRange: false
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: []}]
 decorations:
   - name: justAddedBackground

--- a/src/test/suite/fixtures/recorded/actions/insertEmptyLines/puffThis20.yml
+++ b/src/test/suite/fixtures/recorded/actions/insertEmptyLines/puffThis20.yml
@@ -27,8 +27,12 @@ finalState:
     - anchor: {line: 2, character: 0}
       active: {line: 2, character: 0}
   thatMark:
-    - anchor: {line: 2, character: 0}
-      active: {line: 2, character: 0}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 2, character: 0}
+        end: {line: 2, character: 0}
+      isReversed: false
+      hasExplicitRange: false
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: []}]
 decorations:
   - name: justAddedBackground

--- a/src/test/suite/fixtures/recorded/actions/insertEmptyLines/puffThis21.yml
+++ b/src/test/suite/fixtures/recorded/actions/insertEmptyLines/puffThis21.yml
@@ -27,8 +27,12 @@ finalState:
     - anchor: {line: 2, character: 3}
       active: {line: 2, character: 3}
   thatMark:
-    - anchor: {line: 2, character: 3}
-      active: {line: 2, character: 3}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 2, character: 3}
+        end: {line: 2, character: 3}
+      isReversed: false
+      hasExplicitRange: false
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: []}]
 decorations:
   - name: justAddedBackground

--- a/src/test/suite/fixtures/recorded/actions/insertEmptyLines/puffThis22.yml
+++ b/src/test/suite/fixtures/recorded/actions/insertEmptyLines/puffThis22.yml
@@ -27,8 +27,12 @@ finalState:
     - anchor: {line: 2, character: 7}
       active: {line: 2, character: 7}
   thatMark:
-    - anchor: {line: 2, character: 7}
-      active: {line: 2, character: 7}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 2, character: 7}
+        end: {line: 2, character: 7}
+      isReversed: false
+      hasExplicitRange: false
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: []}]
 decorations:
   - name: justAddedBackground

--- a/src/test/suite/fixtures/recorded/actions/insertEmptyLines/puffThis3.yml
+++ b/src/test/suite/fixtures/recorded/actions/insertEmptyLines/puffThis3.yml
@@ -21,8 +21,12 @@ finalState:
     - anchor: {line: 2, character: 0}
       active: {line: 2, character: 0}
   thatMark:
-    - anchor: {line: 2, character: 0}
-      active: {line: 2, character: 0}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 2, character: 0}
+        end: {line: 2, character: 0}
+      isReversed: false
+      hasExplicitRange: false
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: []}]
 decorations:
   - name: justAddedBackground

--- a/src/test/suite/fixtures/recorded/actions/insertEmptyLines/puffThis4.yml
+++ b/src/test/suite/fixtures/recorded/actions/insertEmptyLines/puffThis4.yml
@@ -21,8 +21,12 @@ finalState:
     - anchor: {line: 2, character: 0}
       active: {line: 2, character: 0}
   thatMark:
-    - anchor: {line: 2, character: 0}
-      active: {line: 2, character: 0}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 2, character: 0}
+        end: {line: 2, character: 0}
+      isReversed: false
+      hasExplicitRange: false
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: []}]
 decorations:
   - name: justAddedBackground

--- a/src/test/suite/fixtures/recorded/actions/insertEmptyLines/puffThis5.yml
+++ b/src/test/suite/fixtures/recorded/actions/insertEmptyLines/puffThis5.yml
@@ -24,8 +24,12 @@ finalState:
     - anchor: {line: 3, character: 0}
       active: {line: 3, character: 0}
   thatMark:
-    - anchor: {line: 3, character: 0}
-      active: {line: 3, character: 0}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 3, character: 0}
+        end: {line: 3, character: 0}
+      isReversed: false
+      hasExplicitRange: false
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: []}]
 decorations:
   - name: justAddedBackground

--- a/src/test/suite/fixtures/recorded/actions/insertEmptyLines/puffThis6.yml
+++ b/src/test/suite/fixtures/recorded/actions/insertEmptyLines/puffThis6.yml
@@ -24,8 +24,12 @@ finalState:
     - anchor: {line: 3, character: 0}
       active: {line: 3, character: 0}
   thatMark:
-    - anchor: {line: 3, character: 0}
-      active: {line: 3, character: 0}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 3, character: 0}
+        end: {line: 3, character: 0}
+      isReversed: false
+      hasExplicitRange: false
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: []}]
 decorations:
   - name: justAddedBackground

--- a/src/test/suite/fixtures/recorded/actions/insertEmptyLines/puffThis7.yml
+++ b/src/test/suite/fixtures/recorded/actions/insertEmptyLines/puffThis7.yml
@@ -24,8 +24,12 @@ finalState:
     - anchor: {line: 2, character: 0}
       active: {line: 2, character: 0}
   thatMark:
-    - anchor: {line: 2, character: 0}
-      active: {line: 2, character: 0}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 2, character: 0}
+        end: {line: 2, character: 0}
+      isReversed: false
+      hasExplicitRange: false
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: []}]
 decorations:
   - name: justAddedBackground

--- a/src/test/suite/fixtures/recorded/actions/insertEmptyLines/puffThis8.yml
+++ b/src/test/suite/fixtures/recorded/actions/insertEmptyLines/puffThis8.yml
@@ -23,8 +23,12 @@ finalState:
     - anchor: {line: 3, character: 0}
       active: {line: 3, character: 0}
   thatMark:
-    - anchor: {line: 3, character: 0}
-      active: {line: 3, character: 0}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 3, character: 0}
+        end: {line: 3, character: 0}
+      isReversed: false
+      hasExplicitRange: false
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: []}]
 decorations:
   - name: justAddedBackground

--- a/src/test/suite/fixtures/recorded/actions/insertEmptyLines/puffThis9.yml
+++ b/src/test/suite/fixtures/recorded/actions/insertEmptyLines/puffThis9.yml
@@ -23,8 +23,12 @@ finalState:
     - anchor: {line: 3, character: 0}
       active: {line: 3, character: 0}
   thatMark:
-    - anchor: {line: 3, character: 0}
-      active: {line: 3, character: 0}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 3, character: 0}
+        end: {line: 3, character: 0}
+      isReversed: false
+      hasExplicitRange: false
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: []}]
 decorations:
   - name: justAddedBackground

--- a/src/test/suite/fixtures/recorded/actions/insertEmptyLines/puffVest.yml
+++ b/src/test/suite/fixtures/recorded/actions/insertEmptyLines/puffVest.yml
@@ -27,8 +27,12 @@ finalState:
     - anchor: {line: 0, character: 0}
       active: {line: 0, character: 0}
   thatMark:
-    - anchor: {line: 2, character: 6}
-      active: {line: 2, character: 11}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 2, character: 6}
+        end: {line: 2, character: 11}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: v}, selectionType: token, position: contents, modifier: {type: identity}, insideOutsideType: inside}]
 decorations:
   - name: justAddedBackground

--- a/src/test/suite/fixtures/recorded/actions/insertEmptyLines/puffVest2.yml
+++ b/src/test/suite/fixtures/recorded/actions/insertEmptyLines/puffVest2.yml
@@ -28,8 +28,12 @@ finalState:
     - anchor: {line: 0, character: 0}
       active: {line: 0, character: 0}
   thatMark:
-    - anchor: {line: 2, character: 10}
-      active: {line: 2, character: 15}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 2, character: 10}
+        end: {line: 2, character: 15}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: v}, modifiers: []}]
 decorations:
   - name: justAddedBackground

--- a/src/test/suite/fixtures/recorded/actions/moveEveryArgMade.yml
+++ b/src/test/suite/fixtures/recorded/actions/moveEveryArgMade.yml
@@ -26,9 +26,17 @@ finalState:
     - anchor: {line: 1, character: 40}
       active: {line: 1, character: 40}
   thatMark:
-    - anchor: {line: 1, character: 0}
-      active: {line: 1, character: 40}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 0}
+        end: {line: 1, character: 40}
+      isReversed: false
+      hasExplicitRange: true
   sourceMark:
-    - anchor: {line: 0, character: 16}
-      active: {line: 0, character: 16}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 16}
+        end: {line: 0, character: 16}
+      isReversed: false
+      hasExplicitRange: false
 fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: m}, selectionType: token, position: contents, insideOutsideType: null, modifier: {type: containingScope, scopeType: argumentOrParameter, includeSiblings: true}, isImplicit: false}, {type: primitive, mark: {type: cursor}, selectionType: token, position: contents, insideOutsideType: null, modifier: {type: identity}, isImplicit: true}]

--- a/src/test/suite/fixtures/recorded/actions/moveVest.yml
+++ b/src/test/suite/fixtures/recorded/actions/moveVest.yml
@@ -26,9 +26,17 @@ finalState:
     - anchor: {line: 0, character: 5}
       active: {line: 0, character: 5}
   thatMark:
-    - anchor: {line: 0, character: 0}
-      active: {line: 0, character: 5}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 0}
+        end: {line: 0, character: 5}
+      isReversed: false
+      hasExplicitRange: true
   sourceMark:
-    - anchor: {line: 1, character: 6}
-      active: {line: 1, character: 6}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 6}
+        end: {line: 1, character: 6}
+      isReversed: false
+      hasExplicitRange: false
 fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: v}, selectionType: token, position: contents, modifier: {type: identity}, insideOutsideType: null}, {type: primitive, mark: {type: cursor}, selectionType: token, position: contents, modifier: {type: identity}, insideOutsideType: inside}]

--- a/src/test/suite/fixtures/recorded/actions/moveVestToCap.yml
+++ b/src/test/suite/fixtures/recorded/actions/moveVestToCap.yml
@@ -30,9 +30,17 @@ finalState:
     - anchor: {line: 0, character: 0}
       active: {line: 0, character: 0}
   thatMark:
-    - anchor: {line: 1, character: 0}
-      active: {line: 1, character: 5}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 0}
+        end: {line: 1, character: 5}
+      isReversed: false
+      hasExplicitRange: true
   sourceMark:
-    - anchor: {line: 1, character: 6}
-      active: {line: 1, character: 6}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 6}
+        end: {line: 1, character: 6}
+      isReversed: false
+      hasExplicitRange: false
 fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: v}, selectionType: token, position: contents, modifier: {type: identity}, insideOutsideType: null}, {type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: c}, selectionType: token, position: contents, modifier: {type: identity}, insideOutsideType: null}]

--- a/src/test/suite/fixtures/recorded/actions/pasteAfterArgueBat.yml
+++ b/src/test/suite/fixtures/recorded/actions/pasteAfterArgueBat.yml
@@ -27,8 +27,12 @@ finalState:
     - anchor: {line: 0, character: 6}
       active: {line: 0, character: 6}
   thatMark:
-    - anchor: {line: 0, character: 21}
-      active: {line: 0, character: 24}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 21}
+        end: {line: 0, character: 24}
+      isReversed: false
+      hasExplicitRange: true
 decorations:
   - name: justAddedBackground
     type: token

--- a/src/test/suite/fixtures/recorded/actions/pasteAfterLineSpunAndAfterBlockLookAndBeforeLineSpun.yml
+++ b/src/test/suite/fixtures/recorded/actions/pasteAfterLineSpunAndAfterBlockLookAndBeforeLineSpun.yml
@@ -60,12 +60,24 @@ finalState:
     - anchor: {line: 5, character: 5}
       active: {line: 5, character: 5}
   thatMark:
-    - anchor: {line: 2, character: 0}
-      active: {line: 2, character: 3}
-    - anchor: {line: 7, character: 0}
-      active: {line: 7, character: 3}
-    - anchor: {line: 0, character: 0}
-      active: {line: 0, character: 3}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 2, character: 0}
+        end: {line: 2, character: 3}
+      isReversed: false
+      hasExplicitRange: true
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 7, character: 0}
+        end: {line: 7, character: 3}
+      isReversed: false
+      hasExplicitRange: true
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 0}
+        end: {line: 0, character: 3}
+      isReversed: false
+      hasExplicitRange: true
 decorations:
   - name: justAddedBackground
     type: token

--- a/src/test/suite/fixtures/recorded/actions/pasteAfterLineTrapAndAfterBlockTrap.yml
+++ b/src/test/suite/fixtures/recorded/actions/pasteAfterLineTrapAndAfterBlockTrap.yml
@@ -42,8 +42,16 @@ finalState:
     - anchor: {line: 5, character: 0}
       active: {line: 5, character: 0}
   thatMark:
-    - anchor: {line: 1, character: 4}
-      active: {line: 1, character: 18}
-    - anchor: {line: 4, character: 0}
-      active: {line: 4, character: 14}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 4}
+        end: {line: 1, character: 18}
+      isReversed: false
+      hasExplicitRange: true
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 4, character: 0}
+        end: {line: 4, character: 14}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: list, elements: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: t}, modifiers: [{type: position, position: after}, {type: containingScope, scopeType: {type: line}}]}, {type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: t}, modifiers: [{type: position, position: after}, {type: containingScope, scopeType: {type: paragraph}}]}]}]

--- a/src/test/suite/fixtures/recorded/actions/pasteAfterState.yml
+++ b/src/test/suite/fixtures/recorded/actions/pasteAfterState.yml
@@ -29,8 +29,12 @@ finalState:
     - anchor: {line: 0, character: 21}
       active: {line: 0, character: 21}
   thatMark:
-    - anchor: {line: 1, character: 0}
-      active: {line: 1, character: 25}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 0}
+        end: {line: 1, character: 25}
+      isReversed: false
+      hasExplicitRange: true
 decorations:
   - name: justAddedBackground
     type: token

--- a/src/test/suite/fixtures/recorded/actions/pasteBeforeArgueZip.yml
+++ b/src/test/suite/fixtures/recorded/actions/pasteBeforeArgueZip.yml
@@ -27,8 +27,12 @@ finalState:
     - anchor: {line: 0, character: 24}
       active: {line: 0, character: 24}
   thatMark:
-    - anchor: {line: 0, character: 9}
-      active: {line: 0, character: 12}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 9}
+        end: {line: 0, character: 12}
+      isReversed: false
+      hasExplicitRange: true
 decorations:
   - name: justAddedBackground
     type: token

--- a/src/test/suite/fixtures/recorded/actions/pasteBeforeState.yml
+++ b/src/test/suite/fixtures/recorded/actions/pasteBeforeState.yml
@@ -29,8 +29,12 @@ finalState:
     - anchor: {line: 1, character: 21}
       active: {line: 1, character: 21}
   thatMark:
-    - anchor: {line: 0, character: 0}
-      active: {line: 0, character: 25}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 0}
+        end: {line: 0, character: 25}
+      isReversed: false
+      hasExplicitRange: true
 decorations:
   - name: justAddedBackground
     type: token

--- a/src/test/suite/fixtures/recorded/actions/pasteCap.yml
+++ b/src/test/suite/fixtures/recorded/actions/pasteCap.yml
@@ -27,6 +27,10 @@ finalState:
       active: {line: 0, character: 0}
   clipboard: value
   thatMark:
-    - anchor: {line: 1, character: 0}
-      active: {line: 1, character: 5}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 0}
+        end: {line: 1, character: 5}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: c}, selectionType: token, position: contents, modifier: {type: identity}, insideOutsideType: inside}]

--- a/src/test/suite/fixtures/recorded/actions/phonesSpy.yml
+++ b/src/test/suite/fixtures/recorded/actions/phonesSpy.yml
@@ -27,6 +27,10 @@ finalState:
     - anchor: {line: 0, character: 0}
       active: {line: 0, character: 0}
   thatMark:
-    - anchor: {line: 1, character: 15}
-      active: {line: 1, character: 18}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 15}
+        end: {line: 1, character: 18}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: s}, selectionType: token, position: contents, modifier: {type: identity}, insideOutsideType: null}]

--- a/src/test/suite/fixtures/recorded/actions/postVest.yml
+++ b/src/test/suite/fixtures/recorded/actions/postVest.yml
@@ -25,6 +25,10 @@ finalState:
     - anchor: {line: 1, character: 11}
       active: {line: 1, character: 11}
   thatMark:
-    - anchor: {line: 1, character: 6}
-      active: {line: 1, character: 11}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 6}
+        end: {line: 1, character: 11}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: v}, selectionType: token, position: contents, modifier: {type: identity}, insideOutsideType: inside}]

--- a/src/test/suite/fixtures/recorded/actions/pourArg.yml
+++ b/src/test/suite/fixtures/recorded/actions/pourArg.yml
@@ -23,6 +23,10 @@ finalState:
     - anchor: {line: 0, character: 46}
       active: {line: 0, character: 46}
   thatMark:
-    - anchor: {line: 0, character: 33}
-      active: {line: 0, character: 44}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 33}
+        end: {line: 0, character: 44}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: [{type: containingScope, scopeType: argumentOrParameter}]}]

--- a/src/test/suite/fixtures/recorded/actions/pourArg2.yml
+++ b/src/test/suite/fixtures/recorded/actions/pourArg2.yml
@@ -30,6 +30,10 @@ finalState:
     - anchor: {line: 2, character: 4}
       active: {line: 2, character: 4}
   thatMark:
-    - anchor: {line: 1, character: 4}
-      active: {line: 1, character: 16}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 4}
+        end: {line: 1, character: 16}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: [{type: containingScope, scopeType: {type: argumentOrParameter}}]}]

--- a/src/test/suite/fixtures/recorded/actions/pourArg3.yml
+++ b/src/test/suite/fixtures/recorded/actions/pourArg3.yml
@@ -30,6 +30,10 @@ finalState:
     - anchor: {line: 3, character: 4}
       active: {line: 3, character: 4}
   thatMark:
-    - anchor: {line: 2, character: 4}
-      active: {line: 2, character: 17}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 2, character: 4}
+        end: {line: 2, character: 17}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: [{type: containingScope, scopeType: {type: argumentOrParameter}}]}]

--- a/src/test/suite/fixtures/recorded/actions/pourArg4.yml
+++ b/src/test/suite/fixtures/recorded/actions/pourArg4.yml
@@ -30,6 +30,10 @@ finalState:
     - anchor: {line: 3, character: 4}
       active: {line: 3, character: 4}
   thatMark:
-    - anchor: {line: 2, character: 4}
-      active: {line: 2, character: 17}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 2, character: 4}
+        end: {line: 2, character: 17}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: [{type: containingScope, scopeType: {type: argumentOrParameter}}]}]

--- a/src/test/suite/fixtures/recorded/actions/pourBlock.yml
+++ b/src/test/suite/fixtures/recorded/actions/pourBlock.yml
@@ -25,6 +25,10 @@ finalState:
     - anchor: {line: 2, character: 0}
       active: {line: 2, character: 0}
   thatMark:
-    - anchor: {line: 0, character: 0}
-      active: {line: 0, character: 61}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 0}
+        end: {line: 0, character: 61}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: [{type: containingScope, scopeType: paragraph}]}]

--- a/src/test/suite/fixtures/recorded/actions/pourBlockHarpAndLineWhale.yml
+++ b/src/test/suite/fixtures/recorded/actions/pourBlockHarpAndLineWhale.yml
@@ -48,8 +48,16 @@ finalState:
     - anchor: {line: 5, character: 4}
       active: {line: 5, character: 4}
   thatMark:
-    - anchor: {line: 0, character: 4}
-      active: {line: 0, character: 9}
-    - anchor: {line: 4, character: 4}
-      active: {line: 4, character: 9}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 4}
+        end: {line: 0, character: 9}
+      isReversed: false
+      hasExplicitRange: true
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 4, character: 4}
+        end: {line: 4, character: 9}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: list, elements: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: h}, modifiers: [{type: containingScope, scopeType: {type: paragraph}}]}, {type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: w}, modifiers: [{type: containingScope, scopeType: {type: line}}]}]}]

--- a/src/test/suite/fixtures/recorded/actions/pourHarpAndLookAndTrap.yml
+++ b/src/test/suite/fixtures/recorded/actions/pourHarpAndLookAndTrap.yml
@@ -37,6 +37,10 @@ finalState:
     - anchor: {line: 1, character: 0}
       active: {line: 1, character: 0}
   thatMark:
-    - anchor: {line: 0, character: 0}
-      active: {line: 0, character: 5}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 0}
+        end: {line: 0, character: 5}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: list, elements: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: h}, modifiers: []}, {type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: l}, modifiers: []}, {type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: t}, modifiers: []}]}]

--- a/src/test/suite/fixtures/recorded/actions/pourItem.yml
+++ b/src/test/suite/fixtures/recorded/actions/pourItem.yml
@@ -32,6 +32,10 @@ finalState:
     - anchor: {line: 4, character: 4}
       active: {line: 4, character: 4}
   thatMark:
-    - anchor: {line: 3, character: 4}
-      active: {line: 3, character: 5}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 3, character: 4}
+        end: {line: 3, character: 5}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: [{type: containingScope, scopeType: {type: collectionItem}}]}]

--- a/src/test/suite/fixtures/recorded/actions/pourItem2.yml
+++ b/src/test/suite/fixtures/recorded/actions/pourItem2.yml
@@ -32,6 +32,10 @@ finalState:
     - anchor: {line: 4, character: 4}
       active: {line: 4, character: 4}
   thatMark:
-    - anchor: {line: 3, character: 4}
-      active: {line: 3, character: 5}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 3, character: 4}
+        end: {line: 3, character: 5}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: [{type: containingScope, scopeType: {type: collectionItem}}]}]

--- a/src/test/suite/fixtures/recorded/actions/pourItem3.yml
+++ b/src/test/suite/fixtures/recorded/actions/pourItem3.yml
@@ -32,6 +32,10 @@ finalState:
     - anchor: {line: 2, character: 4}
       active: {line: 2, character: 4}
   thatMark:
-    - anchor: {line: 1, character: 4}
-      active: {line: 1, character: 5}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 4}
+        end: {line: 1, character: 5}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: [{type: containingScope, scopeType: {type: collectionItem}}]}]

--- a/src/test/suite/fixtures/recorded/actions/pourLine.yml
+++ b/src/test/suite/fixtures/recorded/actions/pourLine.yml
@@ -29,6 +29,10 @@ finalState:
     - anchor: {line: 2, character: 8}
       active: {line: 2, character: 8}
   thatMark:
-    - anchor: {line: 1, character: 4}
-      active: {line: 1, character: 18}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 4}
+        end: {line: 1, character: 18}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: [{type: containingScope, scopeType: {type: line}}]}]

--- a/src/test/suite/fixtures/recorded/actions/pourLineHarpAndBlockWhale.yml
+++ b/src/test/suite/fixtures/recorded/actions/pourLineHarpAndBlockWhale.yml
@@ -48,8 +48,16 @@ finalState:
     - anchor: {line: 6, character: 4}
       active: {line: 6, character: 4}
   thatMark:
-    - anchor: {line: 0, character: 4}
-      active: {line: 0, character: 9}
-    - anchor: {line: 3, character: 4}
-      active: {line: 4, character: 7}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 4}
+        end: {line: 0, character: 9}
+      isReversed: false
+      hasExplicitRange: true
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 3, character: 4}
+        end: {line: 4, character: 7}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: list, elements: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: h}, modifiers: [{type: containingScope, scopeType: {type: line}}]}, {type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: w}, modifiers: [{type: containingScope, scopeType: {type: paragraph}}]}]}]

--- a/src/test/suite/fixtures/recorded/actions/pourThis.yml
+++ b/src/test/suite/fixtures/recorded/actions/pourThis.yml
@@ -24,6 +24,10 @@ finalState:
     - anchor: {line: 1, character: 0}
       active: {line: 1, character: 0}
   thatMark:
-    - anchor: {line: 0, character: 2}
-      active: {line: 0, character: 2}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 2}
+        end: {line: 0, character: 2}
+      isReversed: false
+      hasExplicitRange: false
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: []}]

--- a/src/test/suite/fixtures/recorded/actions/pourVest.yml
+++ b/src/test/suite/fixtures/recorded/actions/pourVest.yml
@@ -26,6 +26,10 @@ finalState:
     - anchor: {line: 2, character: 0}
       active: {line: 2, character: 0}
   thatMark:
-    - anchor: {line: 1, character: 6}
-      active: {line: 1, character: 11}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 6}
+        end: {line: 1, character: 11}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: v}, selectionType: token, position: contents, modifier: {type: identity}, insideOutsideType: outside}]

--- a/src/test/suite/fixtures/recorded/actions/pourVest2.yml
+++ b/src/test/suite/fixtures/recorded/actions/pourVest2.yml
@@ -27,6 +27,10 @@ finalState:
     - anchor: {line: 2, character: 4}
       active: {line: 2, character: 4}
   thatMark:
-    - anchor: {line: 1, character: 10}
-      active: {line: 1, character: 15}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 10}
+        end: {line: 1, character: 15}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: v}, modifiers: []}]

--- a/src/test/suite/fixtures/recorded/actions/preeVest.yml
+++ b/src/test/suite/fixtures/recorded/actions/preeVest.yml
@@ -25,6 +25,10 @@ finalState:
     - anchor: {line: 1, character: 6}
       active: {line: 1, character: 6}
   thatMark:
-    - anchor: {line: 1, character: 6}
-      active: {line: 1, character: 11}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 6}
+        end: {line: 1, character: 11}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: v}, selectionType: token, position: contents, modifier: {type: identity}, insideOutsideType: inside}]

--- a/src/test/suite/fixtures/recorded/actions/reformatHarpAsSnake.yml
+++ b/src/test/suite/fixtures/recorded/actions/reformatHarpAsSnake.yml
@@ -27,7 +27,11 @@ finalState:
     - anchor: {line: 0, character: 0}
       active: {line: 0, character: 0}
   thatMark:
-    - anchor: {line: 1, character: 15}
-      active: {line: 1, character: 25}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 15}
+        end: {line: 1, character: 25}
+      isReversed: false
+      hasExplicitRange: true
 returnValue: [helloWorld]
 fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: h}, selectionType: token, position: contents, modifier: {type: identity}, insideOutsideType: inside}]

--- a/src/test/suite/fixtures/recorded/actions/reformatHarpAsSnake2.yml
+++ b/src/test/suite/fixtures/recorded/actions/reformatHarpAsSnake2.yml
@@ -27,6 +27,10 @@ finalState:
     - anchor: {line: 0, character: 0}
       active: {line: 0, character: 0}
   thatMark:
-    - anchor: {line: 1, character: 15}
-      active: {line: 1, character: 26}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 15}
+        end: {line: 1, character: 26}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: h}, selectionType: token, position: contents, modifier: {type: identity}, insideOutsideType: null}]

--- a/src/test/suite/fixtures/recorded/actions/replaceAirAndBatAndCapWithCount.yml
+++ b/src/test/suite/fixtures/recorded/actions/replaceAirAndBatAndCapWithCount.yml
@@ -43,10 +43,22 @@ finalState:
     - anchor: {line: 0, character: 0}
       active: {line: 0, character: 0}
   thatMark:
-    - anchor: {line: 1, character: 0}
-      active: {line: 1, character: 1}
-    - anchor: {line: 2, character: 0}
-      active: {line: 2, character: 1}
-    - anchor: {line: 3, character: 0}
-      active: {line: 3, character: 1}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 0}
+        end: {line: 1, character: 1}
+      isReversed: false
+      hasExplicitRange: true
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 2, character: 0}
+        end: {line: 2, character: 1}
+      isReversed: false
+      hasExplicitRange: true
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 3, character: 0}
+        end: {line: 3, character: 1}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: list, elements: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: a}, selectionType: token, position: contents, modifier: {type: identity}, insideOutsideType: null}, {type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: b}, selectionType: token, position: contents, modifier: {type: identity}, insideOutsideType: null}, {type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: c}, selectionType: token, position: contents, modifier: {type: identity}, insideOutsideType: null}]}]

--- a/src/test/suite/fixtures/recorded/actions/replaceVestWithWhatever.yml
+++ b/src/test/suite/fixtures/recorded/actions/replaceVestWithWhatever.yml
@@ -27,6 +27,10 @@ finalState:
     - anchor: {line: 0, character: 0}
       active: {line: 0, character: 0}
   thatMark:
-    - anchor: {line: 1, character: 6}
-      active: {line: 1, character: 14}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 6}
+        end: {line: 1, character: 14}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: v}, selectionType: token, position: contents, modifier: {type: identity}, insideOutsideType: null}]

--- a/src/test/suite/fixtures/recorded/actions/reverseAirAndBatAndCap.yml
+++ b/src/test/suite/fixtures/recorded/actions/reverseAirAndBatAndCap.yml
@@ -37,10 +37,22 @@ finalState:
     - anchor: {line: 0, character: 0}
       active: {line: 0, character: 0}
   thatMark:
-    - anchor: {line: 1, character: 16}
-      active: {line: 1, character: 17}
-    - anchor: {line: 1, character: 21}
-      active: {line: 1, character: 22}
-    - anchor: {line: 1, character: 26}
-      active: {line: 1, character: 27}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 16}
+        end: {line: 1, character: 17}
+      isReversed: false
+      hasExplicitRange: true
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 21}
+        end: {line: 1, character: 22}
+      isReversed: false
+      hasExplicitRange: true
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 26}
+        end: {line: 1, character: 27}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: list, elements: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: a}, selectionType: token, position: contents, modifier: {type: identity}, insideOutsideType: inside}, {type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: b}, selectionType: token, position: contents, modifier: {type: identity}, insideOutsideType: inside}, {type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: c}, selectionType: token, position: contents, modifier: {type: identity}, insideOutsideType: inside}]}]

--- a/src/test/suite/fixtures/recorded/actions/roundWrapThis.yml
+++ b/src/test/suite/fixtures/recorded/actions/roundWrapThis.yml
@@ -23,9 +23,17 @@ finalState:
     - anchor: {line: 0, character: 1}
       active: {line: 0, character: 1}
   thatMark:
-    - anchor: {line: 0, character: 0}
-      active: {line: 0, character: 2}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 0}
+        end: {line: 0, character: 2}
+      isReversed: false
+      hasExplicitRange: true
   sourceMark:
-    - anchor: {line: 0, character: 1}
-      active: {line: 0, character: 1}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 1}
+        end: {line: 0, character: 1}
+      isReversed: false
+      hasExplicitRange: false
 fullTargets: [{type: primitive, mark: {type: cursor}, selectionType: token, position: contents, modifier: {type: identity}, insideOutsideType: inside}]

--- a/src/test/suite/fixtures/recorded/actions/roundWrapVest.yml
+++ b/src/test/suite/fixtures/recorded/actions/roundWrapVest.yml
@@ -26,9 +26,17 @@ finalState:
     - anchor: {line: 1, character: 12}
       active: {line: 1, character: 12}
   thatMark:
-    - anchor: {line: 1, character: 6}
-      active: {line: 1, character: 13}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 6}
+        end: {line: 1, character: 13}
+      isReversed: false
+      hasExplicitRange: true
   sourceMark:
-    - anchor: {line: 1, character: 7}
-      active: {line: 1, character: 12}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 7}
+        end: {line: 1, character: 12}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: v}, selectionType: token, position: contents, modifier: {type: identity}, insideOutsideType: inside}]

--- a/src/test/suite/fixtures/recorded/actions/roundWrapVest2.yml
+++ b/src/test/suite/fixtures/recorded/actions/roundWrapVest2.yml
@@ -26,9 +26,17 @@ finalState:
     - anchor: {line: 1, character: 14}
       active: {line: 1, character: 14}
   thatMark:
-    - anchor: {line: 1, character: 6}
-      active: {line: 1, character: 13}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 6}
+        end: {line: 1, character: 13}
+      isReversed: false
+      hasExplicitRange: true
   sourceMark:
-    - anchor: {line: 1, character: 7}
-      active: {line: 1, character: 12}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 7}
+        end: {line: 1, character: 12}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: v}, selectionType: token, position: contents, modifier: {type: identity}, insideOutsideType: inside}]

--- a/src/test/suite/fixtures/recorded/actions/shuffleThis.yml
+++ b/src/test/suite/fixtures/recorded/actions/shuffleThis.yml
@@ -18,6 +18,10 @@ finalState:
     - anchor: {line: 0, character: 0}
       active: {line: 0, character: 5}
   thatMark:
-    - anchor: {line: 0, character: 0}
-      active: {line: 0, character: 5}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 0}
+        end: {line: 0, character: 5}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: cursor}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: identity}, isImplicit: false}]

--- a/src/test/suite/fixtures/recorded/actions/snippets/duplicatedDuplicatedWrapThis.yml
+++ b/src/test/suite/fixtures/recorded/actions/snippets/duplicatedDuplicatedWrapThis.yml
@@ -23,6 +23,10 @@ finalState:
     - anchor: {line: 0, character: 69}
       active: {line: 0, character: 69}
   thatMark:
-    - anchor: {line: 0, character: 81}
-      active: {line: 0, character: 0}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 0}
+        end: {line: 0, character: 81}
+      isReversed: true
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: []}]

--- a/src/test/suite/fixtures/recorded/actions/snippets/duplicatedUniqueWrapThis.yml
+++ b/src/test/suite/fixtures/recorded/actions/snippets/duplicatedUniqueWrapThis.yml
@@ -23,6 +23,10 @@ finalState:
     - anchor: {line: 0, character: 39}
       active: {line: 0, character: 39}
   thatMark:
-    - anchor: {line: 0, character: 70}
-      active: {line: 0, character: 0}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 0}
+        end: {line: 0, character: 70}
+      isReversed: true
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: []}]

--- a/src/test/suite/fixtures/recorded/actions/snippets/snipDuplicatedDuplicated.yml
+++ b/src/test/suite/fixtures/recorded/actions/snippets/snipDuplicatedDuplicated.yml
@@ -22,6 +22,10 @@ finalState:
     - anchor: {line: 0, character: 39}
       active: {line: 0, character: 39}
   thatMark:
-    - anchor: {line: 0, character: 0}
-      active: {line: 0, character: 59}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 0}
+        end: {line: 0, character: 59}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: [{type: toRawSelection}]}]

--- a/src/test/suite/fixtures/recorded/actions/snippets/snipDuplicatedDuplicatedHelloWorld.yml
+++ b/src/test/suite/fixtures/recorded/actions/snippets/snipDuplicatedDuplicatedHelloWorld.yml
@@ -24,6 +24,10 @@ finalState:
     - anchor: {line: 0, character: 69}
       active: {line: 0, character: 69}
   thatMark:
-    - anchor: {line: 0, character: 0}
-      active: {line: 0, character: 81}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 0}
+        end: {line: 0, character: 81}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: [{type: toRawSelection}]}]

--- a/src/test/suite/fixtures/recorded/actions/snippets/snipDuplicatedUniqueHelloWorld.yml
+++ b/src/test/suite/fixtures/recorded/actions/snippets/snipDuplicatedUniqueHelloWorld.yml
@@ -24,6 +24,10 @@ finalState:
     - anchor: {line: 0, character: 39}
       active: {line: 0, character: 39}
   thatMark:
-    - anchor: {line: 0, character: 0}
-      active: {line: 0, character: 69}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 0}
+        end: {line: 0, character: 69}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: [{type: toRawSelection}]}]

--- a/src/test/suite/fixtures/recorded/actions/snippets/snipFunk.yml
+++ b/src/test/suite/fixtures/recorded/actions/snippets/snipFunk.yml
@@ -20,6 +20,10 @@ finalState:
     - anchor: {line: 0, character: 9}
       active: {line: 0, character: 9}
   thatMark:
-    - anchor: {line: 0, character: 0}
-      active: {line: 2, character: 1}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 0}
+        end: {line: 2, character: 1}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: cursor}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: identity}}]

--- a/src/test/suite/fixtures/recorded/actions/snippets/snipFunkAfterFineAndZip.yml
+++ b/src/test/suite/fixtures/recorded/actions/snippets/snipFunkAfterFineAndZip.yml
@@ -45,8 +45,16 @@ finalState:
     - anchor: {line: 5, character: 9}
       active: {line: 5, character: 9}
   thatMark:
-    - anchor: {line: 1, character: 0}
-      active: {line: 3, character: 1}
-    - anchor: {line: 5, character: 0}
-      active: {line: 7, character: 1}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 0}
+        end: {line: 3, character: 1}
+      isReversed: false
+      hasExplicitRange: true
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 5, character: 0}
+        end: {line: 7, character: 1}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: list, elements: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: f}, modifiers: [{type: position, position: after}]}, {type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: z}, modifiers: [{type: position, position: after}]}]}]

--- a/src/test/suite/fixtures/recorded/actions/snippets/snipFunkAfterMadeAndBeforeFineAndZip.yml
+++ b/src/test/suite/fixtures/recorded/actions/snippets/snipFunkAfterMadeAndBeforeFineAndZip.yml
@@ -59,10 +59,22 @@ finalState:
     - anchor: {line: 4, character: 9}
       active: {line: 4, character: 9}
   thatMark:
-    - anchor: {line: 9, character: 0}
-      active: {line: 11, character: 1}
-    - anchor: {line: 0, character: 0}
-      active: {line: 2, character: 1}
-    - anchor: {line: 4, character: 0}
-      active: {line: 6, character: 1}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 9, character: 0}
+        end: {line: 11, character: 1}
+      isReversed: false
+      hasExplicitRange: true
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 0}
+        end: {line: 2, character: 1}
+      isReversed: false
+      hasExplicitRange: true
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 4, character: 0}
+        end: {line: 6, character: 1}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: list, elements: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: m}, modifiers: [{type: position, position: after}]}, {type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: f}, modifiers: [{type: position, position: before}]}, {type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: z}, modifiers: [{type: position, position: before}]}]}]

--- a/src/test/suite/fixtures/recorded/actions/snippets/snipFunkAfterThis.yml
+++ b/src/test/suite/fixtures/recorded/actions/snippets/snipFunkAfterThis.yml
@@ -27,6 +27,10 @@ finalState:
     - anchor: {line: 1, character: 13}
       active: {line: 1, character: 13}
   thatMark:
-    - anchor: {line: 1, character: 4}
-      active: {line: 3, character: 5}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 4}
+        end: {line: 3, character: 5}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: [{type: position, position: after}]}]

--- a/src/test/suite/fixtures/recorded/actions/snippets/snipFunkAfterThis2.yml
+++ b/src/test/suite/fixtures/recorded/actions/snippets/snipFunkAfterThis2.yml
@@ -31,6 +31,10 @@ finalState:
     - anchor: {line: 1, character: 9}
       active: {line: 1, character: 9}
   thatMark:
-    - anchor: {line: 1, character: 0}
-      active: {line: 3, character: 1}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 0}
+        end: {line: 3, character: 1}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: [{type: position, position: after}]}]

--- a/src/test/suite/fixtures/recorded/actions/snippets/snipFunkAfterThis3.yml
+++ b/src/test/suite/fixtures/recorded/actions/snippets/snipFunkAfterThis3.yml
@@ -33,6 +33,10 @@ finalState:
     - anchor: {line: 4, character: 9}
       active: {line: 4, character: 9}
   thatMark:
-    - anchor: {line: 4, character: 0}
-      active: {line: 6, character: 1}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 4, character: 0}
+        end: {line: 6, character: 1}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: [], positionModifier: {type: position, position: after}}]

--- a/src/test/suite/fixtures/recorded/actions/snippets/snipFunkAfterThis4.yml
+++ b/src/test/suite/fixtures/recorded/actions/snippets/snipFunkAfterThis4.yml
@@ -23,6 +23,10 @@ finalState:
     - anchor: {line: 1, character: 9}
       active: {line: 1, character: 9}
   thatMark:
-    - anchor: {line: 1, character: 0}
-      active: {line: 3, character: 1}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 0}
+        end: {line: 3, character: 1}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: cursor}, selectionType: token, position: after, insideOutsideType: outside, modifier: {type: containingScope, scopeType: statement, includeSiblings: false}}]

--- a/src/test/suite/fixtures/recorded/actions/snippets/snipFunkAfterZipAndBeforeFine.yml
+++ b/src/test/suite/fixtures/recorded/actions/snippets/snipFunkAfterZipAndBeforeFine.yml
@@ -47,8 +47,16 @@ finalState:
     - anchor: {line: 0, character: 9}
       active: {line: 0, character: 9}
   thatMark:
-    - anchor: {line: 5, character: 0}
-      active: {line: 7, character: 1}
-    - anchor: {line: 0, character: 0}
-      active: {line: 2, character: 1}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 5, character: 0}
+        end: {line: 7, character: 1}
+      isReversed: false
+      hasExplicitRange: true
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 0}
+        end: {line: 2, character: 1}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: list, elements: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: z}, modifiers: [{type: position, position: after}]}, {type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: f}, modifiers: [{type: position, position: before}]}]}]

--- a/src/test/suite/fixtures/recorded/actions/snippets/snipFunkBeforeThis.yml
+++ b/src/test/suite/fixtures/recorded/actions/snippets/snipFunkBeforeThis.yml
@@ -27,6 +27,10 @@ finalState:
     - anchor: {line: 0, character: 9}
       active: {line: 0, character: 9}
   thatMark:
-    - anchor: {line: 0, character: 0}
-      active: {line: 2, character: 1}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 0}
+        end: {line: 2, character: 1}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: [{type: position, position: before}]}]

--- a/src/test/suite/fixtures/recorded/actions/snippets/snipFunkBeforeThis2.yml
+++ b/src/test/suite/fixtures/recorded/actions/snippets/snipFunkBeforeThis2.yml
@@ -27,6 +27,10 @@ finalState:
     - anchor: {line: 0, character: 13}
       active: {line: 0, character: 13}
   thatMark:
-    - anchor: {line: 0, character: 4}
-      active: {line: 2, character: 5}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 4}
+        end: {line: 2, character: 5}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: [{type: position, position: before}]}]

--- a/src/test/suite/fixtures/recorded/actions/snippets/snipFunkBeforeThis3.yml
+++ b/src/test/suite/fixtures/recorded/actions/snippets/snipFunkBeforeThis3.yml
@@ -31,6 +31,10 @@ finalState:
     - anchor: {line: 0, character: 9}
       active: {line: 0, character: 9}
   thatMark:
-    - anchor: {line: 0, character: 0}
-      active: {line: 2, character: 1}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 0}
+        end: {line: 2, character: 1}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: [{type: position, position: before}]}]

--- a/src/test/suite/fixtures/recorded/actions/snippets/snipFunkHelloWorld.yml
+++ b/src/test/suite/fixtures/recorded/actions/snippets/snipFunkHelloWorld.yml
@@ -22,6 +22,10 @@ finalState:
     - anchor: {line: 0, character: 20}
       active: {line: 0, character: 20}
   thatMark:
-    - anchor: {line: 0, character: 0}
-      active: {line: 2, character: 1}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 0}
+        end: {line: 2, character: 1}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: cursor}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: identity}}]

--- a/src/test/suite/fixtures/recorded/actions/snippets/snipFunkHelloWorld2.yml
+++ b/src/test/suite/fixtures/recorded/actions/snippets/snipFunkHelloWorld2.yml
@@ -21,6 +21,10 @@ finalState:
     - anchor: {line: 0, character: 16}
       active: {line: 0, character: 16}
   thatMark:
-    - anchor: {line: 0, character: 0}
-      active: {line: 1, character: 4}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 0}
+        end: {line: 1, character: 4}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: cursor}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: identity}}]

--- a/src/test/suite/fixtures/recorded/actions/snippets/snipIf.yml
+++ b/src/test/suite/fixtures/recorded/actions/snippets/snipIf.yml
@@ -26,6 +26,10 @@ finalState:
     - anchor: {line: 1, character: 8}
       active: {line: 1, character: 8}
   thatMark:
-    - anchor: {line: 1, character: 4}
-      active: {line: 3, character: 5}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 4}
+        end: {line: 3, character: 5}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: cursor}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: identity}, isImplicit: true}]

--- a/src/test/suite/fixtures/recorded/actions/snippets/snipMakeFunk.yml
+++ b/src/test/suite/fixtures/recorded/actions/snippets/snipMakeFunk.yml
@@ -59,6 +59,10 @@ finalState:
     - anchor: {line: 20, character: 7}
       active: {line: 20, character: 16}
   thatMark:
-    - anchor: {line: 0, character: 4}
-      active: {line: 6, character: 5}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 4}
+        end: {line: 6, character: 5}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: [{type: containingScope, scopeType: {type: namedFunction}}]}]

--- a/src/test/suite/fixtures/recorded/actions/snippets/snipMakeState.yml
+++ b/src/test/suite/fixtures/recorded/actions/snippets/snipMakeState.yml
@@ -50,6 +50,10 @@ finalState:
     - anchor: {line: 18, character: 7}
       active: {line: 18, character: 16}
   thatMark:
-    - anchor: {line: 0, character: 0}
-      active: {line: 2, character: 1}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 0}
+        end: {line: 2, character: 1}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: [{type: containingScope, scopeType: {type: statement}}]}]

--- a/src/test/suite/fixtures/recorded/actions/snippets/snipSpaghetti.yml
+++ b/src/test/suite/fixtures/recorded/actions/snippets/snipSpaghetti.yml
@@ -18,6 +18,10 @@ finalState:
     - anchor: {line: 0, character: 10}
       active: {line: 0, character: 10}
   thatMark:
-    - anchor: {line: 0, character: 0}
-      active: {line: 0, character: 34}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 0}
+        end: {line: 0, character: 34}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: cursor}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: identity}}]

--- a/src/test/suite/fixtures/recorded/actions/snippets/snipSpaghettiGraceHopper.yml
+++ b/src/test/suite/fixtures/recorded/actions/snippets/snipSpaghettiGraceHopper.yml
@@ -20,6 +20,10 @@ finalState:
     - anchor: {line: 0, character: 46}
       active: {line: 0, character: 46}
   thatMark:
-    - anchor: {line: 0, character: 0}
-      active: {line: 0, character: 46}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 0}
+        end: {line: 0, character: 46}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: cursor}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: identity}}]

--- a/src/test/suite/fixtures/recorded/actions/snippets/spaghettiWrapPastGust.yml
+++ b/src/test/suite/fixtures/recorded/actions/snippets/spaghettiWrapPastGust.yml
@@ -27,6 +27,10 @@ finalState:
     - anchor: {line: 0, character: 46}
       active: {line: 0, character: 46}
   thatMark:
-    - anchor: {line: 0, character: 46}
-      active: {line: 0, character: 0}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 0}
+        end: {line: 0, character: 46}
+      isReversed: true
+      hasExplicitRange: true
 fullTargets: [{type: range, excludeAnchor: false, excludeActive: false, anchor: {type: primitive, mark: {type: cursor}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: identity}}, active: {type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: g}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: identity}}}]

--- a/src/test/suite/fixtures/recorded/actions/sortAirAndCapAndBat.yml
+++ b/src/test/suite/fixtures/recorded/actions/sortAirAndCapAndBat.yml
@@ -37,10 +37,22 @@ finalState:
     - anchor: {line: 0, character: 0}
       active: {line: 0, character: 0}
   thatMark:
-    - anchor: {line: 1, character: 16}
-      active: {line: 1, character: 17}
-    - anchor: {line: 1, character: 21}
-      active: {line: 1, character: 22}
-    - anchor: {line: 1, character: 26}
-      active: {line: 1, character: 27}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 16}
+        end: {line: 1, character: 17}
+      isReversed: false
+      hasExplicitRange: true
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 21}
+        end: {line: 1, character: 22}
+      isReversed: false
+      hasExplicitRange: true
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 26}
+        end: {line: 1, character: 27}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: list, elements: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: a}, selectionType: token, position: contents, modifier: {type: identity}, insideOutsideType: inside}, {type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: c}, selectionType: token, position: contents, modifier: {type: identity}, insideOutsideType: inside}, {type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: b}, selectionType: token, position: contents, modifier: {type: identity}, insideOutsideType: inside}]}]

--- a/src/test/suite/fixtures/recorded/actions/sortThis.yml
+++ b/src/test/suite/fixtures/recorded/actions/sortThis.yml
@@ -33,10 +33,22 @@ finalState:
     - anchor: {line: 2, character: 0}
       active: {line: 2, character: 1}
   thatMark:
-    - anchor: {line: 0, character: 0}
-      active: {line: 0, character: 1}
-    - anchor: {line: 1, character: 0}
-      active: {line: 1, character: 1}
-    - anchor: {line: 2, character: 0}
-      active: {line: 2, character: 1}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 0}
+        end: {line: 0, character: 1}
+      isReversed: false
+      hasExplicitRange: true
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 0}
+        end: {line: 1, character: 1}
+      isReversed: false
+      hasExplicitRange: true
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 2, character: 0}
+        end: {line: 2, character: 1}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: []}]

--- a/src/test/suite/fixtures/recorded/actions/sortThis2.yml
+++ b/src/test/suite/fixtures/recorded/actions/sortThis2.yml
@@ -33,10 +33,22 @@ finalState:
     - anchor: {line: 0, character: 0}
       active: {line: 0, character: 1}
   thatMark:
-    - anchor: {line: 0, character: 0}
-      active: {line: 0, character: 1}
-    - anchor: {line: 1, character: 0}
-      active: {line: 1, character: 1}
-    - anchor: {line: 2, character: 0}
-      active: {line: 2, character: 1}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 0}
+        end: {line: 0, character: 1}
+      isReversed: false
+      hasExplicitRange: true
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 0}
+        end: {line: 1, character: 1}
+      isReversed: false
+      hasExplicitRange: true
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 2, character: 0}
+        end: {line: 2, character: 1}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: []}]

--- a/src/test/suite/fixtures/recorded/actions/squareRepackHarp.yml
+++ b/src/test/suite/fixtures/recorded/actions/squareRepackHarp.yml
@@ -24,9 +24,17 @@ finalState:
     - anchor: {line: 1, character: 0}
       active: {line: 1, character: 0}
   thatMark:
-    - anchor: {line: 0, character: 0}
-      active: {line: 0, character: 7}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 0}
+        end: {line: 0, character: 7}
+      isReversed: false
+      hasExplicitRange: true
   sourceMark:
-    - anchor: {line: 0, character: 1}
-      active: {line: 0, character: 6}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 1}
+        end: {line: 0, character: 6}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: h}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: surroundingPair, delimiter: any}}]

--- a/src/test/suite/fixtures/recorded/actions/squareRepackLeper.yml
+++ b/src/test/suite/fixtures/recorded/actions/squareRepackLeper.yml
@@ -24,9 +24,17 @@ finalState:
     - anchor: {line: 1, character: 0}
       active: {line: 1, character: 0}
   thatMark:
-    - anchor: {line: 0, character: 0}
-      active: {line: 0, character: 7}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 0}
+        end: {line: 0, character: 7}
+      isReversed: false
+      hasExplicitRange: true
   sourceMark:
-    - anchor: {line: 0, character: 0}
-      active: {line: 0, character: 1}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 0}
+        end: {line: 0, character: 1}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: (}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: surroundingPair, delimiter: any}}]

--- a/src/test/suite/fixtures/recorded/actions/squareRepackPair.yml
+++ b/src/test/suite/fixtures/recorded/actions/squareRepackPair.yml
@@ -21,9 +21,17 @@ finalState:
     - anchor: {line: 0, character: 2}
       active: {line: 0, character: 2}
   thatMark:
-    - anchor: {line: 0, character: 0}
-      active: {line: 0, character: 7}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 0}
+        end: {line: 0, character: 7}
+      isReversed: false
+      hasExplicitRange: true
   sourceMark:
-    - anchor: {line: 0, character: 0}
-      active: {line: 0, character: 7}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 0}
+        end: {line: 0, character: 7}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: cursor}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: surroundingPair, delimiter: any}}]

--- a/src/test/suite/fixtures/recorded/actions/squareRepackThis.yml
+++ b/src/test/suite/fixtures/recorded/actions/squareRepackThis.yml
@@ -19,9 +19,17 @@ finalState:
     - anchor: {line: 0, character: 4}
       active: {line: 0, character: 4}
   thatMark:
-    - anchor: {line: 0, character: 0}
-      active: {line: 0, character: 7}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 0}
+        end: {line: 0, character: 7}
+      isReversed: false
+      hasExplicitRange: true
   sourceMark:
-    - anchor: {line: 0, character: 4}
-      active: {line: 0, character: 4}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 4}
+        end: {line: 0, character: 4}
+      isReversed: false
+      hasExplicitRange: false
 fullTargets: [{type: primitive, mark: {type: cursor}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: surroundingPair, delimiter: any}}]

--- a/src/test/suite/fixtures/recorded/actions/swapVestWithCap.yml
+++ b/src/test/suite/fixtures/recorded/actions/swapVestWithCap.yml
@@ -30,9 +30,17 @@ finalState:
     - anchor: {line: 0, character: 0}
       active: {line: 0, character: 0}
   thatMark:
-    - anchor: {line: 1, character: 0}
-      active: {line: 1, character: 5}
-    - anchor: {line: 1, character: 6}
-      active: {line: 1, character: 11}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 0}
+        end: {line: 1, character: 5}
+      isReversed: false
+      hasExplicitRange: true
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 6}
+        end: {line: 1, character: 11}
+      isReversed: false
+      hasExplicitRange: true
   sourceMark: []
 fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: v}, selectionType: token, position: contents, modifier: {type: identity}, insideOutsideType: null}, {type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: c}, selectionType: token, position: contents, modifier: {type: identity}, insideOutsideType: null}]

--- a/src/test/suite/fixtures/recorded/actions/swapWithVest.yml
+++ b/src/test/suite/fixtures/recorded/actions/swapWithVest.yml
@@ -26,9 +26,17 @@ finalState:
     - anchor: {line: 0, character: 5}
       active: {line: 0, character: 5}
   thatMark:
-    - anchor: {line: 1, character: 6}
-      active: {line: 1, character: 6}
-    - anchor: {line: 0, character: 0}
-      active: {line: 0, character: 5}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 6}
+        end: {line: 1, character: 6}
+      isReversed: false
+      hasExplicitRange: false
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 0}
+        end: {line: 0, character: 5}
+      isReversed: false
+      hasExplicitRange: true
   sourceMark: []
 fullTargets: [{type: primitive, mark: {type: cursor}, selectionType: token, position: contents, modifier: {type: identity}, insideOutsideType: null}, {type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: v}, selectionType: token, position: contents, modifier: {type: identity}, insideOutsideType: null}]

--- a/src/test/suite/fixtures/recorded/actions/takeVest.yml
+++ b/src/test/suite/fixtures/recorded/actions/takeVest.yml
@@ -25,6 +25,10 @@ finalState:
     - anchor: {line: 1, character: 6}
       active: {line: 1, character: 11}
   thatMark:
-    - anchor: {line: 1, character: 6}
-      active: {line: 1, character: 11}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 6}
+        end: {line: 1, character: 11}
+      isReversed: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: v}, selectionType: token, position: contents, modifier: {type: identity}, insideOutsideType: inside}]

--- a/src/test/suite/fixtures/recorded/decorations/highlightFine.yml
+++ b/src/test/suite/fixtures/recorded/decorations/highlightFine.yml
@@ -28,8 +28,12 @@ finalState:
     - anchor: {line: 0, character: 0}
       active: {line: 0, character: 0}
   thatMark:
-    - anchor: {line: 1, character: 4}
-      active: {line: 1, character: 7}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 4}
+        end: {line: 1, character: 7}
+      isReversed: false
+      hasExplicitRange: true
 decorations:
   - name: highlight0Background
     type: token

--- a/src/test/suite/fixtures/recorded/decorations/highlightLineFine.yml
+++ b/src/test/suite/fixtures/recorded/decorations/highlightLineFine.yml
@@ -31,8 +31,12 @@ finalState:
     - anchor: {line: 0, character: 0}
       active: {line: 0, character: 0}
   thatMark:
-    - anchor: {line: 1, character: 4}
-      active: {line: 1, character: 7}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 4}
+        end: {line: 1, character: 7}
+      isReversed: false
+      hasExplicitRange: true
 decorations:
   - name: highlight0Background
     type: line

--- a/src/test/suite/fixtures/recorded/implicitExpansion/chuckBoundingThat.yml
+++ b/src/test/suite/fixtures/recorded/implicitExpansion/chuckBoundingThat.yml
@@ -16,8 +16,12 @@ initialState:
       active: {line: 0, character: 8}
   marks: {}
   thatMark:
-    - anchor: {line: 0, character: 7}
-      active: {line: 0, character: 7}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 7}
+        end: {line: 0, character: 7}
+      isReversed: false
+      hasExplicitRange: false
 finalState:
   documentContents: hello
   selections:

--- a/src/test/suite/fixtures/recorded/implicitExpansion/chuckCoreThat.yml
+++ b/src/test/suite/fixtures/recorded/implicitExpansion/chuckCoreThat.yml
@@ -16,8 +16,12 @@ initialState:
       active: {line: 0, character: 8}
   marks: {}
   thatMark:
-    - anchor: {line: 0, character: 7}
-      active: {line: 0, character: 7}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 7}
+        end: {line: 0, character: 7}
+      isReversed: false
+      hasExplicitRange: false
 finalState:
   documentContents: ()
   selections:

--- a/src/test/suite/fixtures/recorded/implicitExpansion/chuckLeadingThat.yml
+++ b/src/test/suite/fixtures/recorded/implicitExpansion/chuckLeadingThat.yml
@@ -16,8 +16,12 @@ initialState:
       active: {line: 0, character: 6}
   marks: {}
   thatMark:
-    - anchor: {line: 0, character: 6}
-      active: {line: 0, character: 6}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 6}
+        end: {line: 0, character: 6}
+      isReversed: false
+      hasExplicitRange: false
 finalState:
   documentContents: hello
   selections:

--- a/src/test/suite/fixtures/recorded/implicitExpansion/chuckSecondWordThat.yml
+++ b/src/test/suite/fixtures/recorded/implicitExpansion/chuckSecondWordThat.yml
@@ -21,8 +21,12 @@ initialState:
       active: {line: 0, character: 10}
   marks: {}
   thatMark:
-    - anchor: {line: 0, character: 10}
-      active: {line: 0, character: 10}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 10}
+        end: {line: 0, character: 10}
+      isReversed: false
+      hasExplicitRange: false
 finalState:
   documentContents: hello
   selections:

--- a/src/test/suite/fixtures/recorded/implicitExpansion/clearBoundingThat.yml
+++ b/src/test/suite/fixtures/recorded/implicitExpansion/clearBoundingThat.yml
@@ -17,8 +17,12 @@ initialState:
       active: {line: 1, character: 0}
   marks: {}
   thatMark:
-    - anchor: {line: 0, character: 1}
-      active: {line: 0, character: 6}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 1}
+        end: {line: 0, character: 6}
+      isReversed: false
+      hasExplicitRange: true
 finalState:
   documentContents: |
     hello now

--- a/src/test/suite/fixtures/recorded/implicitExpansion/clearCoreThat.yml
+++ b/src/test/suite/fixtures/recorded/implicitExpansion/clearCoreThat.yml
@@ -17,8 +17,12 @@ initialState:
       active: {line: 1, character: 0}
   marks: {}
   thatMark:
-    - anchor: {line: 0, character: 1}
-      active: {line: 0, character: 6}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 1}
+        end: {line: 0, character: 6}
+      isReversed: false
+      hasExplicitRange: true
 finalState:
   documentContents: |
     ()

--- a/src/test/suite/fixtures/recorded/implicitExpansion/clearEveryLineThat.yml
+++ b/src/test/suite/fixtures/recorded/implicitExpansion/clearEveryLineThat.yml
@@ -19,8 +19,12 @@ initialState:
       active: {line: 1, character: 8}
   marks: {}
   thatMark:
-    - anchor: {line: 0, character: 5}
-      active: {line: 0, character: 5}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 5}
+        end: {line: 0, character: 5}
+      isReversed: false
+      hasExplicitRange: false
 finalState:
   documentContents: |+
 

--- a/src/test/suite/fixtures/recorded/implicitExpansion/clearEveryLineThat2.yml
+++ b/src/test/suite/fixtures/recorded/implicitExpansion/clearEveryLineThat2.yml
@@ -21,8 +21,12 @@ initialState:
       active: {line: 0, character: 0}
   marks: {}
   thatMark:
-    - anchor: {line: 1, character: 0}
-      active: {line: 2, character: 7}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 0}
+        end: {line: 2, character: 7}
+      isReversed: false
+      hasExplicitRange: true
 finalState:
   documentContents: |-
     hello

--- a/src/test/suite/fixtures/recorded/implicitExpansion/clearFirstWordThat.yml
+++ b/src/test/suite/fixtures/recorded/implicitExpansion/clearFirstWordThat.yml
@@ -22,8 +22,12 @@ initialState:
       active: {line: 1, character: 0}
   marks: {}
   thatMark:
-    - anchor: {line: 0, character: 5}
-      active: {line: 0, character: 10}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 5}
+        end: {line: 0, character: 10}
+      isReversed: false
+      hasExplicitRange: true
 finalState:
   documentContents: |
     hello now

--- a/src/test/suite/fixtures/recorded/implicitExpansion/clearTrailingThat.yml
+++ b/src/test/suite/fixtures/recorded/implicitExpansion/clearTrailingThat.yml
@@ -17,8 +17,12 @@ initialState:
       active: {line: 1, character: 0}
   marks: {}
   thatMark:
-    - anchor: {line: 0, character: 10}
-      active: {line: 0, character: 10}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 10}
+        end: {line: 0, character: 10}
+      isReversed: false
+      hasExplicitRange: false
 finalState:
   documentContents: |
     helloWorldnow

--- a/src/test/suite/fixtures/recorded/implicitExpansion/cloneThat.yml
+++ b/src/test/suite/fixtures/recorded/implicitExpansion/cloneThat.yml
@@ -15,8 +15,12 @@ initialState:
       active: {line: 0, character: 0}
   marks: {}
   thatMark:
-    - anchor: {line: 0, character: 6}
-      active: {line: 0, character: 6}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 6}
+        end: {line: 0, character: 6}
+      isReversed: false
+      hasExplicitRange: false
 finalState:
   documentContents: |
     hello world

--- a/src/test/suite/fixtures/recorded/implicitExpansion/cloneThat2.yml
+++ b/src/test/suite/fixtures/recorded/implicitExpansion/cloneThat2.yml
@@ -16,8 +16,12 @@ initialState:
       active: {line: 2, character: 0}
   marks: {}
   thatMark:
-    - anchor: {line: 0, character: 6}
-      active: {line: 0, character: 11}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 6}
+        end: {line: 0, character: 11}
+      isReversed: false
+      hasExplicitRange: true
 finalState:
   documentContents: |+
     hello world

--- a/src/test/suite/fixtures/recorded/implicitExpansion/funkWrapThat.yml
+++ b/src/test/suite/fixtures/recorded/implicitExpansion/funkWrapThat.yml
@@ -17,8 +17,12 @@ initialState:
       active: {line: 1, character: 0}
   marks: {}
   thatMark:
-    - anchor: {line: 0, character: 23}
-      active: {line: 0, character: 23}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 23}
+        end: {line: 0, character: 23}
+      isReversed: false
+      hasExplicitRange: false
 finalState:
   documentContents: |
     function () {

--- a/src/test/suite/fixtures/recorded/implicitExpansion/funkWrapThat2.yml
+++ b/src/test/suite/fixtures/recorded/implicitExpansion/funkWrapThat2.yml
@@ -17,8 +17,12 @@ initialState:
       active: {line: 1, character: 0}
   marks: {}
   thatMark:
-    - anchor: {line: 0, character: 6}
-      active: {line: 0, character: 14}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 6}
+        end: {line: 0, character: 14}
+      isReversed: false
+      hasExplicitRange: true
 finalState:
   documentContents: |
     function () {

--- a/src/test/suite/fixtures/recorded/implicitExpansion/pourThat.yml
+++ b/src/test/suite/fixtures/recorded/implicitExpansion/pourThat.yml
@@ -16,8 +16,12 @@ initialState:
       active: {line: 2, character: 0}
   marks: {}
   thatMark:
-    - anchor: {line: 0, character: 6}
-      active: {line: 0, character: 6}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 6}
+        end: {line: 0, character: 6}
+      isReversed: false
+      hasExplicitRange: false
 finalState:
   documentContents: |+
     hello world

--- a/src/test/suite/fixtures/recorded/implicitExpansion/pourThat2.yml
+++ b/src/test/suite/fixtures/recorded/implicitExpansion/pourThat2.yml
@@ -16,8 +16,12 @@ initialState:
       active: {line: 2, character: 0}
   marks: {}
   thatMark:
-    - anchor: {line: 0, character: 6}
-      active: {line: 0, character: 11}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 6}
+        end: {line: 0, character: 11}
+      isReversed: false
+      hasExplicitRange: true
 finalState:
   documentContents: |+
     hello world

--- a/src/test/suite/fixtures/recorded/implicitExpansion/snipFunkAfterThat.yml
+++ b/src/test/suite/fixtures/recorded/implicitExpansion/snipFunkAfterThat.yml
@@ -21,8 +21,12 @@ initialState:
       active: {line: 0, character: 0}
   marks: {}
   thatMark:
-    - anchor: {line: 1, character: 27}
-      active: {line: 1, character: 27}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 27}
+        end: {line: 1, character: 27}
+      isReversed: false
+      hasExplicitRange: false
 finalState:
   documentContents: |
     function myFunction() {

--- a/src/test/suite/fixtures/recorded/implicitExpansion/snipFunkAfterThat2.yml
+++ b/src/test/suite/fixtures/recorded/implicitExpansion/snipFunkAfterThat2.yml
@@ -21,8 +21,12 @@ initialState:
       active: {line: 0, character: 0}
   marks: {}
   thatMark:
-    - anchor: {line: 1, character: 10}
-      active: {line: 1, character: 15}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 10}
+        end: {line: 1, character: 15}
+      isReversed: false
+      hasExplicitRange: true
 finalState:
   documentContents: |-
     function whatever() {

--- a/src/test/suite/fixtures/recorded/implicitExpansion/squareSwitchThat.yml
+++ b/src/test/suite/fixtures/recorded/implicitExpansion/squareSwitchThat.yml
@@ -17,8 +17,12 @@ initialState:
       active: {line: 1, character: 0}
   marks: {}
   thatMark:
-    - anchor: {line: 0, character: 7}
-      active: {line: 0, character: 7}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 7}
+        end: {line: 0, character: 7}
+      isReversed: false
+      hasExplicitRange: false
 finalState:
   documentContents: |
     [hello ]

--- a/src/test/suite/fixtures/recorded/implicitExpansion/squareSwitchThat2.yml
+++ b/src/test/suite/fixtures/recorded/implicitExpansion/squareSwitchThat2.yml
@@ -17,8 +17,12 @@ initialState:
       active: {line: 1, character: 0}
   marks: {}
   thatMark:
-    - anchor: {line: 0, character: 7}
-      active: {line: 0, character: 12}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 7}
+        end: {line: 0, character: 12}
+      isReversed: false
+      hasExplicitRange: true
 finalState:
   documentContents: |
     [hello world]

--- a/src/test/suite/fixtures/recorded/marks/takeSource.yml
+++ b/src/test/suite/fixtures/recorded/marks/takeSource.yml
@@ -14,8 +14,12 @@ initialState:
     - anchor: {line: 0, character: 5}
       active: {line: 0, character: 5}
   sourceMark:
-    - anchor: {line: 1, character: 6}
-      active: {line: 1, character: 11}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 6}
+        end: {line: 1, character: 11}
+      isReversed: false
+      hasExplicitRange: true
   marks: {}
 finalState:
   documentContents: |

--- a/src/test/suite/fixtures/recorded/marks/takeThat.yml
+++ b/src/test/suite/fixtures/recorded/marks/takeThat.yml
@@ -14,8 +14,12 @@ initialState:
     - anchor: {line: 0, character: 5}
       active: {line: 0, character: 5}
   thatMark:
-    - anchor: {line: 0, character: 0}
-      active: {line: 0, character: 5}
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 0}
+        end: {line: 0, character: 5}
+      isReversed: false
+      hasExplicitRange: true
   marks: {}
 finalState:
   documentContents: |

--- a/src/test/suite/recorded.test.ts
+++ b/src/test/suite/recorded.test.ts
@@ -5,6 +5,7 @@ import * as vscode from "vscode";
 import HatTokenMap from "../../core/HatTokenMap";
 import { ReadOnlyHatMap } from "../../core/IndividualHatMap";
 import { extractTargetedMarks } from "../../testUtil/extractTargetedMarks";
+import { plainObjectToTarget } from "../../testUtil/fromPlainObject";
 import serialize from "../../testUtil/serialize";
 import {
   ExcludableSnapshotField,
@@ -78,18 +79,17 @@ async function runTest(file: string) {
   editor.selections = fixture.initialState.selections.map(createSelection);
 
   if (fixture.initialState.thatMark) {
-    const initialThatMark = fixture.initialState.thatMark.map((mark) => ({
-      selection: createSelection(mark),
-      editor,
-    }));
-    cursorlessApi.thatMark.set(initialThatMark);
+    const initialThatTargets = fixture.initialState.thatMark.map((mark) =>
+      plainObjectToTarget(editor, mark)
+    );
+    cursorlessApi.thatMark.set(initialThatTargets);
   }
+
   if (fixture.initialState.sourceMark) {
-    const initialSourceMark = fixture.initialState.sourceMark.map((mark) => ({
-      selection: createSelection(mark),
-      editor,
-    }));
-    cursorlessApi.sourceMark.set(initialSourceMark);
+    const initialSourceTargets = fixture.initialState.sourceMark.map((mark) =>
+      plainObjectToTarget(editor, mark)
+    );
+    cursorlessApi.sourceMark.set(initialSourceTargets);
   }
 
   if (fixture.initialState.clipboard) {

--- a/src/testUtil/fromPlainObject.ts
+++ b/src/testUtil/fromPlainObject.ts
@@ -6,7 +6,6 @@ import {
   RangePlainObject,
   SelectionPlainObject,
   TargetPlainObject,
-  TARGET_DEFAULTS,
 } from "./toPlainObject";
 
 /**
@@ -19,22 +18,19 @@ import {
  * exception if we try to rehydrate anything other than an `UntypedTarget`.
  *
  * @param editor The editor where the target ranges are defined
- * @param partialPlainObject A plain object describing a `Target`
+ * @param plainObject A plain object describing a `Target`
  * @returns A `Target` constructed from the given plain object
  */
 export function plainObjectToTarget(
   editor: TextEditor,
-  partialPlainObject: TargetPlainObject
+  plainObject: TargetPlainObject
 ): Target {
-  const plainObject = { ...TARGET_DEFAULTS, ...partialPlainObject };
-
-  const contentRange = plainObjectToRange(plainObject.contentRange);
   switch (plainObject.type) {
     case "UntypedTarget":
       return new UntypedTarget({
         editor,
         isReversed: plainObject.isReversed,
-        contentRange,
+        contentRange: plainObjectToRange(plainObject.contentRange),
         hasExplicitRange: plainObject.hasExplicitRange,
       });
     default:

--- a/src/testUtil/fromPlainObject.ts
+++ b/src/testUtil/fromPlainObject.ts
@@ -1,0 +1,64 @@
+import { Position, Range, Selection, TextEditor } from "vscode";
+import { UntypedTarget } from "../processTargets/targets";
+import type { Target } from "../typings/target.types";
+import {
+  PositionPlainObject,
+  RangePlainObject,
+  SelectionPlainObject,
+  TargetPlainObject,
+  TARGET_DEFAULTS,
+} from "./toPlainObject";
+
+/**
+ * Given a plain object describing a target, constructs a `Target` object.
+ * Note that the target object today doesn't include a reference to an editor,
+ * because all of our recorded tests are on single editors, so we just construct
+ * a target where the ranges refer to {@link editor}.
+ *
+ * Note that this function is just a partial implementation today, throwing an
+ * exception if we try to rehydrate anything other than an `UntypedTarget`.
+ *
+ * @param editor The editor where the target ranges are defined
+ * @param partialPlainObject A plain object describing a `Target`
+ * @returns A `Target` constructed from the given plain object
+ */
+export function plainObjectToTarget(
+  editor: TextEditor,
+  partialPlainObject: TargetPlainObject
+): Target {
+  const plainObject = { ...TARGET_DEFAULTS, ...partialPlainObject };
+
+  const contentRange = plainObjectToRange(plainObject.contentRange);
+  switch (plainObject.type) {
+    case "UntypedTarget":
+      return new UntypedTarget({
+        editor,
+        isReversed: plainObject.isReversed,
+        contentRange,
+        hasExplicitRange: plainObject.hasExplicitRange,
+      });
+    default:
+      throw Error(`Unsupported target type ${plainObject.type}`);
+  }
+}
+
+export function plainObjectToPosition({
+  line,
+  character,
+}: PositionPlainObject): Position {
+  return new Position(line, character);
+}
+
+export function plainObjectToRange({ start, end }: RangePlainObject): Range {
+  return new Range(plainObjectToPosition(start), plainObjectToPosition(end));
+}
+
+export function plainObjectToSelection({
+  anchor,
+  active,
+}: SelectionPlainObject): Selection {
+  return new Selection(
+    plainObjectToPosition(anchor),
+    plainObjectToPosition(active)
+  );
+}

--- a/src/testUtil/takeSnapshot.ts
+++ b/src/testUtil/takeSnapshot.ts
@@ -8,6 +8,8 @@ import {
   SelectionPlainObject,
   selectionToPlainObject,
   SerializedMarks,
+  TargetPlainObject,
+  targetToPlainObject,
 } from "./toPlainObject";
 
 export type ExtraSnapshotField = keyof TestCaseSnapshot;
@@ -21,8 +23,8 @@ export type TestCaseSnapshot = {
   // https://github.com/cursorless-dev/cursorless/issues/160
   visibleRanges?: RangePlainObject[];
   marks?: SerializedMarks;
-  thatMark?: SelectionPlainObject[];
-  sourceMark?: SelectionPlainObject[];
+  thatMark?: TargetPlainObject[];
+  sourceMark?: TargetPlainObject[];
   timeOffsetSeconds?: number;
 
   /**
@@ -72,9 +74,7 @@ export async function takeSnapshot(
     thatMark.exists() &&
     !excludeFields.includes("thatMark")
   ) {
-    snapshot.thatMark = thatMark
-      .get()
-      .map((mark) => selectionToPlainObject(mark.selection));
+    snapshot.thatMark = thatMark.get().map(targetToPlainObject);
   }
 
   if (
@@ -82,9 +82,7 @@ export async function takeSnapshot(
     sourceMark.exists() &&
     !excludeFields.includes("sourceMark")
   ) {
-    snapshot.sourceMark = sourceMark
-      .get()
-      .map((mark) => selectionToPlainObject(mark.selection));
+    snapshot.sourceMark = sourceMark.get().map(targetToPlainObject);
   }
 
   if (extraFields.includes("timeOffsetSeconds")) {

--- a/src/testUtil/toPlainObject.ts
+++ b/src/testUtil/toPlainObject.ts
@@ -29,10 +29,9 @@ export type SelectionPlainObject = {
  */
 export type TargetPlainObject = {
   /**
-   * The type name of the target, eg `UntypedTarget`. If excluded, assumed to be
-   * `"UntypedTarget"`.
+   * The type name of the target, eg `UntypedTarget`.
    */
-  type?: string;
+  type: string;
 
   /**
    * Corresponds to {@link Target.contentRange}
@@ -40,36 +39,15 @@ export type TargetPlainObject = {
   contentRange: RangePlainObject;
 
   /**
-   * Corresponds to {@link Target.isReversed}.  If excluded, assumed to be `false`.
+   * Corresponds to {@link Target.isReversed}.
    */
-  isReversed?: boolean;
+  isReversed: boolean;
 
   /**
-   * Corresponds to {@link Target.hasExplicitRange}.  If excluded, assumed to
-   * be `true`.
+   * Corresponds to {@link Target.hasExplicitRange}.
    */
-  hasExplicitRange?: boolean;
+  hasExplicitRange: boolean;
 };
-
-/**
- * Returns an object including only the optional fields of {@link T}
- */
-type GetOptional<T> = {
-  [K in keyof T as Pick<T, K> extends Required<Pick<T, K>> ? never : K]: T[K];
-};
-
-/**
- * For concision, any fields in a {@link TargetPlainObject} which are equal to
- * the default value from this object will be excluded from serialisation.  We
- * re-insert these default values during deserialisation.
- */
-export const TARGET_DEFAULTS: Required<GetOptional<TargetPlainObject>> = {
-  type: "UntypedTarget",
-  isReversed: false,
-  hasExplicitRange: true,
-};
-
-export type KeyWithDefault = Exclude<keyof typeof TARGET_DEFAULTS, "type">;
 
 export type SerializedMarks = {
   [decoratedCharacter: string]: RangePlainObject;
@@ -98,28 +76,16 @@ export function selectionToPlainObject(
  * object is not an un typed target if it is not, via the {@link type}
  * attribute.
  *
- * Note that we exclude any attributes that are equal to their value in
- * {@link TARGET_DEFAULTS} for concision.
- *
  * @param target The target to convert to a plain object
  * @returns A plain object that can be json serialized
  */
 export function targetToPlainObject(target: Target): TargetPlainObject {
-  const returnValue = {
+  return {
     type: target.constructor.name,
     contentRange: rangeToPlainObject(target.contentRange),
     isReversed: target.isReversed,
     hasExplicitRange: target.hasExplicitRange,
   };
-
-  // To remove any entries that are equal to their defaults for concision
-  for (const [key, defaultValue] of Object.entries(TARGET_DEFAULTS)) {
-    if (returnValue[key as KeyWithDefault] === defaultValue) {
-      delete returnValue[key as KeyWithDefault];
-    }
-  }
-
-  return returnValue;
 }
 
 export function positionToPlainObject({

--- a/src/testUtil/toPlainObject.ts
+++ b/src/testUtil/toPlainObject.ts
@@ -1,5 +1,6 @@
-import { Selection, Position, Range } from "vscode";
+import { Position, Range, Selection } from "vscode";
 import { TestDecoration } from "../core/editStyles";
+import type { Target } from "../typings/target.types";
 import { Token } from "../typings/Types";
 
 export type PositionPlainObject = {
@@ -16,6 +17,59 @@ export type SelectionPlainObject = {
   anchor: PositionPlainObject;
   active: PositionPlainObject;
 };
+
+/**
+ * Type for a plain object representing a {@link Target}, to be used for
+ * serialization via json.  Note that this definition is still quite incomplete,
+ * as it is missing a lot of attributes, so today can only properly round-trip
+ * an `UntypedTarget`, but for other types it at least captures the fact that
+ * they are not `UntypedTargets`, so we can use to check that actions return
+ * rich targets, even if we don't check everything about the target, and we
+ * can't use it to construct rich targets as inputs to actions in tests.
+ */
+export type TargetPlainObject = {
+  /**
+   * The type name of the target, eg `UntypedTarget`. If excluded, assumed to be
+   * `"UntypedTarget"`.
+   */
+  type?: string;
+
+  /**
+   * Corresponds to {@link Target.contentRange}
+   */
+  contentRange: RangePlainObject;
+
+  /**
+   * Corresponds to {@link Target.isReversed}.  If excluded, assumed to be `false`.
+   */
+  isReversed?: boolean;
+
+  /**
+   * Corresponds to {@link Target.hasExplicitRange}.  If excluded, assumed to
+   * be `true`.
+   */
+  hasExplicitRange?: boolean;
+};
+
+/**
+ * Returns an object including only the optional fields of {@link T}
+ */
+type GetOptional<T> = {
+  [K in keyof T as Pick<T, K> extends Required<Pick<T, K>> ? never : K]: T[K];
+};
+
+/**
+ * For concision, any fields in a {@link TargetPlainObject} which are equal to
+ * the default value from this object will be excluded from serialisation.  We
+ * re-insert these default values during deserialisation.
+ */
+export const TARGET_DEFAULTS: Required<GetOptional<TargetPlainObject>> = {
+  type: "UntypedTarget",
+  isReversed: false,
+  hasExplicitRange: true,
+};
+
+export type KeyWithDefault = Exclude<keyof typeof TARGET_DEFAULTS, "type">;
 
 export type SerializedMarks = {
   [decoratedCharacter: string]: RangePlainObject;
@@ -37,8 +91,42 @@ export function selectionToPlainObject(
   };
 }
 
-export function positionToPlainObject(position: Position): PositionPlainObject {
-  return { line: position.line, character: position.character };
+/**
+ * Given a target, constructs an object suitable for serialization by json. Note
+ * that this implementation is quite incomplete, but is suitable for
+ * round-tripping {@link UntypedTarget} objects and capturing the fact that an
+ * object is not an un typed target if it is not, via the {@link type}
+ * attribute.
+ *
+ * Note that we exclude any attributes that are equal to their value in
+ * {@link TARGET_DEFAULTS} for concision.
+ *
+ * @param target The target to convert to a plain object
+ * @returns A plain object that can be json serialized
+ */
+export function targetToPlainObject(target: Target): TargetPlainObject {
+  const returnValue = {
+    type: target.constructor.name,
+    contentRange: rangeToPlainObject(target.contentRange),
+    isReversed: target.isReversed,
+    hasExplicitRange: target.hasExplicitRange,
+  };
+
+  // To remove any entries that are equal to their defaults for concision
+  for (const [key, defaultValue] of Object.entries(TARGET_DEFAULTS)) {
+    if (returnValue[key as KeyWithDefault] === defaultValue) {
+      delete returnValue[key as KeyWithDefault];
+    }
+  }
+
+  return returnValue;
+}
+
+export function positionToPlainObject({
+  line,
+  character,
+}: Position): PositionPlainObject {
+  return { line, character };
 }
 
 export function marksToPlainObject(marks: {

--- a/src/typings/Types.ts
+++ b/src/typings/Types.ts
@@ -17,6 +17,7 @@ import { IDE } from "../ide/ide.types";
 import { ModifierStage } from "../processTargets/PipelineStages.types";
 import { TestCaseRecorder } from "../testUtil/TestCaseRecorder";
 import { CommandServerApi } from "../util/getExtensionApi";
+import { Target } from "./target.types";
 import { FullRangeInfo } from "./updateSelections";
 
 /**
@@ -41,8 +42,8 @@ export interface ProcessedTargetsContext {
   currentSelections: SelectionWithEditor[];
   currentEditor: vscode.TextEditor | undefined;
   hatTokenMap: ReadOnlyHatMap;
-  thatMark: SelectionWithEditor[];
-  sourceMark: SelectionWithEditor[];
+  thatMark: Target[];
+  sourceMark: Target[];
   getNodeAtLocation: (location: Location) => SyntaxNode;
 }
 


### PR DESCRIPTION
This PR is the first step towards adding smarter `that` marks (#466).  It adds the infrastructure so that actions can return smarter `that` marks, and allows us to test this behaviour, but for readability, it doesn't actually modify any targets to return smarter `that` marks.  Thus, this PR doesn't actually change Cursorless functionally at all.

See also #965, which builds on this PR to add rich targets to a few easy actions

This PR builds on #967

## Checklist

- [x] Stop removing fields equal to their defaults
- [x] Add new PR which removes `that` mark from all tests except for tests in `action/` directory and makes that mark optional in recorded tests
- [x] Add new PR which adds support for excluding / including that marks in tests (defaults to excluding), adds ability to include recording test config in a directory, adding config to include that marks in action directory.  Make it recursive with parents
- [x] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
