### PR TITLE
Smarter `that` marks for easy actions

### DIFF
--- a/src/actions/CommandAction.ts
+++ b/src/actions/CommandAction.ts
@@ -1,5 +1,6 @@
 import { flatten } from "lodash";
 import { commands, window } from "vscode";
+import { selectionToThatTarget } from "../core/commandRunner/selectionToThatTarget";
 import { callFunctionAndUpdateSelections } from "../core/updateSelections/updateSelections";
 import { Target } from "../typings/target.types";
 import { Graph } from "../typings/Types";
@@ -40,10 +41,11 @@ export default class CommandAction implements Action {
   private async runCommandAndUpdateSelections(
     targets: Target[],
     options: Required<CommandOptions>
-  ) {
+  ): Promise<Target[]> {
     return flatten(
       await runOnTargetsForEachEditor(targets, async (editor, targets) => {
         const originalSelections = editor.selections;
+        const originalEditorVersion = editor.document.version;
 
         const targetSelections = targets.map(
           (target) => target.contentSelection
@@ -70,10 +72,17 @@ export default class CommandAction implements Action {
           setSelectionsWithoutFocusingEditor(editor, updatedOriginalSelections);
         }
 
-        return updatedTargetSelections.map((selection) => ({
-          editor,
-          selection,
-        }));
+        // If the document hasn't changed then we just return the original targets
+        // so that we preserve their rich types, but if it has changed then we
+        // just downgrade them to untyped targets
+        return editor.document.version === originalEditorVersion
+          ? targets
+          : updatedTargetSelections.map((selection) =>
+              selectionToThatTarget({
+                editor,
+                selection,
+              })
+            );
       })
     );
   }
@@ -112,7 +121,7 @@ export default class CommandAction implements Action {
 
     const originalEditor = window.activeTextEditor;
 
-    const thatMark = await this.runCommandAndUpdateSelections(
+    const thatTargets = await this.runCommandAndUpdateSelections(
       targets,
       actualOptions
     );
@@ -129,6 +138,6 @@ export default class CommandAction implements Action {
       await focusEditor(originalEditor);
     }
 
-    return { thatSelections: thatMark };
+    return { thatTargets };
   }
 }

--- a/src/actions/Deselect.ts
+++ b/src/actions/Deselect.ts
@@ -2,7 +2,7 @@ import { Selection } from "vscode";
 import { Target } from "../typings/target.types";
 import { Graph } from "../typings/Types";
 import { setSelectionsWithoutFocusingEditor } from "../util/setSelectionsAndFocusEditor";
-import { createThatMark, runOnTargetsForEachEditor } from "../util/targetUtils";
+import { runOnTargetsForEachEditor } from "../util/targetUtils";
 import { Action, ActionReturnValue } from "./actions.types";
 
 export default class Deselect implements Action {
@@ -30,7 +30,7 @@ export default class Deselect implements Action {
     });
 
     return {
-      thatSelections: createThatMark(targets),
+      thatTargets: targets,
     };
   }
 }

--- a/src/actions/Find.ts
+++ b/src/actions/Find.ts
@@ -14,13 +14,13 @@ export class FindInFiles implements Action {
 
     const {
       returnValue: [query],
-      thatSelections: thatMark,
+      thatTargets,
     } = await this.graph.actions.getText.run([targets]);
 
     await commands.executeCommand("workbench.action.findInFiles", {
       query,
     });
 
-    return { thatSelections: thatMark };
+    return { thatTargets };
   }
 }

--- a/src/actions/GetText.ts
+++ b/src/actions/GetText.ts
@@ -1,6 +1,6 @@
 import { Target } from "../typings/target.types";
 import { Graph } from "../typings/Types";
-import { createThatMark, ensureSingleTarget } from "../util/targetUtils";
+import { ensureSingleTarget } from "../util/targetUtils";
 import { Action, ActionReturnValue } from "./actions.types";
 
 export default class GetText implements Action {
@@ -28,7 +28,7 @@ export default class GetText implements Action {
 
     return {
       returnValue: targets.map((target) => target.contentText),
-      thatSelections: createThatMark(targets),
+      thatTargets: targets,
     };
   }
 }

--- a/src/actions/Highlight.ts
+++ b/src/actions/Highlight.ts
@@ -1,7 +1,6 @@
 import { EditStyleName } from "../core/editStyles";
 import { Target } from "../typings/target.types";
 import { Graph } from "../typings/Types";
-import { createThatMark } from "../util/targetUtils";
 import { Action, ActionReturnValue } from "./actions.types";
 
 export default class Highlight implements Action {
@@ -19,7 +18,7 @@ export default class Highlight implements Action {
     await this.graph.editStyles.setDecorations(targets, style);
 
     return {
-      thatSelections: createThatMark(targets),
+      thatTargets: targets,
     };
   }
 }

--- a/src/actions/Scroll.ts
+++ b/src/actions/Scroll.ts
@@ -3,7 +3,6 @@ import { Target } from "../typings/target.types";
 import { Graph } from "../typings/Types";
 import { groupBy } from "../util/itertools";
 import { focusEditor } from "../util/setSelectionsAndFocusEditor";
-import { createThatMark } from "../util/targetUtils";
 import { Action, ActionReturnValue } from "./actions.types";
 
 class Scroll implements Action {
@@ -56,7 +55,7 @@ class Scroll implements Action {
     );
 
     return {
-      thatSelections: createThatMark(targets),
+      thatTargets: targets,
     };
   }
 }

--- a/src/actions/SetSelection.ts
+++ b/src/actions/SetSelection.ts
@@ -2,7 +2,7 @@ import { Selection } from "vscode";
 import { Target } from "../typings/target.types";
 import { Graph } from "../typings/Types";
 import { setSelectionsAndFocusEditor } from "../util/setSelectionsAndFocusEditor";
-import { createThatMark, ensureSingleEditor } from "../util/targetUtils";
+import { ensureSingleEditor } from "../util/targetUtils";
 import { Action, ActionReturnValue } from "./actions.types";
 
 export class SetSelection implements Action {
@@ -21,7 +21,7 @@ export class SetSelection implements Action {
     await setSelectionsAndFocusEditor(editor, selections);
 
     return {
-      thatSelections: createThatMark(targets),
+      thatTargets: targets,
     };
   }
 }

--- a/src/actions/ToggleBreakpoint.ts
+++ b/src/actions/ToggleBreakpoint.ts
@@ -9,7 +9,6 @@ import {
 import { containingLineIfUntypedStage } from "../processTargets/modifiers/commonContainingScopeIfUntypedStages";
 import { Target } from "../typings/target.types";
 import { Graph } from "../typings/Types";
-import { createThatMark } from "../util/targetUtils";
 import { Action, ActionReturnValue } from "./actions.types";
 
 function getBreakpoints(uri: Uri, range: Range) {
@@ -61,7 +60,7 @@ export default class ToggleBreakpoint implements Action {
     debug.removeBreakpoints(toRemove);
 
     return {
-      thatSelections: createThatMark(thatTargets),
+      thatTargets: targets,
     };
   }
 }

--- a/src/test/suite/fixtures/recorded/actions/copyVest.yml
+++ b/src/test/suite/fixtures/recorded/actions/copyVest.yml
@@ -32,5 +32,5 @@ finalState:
         start: {line: 1, character: 6}
         end: {line: 1, character: 11}
       isReversed: false
-      hasExplicitRange: true
+      hasExplicitRange: false
 fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: v}, selectionType: token, position: contents, modifier: {type: identity}, insideOutsideType: inside}]

--- a/src/test/suite/fixtures/recorded/actions/defineVest.yml
+++ b/src/test/suite/fixtures/recorded/actions/defineVest.yml
@@ -35,5 +35,5 @@ finalState:
         start: {line: 2, character: 12}
         end: {line: 2, character: 17}
       isReversed: false
-      hasExplicitRange: true
+      hasExplicitRange: false
 fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: v}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: identity}}]

--- a/src/test/suite/fixtures/recorded/actions/findVest.yml
+++ b/src/test/suite/fixtures/recorded/actions/findVest.yml
@@ -32,6 +32,6 @@ finalState:
         start: {line: 1, character: 6}
         end: {line: 1, character: 11}
       isReversed: false
-      hasExplicitRange: true
+      hasExplicitRange: false
 returnValue: [value]
 fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: v}, selectionType: token, position: contents, modifier: {type: identity}, insideOutsideType: inside}]

--- a/src/test/suite/fixtures/recorded/actions/giveAfterDot.yml
+++ b/src/test/suite/fixtures/recorded/actions/giveAfterDot.yml
@@ -28,10 +28,10 @@ finalState:
     - anchor: {line: 0, character: 3}
       active: {line: 0, character: 3}
   thatMark:
-    - type: UntypedTarget
+    - type: PositionTarget
       contentRange:
         start: {line: 0, character: 4}
         end: {line: 0, character: 4}
       isReversed: false
-      hasExplicitRange: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: .}, selectionType: token, position: after, insideOutsideType: inside, modifier: {type: identity}}]

--- a/src/test/suite/fixtures/recorded/actions/giveAirAndBang.yml
+++ b/src/test/suite/fixtures/recorded/actions/giveAirAndBang.yml
@@ -39,11 +39,11 @@ finalState:
         start: {line: 0, character: 1}
         end: {line: 0, character: 2}
       isReversed: false
-      hasExplicitRange: true
+      hasExplicitRange: false
     - type: UntypedTarget
       contentRange:
         start: {line: 0, character: 2}
         end: {line: 0, character: 3}
       isReversed: false
-      hasExplicitRange: true
+      hasExplicitRange: false
 fullTargets: [{type: list, elements: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: a}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: identity}}, {type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: '!'}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: identity}}]}]

--- a/src/test/suite/fixtures/recorded/actions/giveBat.yml
+++ b/src/test/suite/fixtures/recorded/actions/giveBat.yml
@@ -28,5 +28,5 @@ finalState:
         start: {line: 0, character: 2}
         end: {line: 0, character: 3}
       isReversed: false
-      hasExplicitRange: true
+      hasExplicitRange: false
 fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: b}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: identity}}]

--- a/src/test/suite/fixtures/recorded/actions/giveBat2.yml
+++ b/src/test/suite/fixtures/recorded/actions/giveBat2.yml
@@ -28,5 +28,5 @@ finalState:
         start: {line: 0, character: 2}
         end: {line: 0, character: 3}
       isReversed: false
-      hasExplicitRange: true
+      hasExplicitRange: false
 fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: b}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: identity}}]

--- a/src/test/suite/fixtures/recorded/actions/giveBeforeDot.yml
+++ b/src/test/suite/fixtures/recorded/actions/giveBeforeDot.yml
@@ -28,10 +28,10 @@ finalState:
     - anchor: {line: 0, character: 4}
       active: {line: 0, character: 4}
   thatMark:
-    - type: UntypedTarget
+    - type: PositionTarget
       contentRange:
         start: {line: 0, character: 3}
         end: {line: 0, character: 3}
       isReversed: false
-      hasExplicitRange: false
+      hasExplicitRange: true
 fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: .}, selectionType: token, position: before, insideOutsideType: inside, modifier: {type: identity}}]

--- a/src/test/suite/fixtures/recorded/actions/giveBlueQuote.yml
+++ b/src/test/suite/fixtures/recorded/actions/giveBlueQuote.yml
@@ -34,5 +34,5 @@ finalState:
         start: {line: 0, character: 6}
         end: {line: 0, character: 7}
       isReversed: false
-      hasExplicitRange: true
+      hasExplicitRange: false
 fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: blue, character: '"'}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: identity}}]

--- a/src/test/suite/fixtures/recorded/actions/giveBlueQuoteAndQuote.yml
+++ b/src/test/suite/fixtures/recorded/actions/giveBlueQuoteAndQuote.yml
@@ -39,11 +39,11 @@ finalState:
         start: {line: 0, character: 6}
         end: {line: 0, character: 7}
       isReversed: false
-      hasExplicitRange: true
+      hasExplicitRange: false
     - type: UntypedTarget
       contentRange:
         start: {line: 0, character: 0}
         end: {line: 0, character: 1}
       isReversed: false
-      hasExplicitRange: true
+      hasExplicitRange: false
 fullTargets: [{type: list, elements: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: blue, character: '"'}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: identity}}, {type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: '"'}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: identity}}]}]

--- a/src/test/suite/fixtures/recorded/actions/giveCap.yml
+++ b/src/test/suite/fixtures/recorded/actions/giveCap.yml
@@ -28,5 +28,5 @@ finalState:
         start: {line: 0, character: 4}
         end: {line: 0, character: 5}
       isReversed: false
-      hasExplicitRange: true
+      hasExplicitRange: false
 fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: c}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: identity}}]

--- a/src/test/suite/fixtures/recorded/actions/giveDot.yml
+++ b/src/test/suite/fixtures/recorded/actions/giveDot.yml
@@ -28,5 +28,5 @@ finalState:
         start: {line: 0, character: 3}
         end: {line: 0, character: 4}
       isReversed: false
-      hasExplicitRange: true
+      hasExplicitRange: false
 fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: .}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: identity}}]

--- a/src/test/suite/fixtures/recorded/actions/giveDot2.yml
+++ b/src/test/suite/fixtures/recorded/actions/giveDot2.yml
@@ -30,5 +30,5 @@ finalState:
         start: {line: 0, character: 3}
         end: {line: 0, character: 4}
       isReversed: false
-      hasExplicitRange: true
+      hasExplicitRange: false
 fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: .}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: identity}}]

--- a/src/test/suite/fixtures/recorded/actions/giveDrum.yml
+++ b/src/test/suite/fixtures/recorded/actions/giveDrum.yml
@@ -28,5 +28,5 @@ finalState:
         start: {line: 0, character: 6}
         end: {line: 0, character: 7}
       isReversed: false
-      hasExplicitRange: true
+      hasExplicitRange: false
 fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: d}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: identity}}]

--- a/src/test/suite/fixtures/recorded/actions/giveHarp.yml
+++ b/src/test/suite/fixtures/recorded/actions/giveHarp.yml
@@ -34,5 +34,5 @@ finalState:
         start: {line: 0, character: 1}
         end: {line: 0, character: 6}
       isReversed: false
-      hasExplicitRange: true
+      hasExplicitRange: false
 fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: h}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: identity}}]

--- a/src/test/suite/fixtures/recorded/actions/giveHarpAndWhale.yml
+++ b/src/test/suite/fixtures/recorded/actions/giveHarpAndWhale.yml
@@ -35,11 +35,11 @@ finalState:
         start: {line: 0, character: 0}
         end: {line: 0, character: 5}
       isReversed: false
-      hasExplicitRange: true
+      hasExplicitRange: false
     - type: UntypedTarget
       contentRange:
         start: {line: 0, character: 6}
         end: {line: 0, character: 11}
       isReversed: false
-      hasExplicitRange: true
+      hasExplicitRange: false
 fullTargets: [{type: list, elements: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: h}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: identity}}, {type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: w}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: identity}}]}]

--- a/src/test/suite/fixtures/recorded/actions/giveQuote.yml
+++ b/src/test/suite/fixtures/recorded/actions/giveQuote.yml
@@ -34,5 +34,5 @@ finalState:
         start: {line: 0, character: 0}
         end: {line: 0, character: 1}
       isReversed: false
-      hasExplicitRange: true
+      hasExplicitRange: false
 fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: '"'}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: identity}}]

--- a/src/test/suite/fixtures/recorded/actions/giveQuoteAndAir.yml
+++ b/src/test/suite/fixtures/recorded/actions/giveQuoteAndAir.yml
@@ -39,11 +39,11 @@ finalState:
         start: {line: 0, character: 0}
         end: {line: 0, character: 1}
       isReversed: false
-      hasExplicitRange: true
+      hasExplicitRange: false
     - type: UntypedTarget
       contentRange:
         start: {line: 0, character: 1}
         end: {line: 0, character: 2}
       isReversed: false
-      hasExplicitRange: true
+      hasExplicitRange: false
 fullTargets: [{type: list, elements: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: '"'}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: identity}}, {type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: a}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: identity}}]}]

--- a/src/test/suite/fixtures/recorded/actions/giveQuoteAndBang.yml
+++ b/src/test/suite/fixtures/recorded/actions/giveQuoteAndBang.yml
@@ -39,11 +39,11 @@ finalState:
         start: {line: 0, character: 0}
         end: {line: 0, character: 1}
       isReversed: false
-      hasExplicitRange: true
+      hasExplicitRange: false
     - type: UntypedTarget
       contentRange:
         start: {line: 0, character: 2}
         end: {line: 0, character: 3}
       isReversed: false
-      hasExplicitRange: true
+      hasExplicitRange: false
 fullTargets: [{type: list, elements: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: '"'}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: identity}}, {type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: '!'}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: identity}}]}]

--- a/src/test/suite/fixtures/recorded/actions/giveVestAndHarp.yml
+++ b/src/test/suite/fixtures/recorded/actions/giveVestAndHarp.yml
@@ -43,11 +43,11 @@ finalState:
         start: {line: 0, character: 6}
         end: {line: 0, character: 12}
       isReversed: false
-      hasExplicitRange: true
+      hasExplicitRange: false
     - type: UntypedTarget
       contentRange:
         start: {line: 0, character: 24}
         end: {line: 0, character: 29}
       isReversed: false
-      hasExplicitRange: true
+      hasExplicitRange: false
 fullTargets: [{type: list, elements: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: v}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: identity}}, {type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: h}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: identity}}]}]

--- a/src/test/suite/fixtures/recorded/actions/postVest.yml
+++ b/src/test/suite/fixtures/recorded/actions/postVest.yml
@@ -30,5 +30,5 @@ finalState:
         start: {line: 1, character: 6}
         end: {line: 1, character: 11}
       isReversed: false
-      hasExplicitRange: true
+      hasExplicitRange: false
 fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: v}, selectionType: token, position: contents, modifier: {type: identity}, insideOutsideType: inside}]

--- a/src/test/suite/fixtures/recorded/actions/preeVest.yml
+++ b/src/test/suite/fixtures/recorded/actions/preeVest.yml
@@ -30,5 +30,5 @@ finalState:
         start: {line: 1, character: 6}
         end: {line: 1, character: 11}
       isReversed: false
-      hasExplicitRange: true
+      hasExplicitRange: false
 fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: v}, selectionType: token, position: contents, modifier: {type: identity}, insideOutsideType: inside}]

--- a/src/test/suite/fixtures/recorded/actions/reformatHarpAsSnake.yml
+++ b/src/test/suite/fixtures/recorded/actions/reformatHarpAsSnake.yml
@@ -32,6 +32,6 @@ finalState:
         start: {line: 1, character: 15}
         end: {line: 1, character: 25}
       isReversed: false
-      hasExplicitRange: true
+      hasExplicitRange: false
 returnValue: [helloWorld]
 fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: h}, selectionType: token, position: contents, modifier: {type: identity}, insideOutsideType: inside}]

--- a/src/test/suite/fixtures/recorded/actions/takeVest.yml
+++ b/src/test/suite/fixtures/recorded/actions/takeVest.yml
@@ -30,5 +30,5 @@ finalState:
         start: {line: 1, character: 6}
         end: {line: 1, character: 11}
       isReversed: false
-      hasExplicitRange: true
+      hasExplicitRange: false
 fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: v}, selectionType: token, position: contents, modifier: {type: identity}, insideOutsideType: inside}]

--- a/src/test/suite/fixtures/recorded/decorations/highlightFine.yml
+++ b/src/test/suite/fixtures/recorded/decorations/highlightFine.yml
@@ -33,7 +33,7 @@ finalState:
         start: {line: 1, character: 4}
         end: {line: 1, character: 7}
       isReversed: false
-      hasExplicitRange: true
+      hasExplicitRange: false
 decorations:
   - name: highlight0Background
     type: token

--- a/src/test/suite/fixtures/recorded/decorations/highlightLineFine.yml
+++ b/src/test/suite/fixtures/recorded/decorations/highlightLineFine.yml
@@ -31,7 +31,7 @@ finalState:
     - anchor: {line: 0, character: 0}
       active: {line: 0, character: 0}
   thatMark:
-    - type: UntypedTarget
+    - type: LineTarget
       contentRange:
         start: {line: 1, character: 4}
         end: {line: 1, character: 7}


### PR DESCRIPTION
This PR partially implements #466 by adding smarter `that` marks for actions where it is easy to do so, because they don't modify the target.  It adds rich targets to the following actions:

- `"highlight"`
- `"take"`
- Any action that uses `CommandAction` that doesn't modify the document, eg `"hover"`

## Checklist

- [x] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
