### PR TITLE
Workaround for `number_small` performance on old knausj version

### DIFF
--- a/cursorless-talon/src/marks/lines_number.py
+++ b/cursorless-talon/src/marks/lines_number.py
@@ -37,16 +37,17 @@ DEFAULT_DIRECTIONS = {d.defaultSpokenForm: d.cursorlessIdentifier for d in direc
 
 
 @mod.capture(
-    rule="{user.cursorless_line_direction} <number_small> [{user.cursorless_range_connective} <number_small>]"
+    rule="{user.cursorless_line_direction} <user.private_cursorless_number_small> [{user.cursorless_range_connective} <user.private_cursorless_number_small>]"
 )
 def cursorless_line_number(m) -> dict[str, Any]:
     direction = directions_map[m.cursorless_line_direction]
     anchor = create_line_number_mark(
-        direction.type, direction.formatter(m.number_small_list[0])
+        direction.type, direction.formatter(m.private_cursorless_number_small_list[0])
     )
-    if len(m.number_small_list) > 1:
+    if len(m.private_cursorless_number_small_list) > 1:
         active = create_line_number_mark(
-            direction.type, direction.formatter(m.number_small_list[1])
+            direction.type,
+            direction.formatter(m.private_cursorless_number_small_list[1]),
         )
         include_anchor = is_anchor_included(m.cursorless_range_connective)
         include_active = is_active_included(m.cursorless_range_connective)

--- a/cursorless-talon/src/modifiers/ordinal_scope.py
+++ b/cursorless-talon/src/modifiers/ordinal_scope.py
@@ -48,16 +48,18 @@ def cursorless_ordinal_range(m) -> dict[str, Any]:
 
 
 @mod.capture(
-    rule="({user.cursorless_first_modifier} | {user.cursorless_last_modifier}) <number_small> <user.cursorless_scope_type_plural>"
+    rule="({user.cursorless_first_modifier} | {user.cursorless_last_modifier}) <user.private_cursorless_number_small> <user.cursorless_scope_type_plural>"
 )
 def cursorless_first_last(m) -> dict[str, Any]:
     """First/last `n` scopes; eg "first three funks"""
     if m[0] == "first":
         return create_ordinal_scope_modifier(
-            m.cursorless_scope_type_plural, 0, m.number_small
+            m.cursorless_scope_type_plural, 0, m.private_cursorless_number_small
         )
     return create_ordinal_scope_modifier(
-        m.cursorless_scope_type_plural, -m.number_small, m.number_small
+        m.cursorless_scope_type_plural,
+        -m.private_cursorless_number_small,
+        m.private_cursorless_number_small,
     )
 
 

--- a/cursorless-talon/src/modifiers/relative_scope.py
+++ b/cursorless-talon/src/modifiers/relative_scope.py
@@ -31,27 +31,27 @@ def cursorless_relative_scope_singular(m) -> dict[str, Any]:
 
 
 @mod.capture(
-    rule="<user.cursorless_relative_direction> <number_small> <user.cursorless_scope_type_plural>"
+    rule="<user.cursorless_relative_direction> <user.private_cursorless_number_small> <user.cursorless_scope_type_plural>"
 )
 def cursorless_relative_scope_plural(m) -> dict[str, Any]:
     """Relative previous/next plural scope. `next three funks`"""
     return create_relative_scope_modifier(
         m.cursorless_scope_type_plural,
         1,
-        m.number_small,
+        m.private_cursorless_number_small,
         m.cursorless_relative_direction,
     )
 
 
 @mod.capture(
-    rule="<number_small> <user.cursorless_scope_type_plural> [{user.cursorless_backward_modifier}]"
+    rule="<user.private_cursorless_number_small> <user.cursorless_scope_type_plural> [{user.cursorless_backward_modifier}]"
 )
 def cursorless_relative_scope_count(m) -> dict[str, Any]:
     """Relative count scope. `three funks`"""
     return create_relative_scope_modifier(
         m.cursorless_scope_type_plural,
         0,
-        m.number_small,
+        m.private_cursorless_number_small,
         getattr(m, "cursorless_backward_modifier", "forward"),
     )
 

--- a/cursorless-talon/src/number_small.py
+++ b/cursorless-talon/src/number_small.py
@@ -1,0 +1,43 @@
+"""
+This file allows us to use a custom `number_small` capture.  See #1021 for more
+info.
+"""
+from talon import Context, Module
+
+mod = Module()
+mod.tag(
+    "cursorless_custom_number_small",
+    "This tag causes Cursorless to use the global <number_small> capture",
+)
+
+ctx = Context()
+ctx.matches = """
+not tag: user.cursorless_custom_number_small
+"""
+
+
+@mod.capture(rule="<number_small>")
+def private_cursorless_number_small(m) -> int:
+    return m.number_small
+
+
+digit_list = "zero one two three four five six seven eight nine".split()
+teens = "ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen".split()
+tens = "twenty thirty forty fifty sixty seventy eighty ninety".split()
+
+number_small_list = [*digit_list, *teens]
+for ten in tens:
+    number_small_list.append(ten)
+    number_small_list.extend(f"{ten} {digit}" for digit in digit_list[1:])
+number_small_map = {n: i for i, n in enumerate(number_small_list)}
+
+mod.list("private_cursorless_number_small", desc="List of small numbers")
+ctx.lists["self.private_cursorless_number_small"] = number_small_map.keys()
+
+
+@ctx.capture(
+    "user.private_cursorless_number_small",
+    rule="{user.private_cursorless_number_small}",
+)
+def override_private_cursorless_number_small(m) -> int:
+    return number_small_map[m.private_cursorless_number_small]


### PR DESCRIPTION
Fixes #1021

Note that I opted to make our own capture because I figured if the user wasn't using our `row` commands at all, they'd be surprised when all of a sudden their `number_small` changed in VSCode

Decided to just add something to wiki for simplicity https://github.com/cursorless-dev/cursorless/wiki/Troubleshooting#custom-number_small-capture-is-not-being-used-by-cursorless
## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet_html)
