### PR TITLE
Handle tests with no final `that` mark

### DIFF
--- a/src/test/suite/recorded.test.ts
+++ b/src/test/suite/recorded.test.ts
@@ -164,6 +164,14 @@ async function runTest(file: string) {
     excludeFields.push("clipboard");
   }
 
+  if (fixture.finalState!.thatMark == null) {
+    excludeFields.push("thatMark");
+  }
+
+  if (fixture.finalState!.sourceMark == null) {
+    excludeFields.push("sourceMark");
+  }
+
   // TODO Visible ranges are not asserted, see:
   // https://github.com/cursorless-dev/cursorless/issues/160
   const { visibleRanges, ...resultState } = await takeSnapshot(


### PR DESCRIPTION
This PR just lays the ground work for #967 by adding support for tests that don't include a final `that` mark.

## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
