### PR TITLE
tokenizer: use the new dashed identifier tokenizer for Talon files

### DIFF
--- a/src/core/tokenizer.ts
+++ b/src/core/tokenizer.ts
@@ -98,6 +98,7 @@ const languageTokenizerOverrides: Partial<
   css: languageWithDashedIdentifiers,
   scss: languageWithDashedIdentifiers,
   shellscript: languageWithDashedIdentifiers,
+  talon: languageWithDashedIdentifiers,
 };
 
 const tokenMatchersForLanguage: Partial<Record<LanguageId, RegExp>> = mapValues(

--- a/src/languages/constants.ts
+++ b/src/languages/constants.ts
@@ -29,7 +29,7 @@ export const supportedLanguageIds = [
  * Other language IDs that we might reference (e.g., for token customization)
  * but don't have full tree-sitter support for yet.
  */
-export const otherLanguageIds = ["shellscript"] as const;
+export const otherLanguageIds = ["shellscript", "talon"] as const;
 
 export const allLanguageIds = [...supportedLanguageIds, ...otherLanguageIds];
 


### PR DESCRIPTION
Dash-separated words are valid inside of Talonscript (e.g. inside of key shortcuts), so I think they should probably use the new dashed tokenizer.

#### Before:

<img width="192" alt="Screen Shot 2022-10-01 at 3 37 39 PM" src="https://user-images.githubusercontent.com/536668/193431023-b2dd1985-68cb-4029-a2d7-605b3576c666.png">

#### After:

<img width="208" alt="Screen Shot 2022-10-01 at 3 47 01 PM" src="https://user-images.githubusercontent.com/536668/193431025-27ec9734-a430-4149-bb3a-21b236d43304.png">

## Advantages:

You get the cleanup logic of the subword tokenizer, so you can say "check second word" on:

```
key(cmd-shift-2)
```

and it becomes:

```
key(cmd-2)
```

Or, with "chuck first word":

```
key(cmd-shift-2)
```

and it becomes:

```
key(shift-2)
```

It reduces the number of hats needed, increasing the likelihood that other tokens are addressable.

Lastly, I find that it's more intuitive for these to be read as a single token, because they are valid value types in the language. This is similar to Bash, where you can do `./foo bar-baz`; in my head, `bar-baz` is one token. But I've learned this is not universally shared -- @AndreasArvidsson disagrees.

## Disadvantages:

You'd have to say "change second word \<token\>" instead of just "change \<other token\>".

Subtraction of tokens without spaces between them (`a-b`) would incorrectly be marked as a single token. I think this is quite rare since most people don't subtraction within Talon files and automatic formatting is becoming more common.