### PR TITLE
Add support for spying ide; add `ide.messages`

### DIFF
--- a/src/core/commandRunner/CommandRunner.ts
+++ b/src/core/commandRunner/CommandRunner.ts
@@ -169,6 +169,8 @@ export default class CommandRunner {
       console.error(err.message);
       console.error(err.stack);
       throw err;
+    } finally {
+      this.graph.testCaseRecorder.finallyHook();
     }
   }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,11 +1,11 @@
 import * as vscode from "vscode";
-import graphFactories from "./util/graphFactories";
-import { Graph } from "./typings/Types";
-import makeGraph, { FactoryMap } from "./util/makeGraph";
-import { ThatMark } from "./core/ThatMark";
-import { getCommandServerApi, getParseTreeApi } from "./util/getExtensionApi";
-import isTesting from "./testUtil/isTesting";
 import CommandRunner from "./core/commandRunner/CommandRunner";
+import { ThatMark } from "./core/ThatMark";
+import isTesting from "./testUtil/isTesting";
+import { Graph } from "./typings/Types";
+import { getCommandServerApi, getParseTreeApi } from "./util/getExtensionApi";
+import graphFactories from "./util/graphFactories";
+import makeGraph, { FactoryMap } from "./util/makeGraph";
 
 /**
  * Extension entrypoint called by VSCode on Cursorless startup.
@@ -19,12 +19,15 @@ export async function activate(context: vscode.ExtensionContext) {
   const { getNodeAtLocation } = await getParseTreeApi();
   const commandServerApi = await getCommandServerApi();
 
-  const graph = makeGraph({
-    ...graphFactories,
-    extensionContext: () => context,
-    commandServerApi: () => commandServerApi,
-    getNodeAtLocation: () => getNodeAtLocation,
-  } as FactoryMap<Graph>);
+  const graph = makeGraph(
+    {
+      ...graphFactories,
+      extensionContext: () => context,
+      commandServerApi: () => commandServerApi,
+      getNodeAtLocation: () => getNodeAtLocation,
+    } as FactoryMap<Graph>,
+    ["ide"]
+  );
   graph.debug.init();
   graph.snippets.init();
   await graph.decorations.init();

--- a/src/ide/ide.types.ts
+++ b/src/ide/ide.types.ts
@@ -34,12 +34,13 @@ export interface Messages {
    * {@link options} for them to select.
    *
    * @param id Each code site where we issue a warning should have a unique,
-   * human readable id for testability. This allows us to have tests without
-   * tying ourself to the specific wording of the warning message.
+   * human readable id for testability, eg "deprecatedPositionInference". This
+   * allows us to write tests without tying ourself to the specific wording of
+   * the warning message provided in {@link message}.
    * @param message The message to display to the user
    * @param options A list of options to display to the user. The selected
    * option will be returned by this function
-   * @returns The option selected by the user, or undefined if no option was
+   * @returns The option selected by the user, or `undefined` if no option was
    * selected
    */
   showWarning(

--- a/src/ide/ide.types.ts
+++ b/src/ide/ide.types.ts
@@ -3,6 +3,7 @@ import type { Listener } from "../util/Notifier";
 
 export interface IDE {
   configuration: Configuration;
+  messages: Messages;
 
   /**
    * Register disposables to be disposed of on IDE exit.
@@ -22,13 +23,30 @@ export interface Configuration {
   getOwnConfiguration<T extends CursorlessConfigKey>(
     key: T
   ): CursorlessConfiguration[T] | undefined;
-  onDidChangeConfiguration: (listener: Listener) => Disposable;
+  onDidChangeConfiguration(listener: Listener): Disposable;
+}
 
-  mockConfiguration<T extends CursorlessConfigKey>(
-    key: T,
-    value: CursorlessConfiguration[T]
-  ): void;
-  resetMocks(): void;
+export type MessageId = string;
+
+export interface Messages {
+  /**
+   * Displays a warning message {@link message} to the user along with possible
+   * {@link options} for them to select.
+   *
+   * @param id Each code site where we issue a warning should have a unique,
+   * human readable id for testability. This allows us to have tests without
+   * tying ourself to the specific wording of the warning message.
+   * @param message The message to display to the user
+   * @param options A list of options to display to the user. The selected
+   * option will be returned by this function
+   * @returns The option selected by the user, or undefined if no option was
+   * selected
+   */
+  showWarning(
+    id: MessageId,
+    message: string,
+    ...options: string[]
+  ): Promise<string | undefined>;
 }
 
 export interface Disposable {

--- a/src/ide/spies/SpyConfiguration.ts
+++ b/src/ide/spies/SpyConfiguration.ts
@@ -1,0 +1,25 @@
+import { Listener } from "../../util/Notifier";
+import {
+  Configuration,
+  CursorlessConfigKey,
+  CursorlessConfiguration,
+  Disposable,
+} from "../ide.types";
+
+export default class SpyConfiguration implements Configuration {
+  constructor(private original: Configuration) {}
+
+  onDidChangeConfiguration(listener: Listener<[]>): Disposable {
+    return this.original.onDidChangeConfiguration(listener);
+  }
+
+  getOwnConfiguration<T extends CursorlessConfigKey>(
+    key: T
+  ): CursorlessConfiguration[T] | undefined {
+    return this.original.getOwnConfiguration(key);
+  }
+
+  getSpyValues() {
+    return undefined;
+  }
+}

--- a/src/ide/spies/SpyIDE.ts
+++ b/src/ide/spies/SpyIDE.ts
@@ -1,0 +1,52 @@
+import { values } from "lodash";
+import { Graph } from "../../typings/Types";
+import { Disposable, IDE } from "../ide.types";
+import SpyConfiguration from "./SpyConfiguration";
+import SpyMessages, { Message } from "./SpyMessages";
+
+export interface SpyIDERecordedValues {
+  configuration: undefined;
+  messages: Message[] | undefined;
+}
+
+export default class SpyIDE implements IDE {
+  configuration: SpyConfiguration;
+  messages: SpyMessages;
+
+  constructor(private original: IDE) {
+    this.configuration = new SpyConfiguration(original.configuration);
+    this.messages = new SpyMessages(original.messages);
+  }
+
+  disposeOnExit(...disposables: Disposable[]): () => void {
+    return this.original.disposeOnExit(...disposables);
+  }
+
+  getSpyValues(): SpyIDERecordedValues | undefined {
+    const ret = {
+      configuration: this.configuration.getSpyValues(),
+      messages: this.messages.getSpyValues(),
+    };
+
+    return values(ret).every((value) => value == null) ? undefined : ret;
+  }
+}
+
+export interface SpyInfo extends Disposable {
+  spy: SpyIDE;
+}
+
+export function injectSpyIde(graph: Graph): SpyInfo {
+  const original = graph.ide;
+  const spy = new SpyIDE(original);
+
+  graph.ide = spy;
+
+  return {
+    spy,
+
+    dispose() {
+      graph.ide = original;
+    },
+  };
+}

--- a/src/ide/spies/SpyMessages.ts
+++ b/src/ide/spies/SpyMessages.ts
@@ -1,0 +1,33 @@
+import { MessageId, Messages } from "../ide.types";
+
+type MessageType = "info" | "warning" | "error";
+
+export interface Message {
+  type: MessageType;
+
+  /**
+   * Each place that we show a message, we should use a message class for
+   * testability, so that our tests aren't tied to specific message wording.
+   */
+  id: MessageId;
+}
+
+export default class SpyMessages implements Messages {
+  private shownMessages: Message[] = [];
+
+  constructor(private original: Messages) {}
+
+  showWarning(
+    id: MessageId,
+    message: string,
+    ...options: string[]
+  ): Promise<string | undefined> {
+    this.shownMessages.push({ type: "warning", id });
+
+    return this.original.showWarning(id, message, ...options);
+  }
+
+  getSpyValues() {
+    return this.shownMessages.length > 0 ? this.shownMessages : undefined;
+  }
+}

--- a/src/ide/vscode/VscodeConfiguration.ts
+++ b/src/ide/vscode/VscodeConfiguration.ts
@@ -5,13 +5,12 @@ import {
   CursorlessConfigKey,
   CursorlessConfiguration,
 } from "../ide.types";
-import { VscodeIDE } from "./VscodeIDE";
+import type VscodeIDE from "./VscodeIDE";
 
-export class VscodeConfiguration implements Configuration {
+export default class VscodeConfiguration implements Configuration {
   private notifier = new Notifier();
-  private mocks: Partial<CursorlessConfiguration> = {};
 
-  constructor(private ide: VscodeIDE) {
+  constructor(ide: VscodeIDE) {
     this.onDidChangeConfiguration = this.onDidChangeConfiguration.bind(this);
 
     ide.disposeOnExit(
@@ -22,25 +21,10 @@ export class VscodeConfiguration implements Configuration {
   getOwnConfiguration<T extends CursorlessConfigKey>(
     key: T
   ): CursorlessConfiguration[T] | undefined {
-    if (key in this.mocks) {
-      return this.mocks[key];
-    }
-
     return vscode.workspace
       .getConfiguration("cursorless")
       .get<CursorlessConfiguration[T]>(key);
   }
 
   onDidChangeConfiguration = this.notifier.registerListener;
-
-  mockConfiguration<T extends CursorlessConfigKey>(
-    key: T,
-    value: CursorlessConfiguration[T]
-  ): void {
-    this.mocks[key] = value;
-  }
-
-  resetMocks(): void {
-    this.mocks = {};
-  }
 }

--- a/src/ide/vscode/VscodeIDE.ts
+++ b/src/ide/vscode/VscodeIDE.ts
@@ -1,13 +1,16 @@
 import { pull } from "lodash";
 import { Graph } from "../../typings/Types";
 import { Disposable, IDE } from "../ide.types";
-import { VscodeConfiguration } from "./VscodeConfiguration";
+import VscodeConfiguration from "./VscodeConfiguration";
+import VscodeMessages from "./VscodeMessages";
 
-export class VscodeIDE implements IDE {
+export default class VscodeIDE implements IDE {
   configuration: VscodeConfiguration;
+  messages: VscodeMessages;
 
   constructor(private graph: Graph) {
     this.configuration = new VscodeConfiguration(this);
+    this.messages = new VscodeMessages();
   }
 
   disposeOnExit(...disposables: Disposable[]): () => void {

--- a/src/ide/vscode/VscodeMessages.ts
+++ b/src/ide/vscode/VscodeMessages.ts
@@ -1,0 +1,12 @@
+import { window } from "vscode";
+import { MessageId, Messages } from "../ide.types";
+
+export default class VscodeMessages implements Messages {
+  async showWarning(
+    _id: MessageId,
+    message: string,
+    ...options: string[]
+  ): Promise<string | undefined> {
+    return await window.showWarningMessage(message, ...options);
+  }
+}

--- a/src/test/suite/fakes/ide/FakeConfiguration.ts
+++ b/src/test/suite/fakes/ide/FakeConfiguration.ts
@@ -6,7 +6,7 @@ import {
 import { Graph } from "../../../../typings/Types";
 import { Notifier } from "../../../../util/Notifier";
 
-export class FakeConfiguration implements Configuration {
+export default class FakeConfiguration implements Configuration {
   private notifier = new Notifier();
   private mocks: Partial<CursorlessConfiguration> = {};
 

--- a/src/test/suite/fakes/ide/FakeIDE.ts
+++ b/src/test/suite/fakes/ide/FakeIDE.ts
@@ -1,14 +1,17 @@
 import { pull } from "lodash";
 import { Disposable, IDE } from "../../../../ide/ide.types";
 import { Graph } from "../../../../typings/Types";
-import { FakeConfiguration } from "./FakeConfiguration";
+import FakeConfiguration from "./FakeConfiguration";
+import FakeMessages from "./FakeMessages";
 
-export class FakeIDE implements IDE {
+export default class FakeIDE implements IDE {
   configuration: FakeConfiguration;
+  messages: FakeMessages;
   private disposables: Disposable[] = [];
 
   constructor(graph: Graph) {
     this.configuration = new FakeConfiguration(graph);
+    this.messages = new FakeMessages();
   }
 
   disposeOnExit(...disposables: Disposable[]): () => void {
@@ -20,4 +23,23 @@ export class FakeIDE implements IDE {
   exit(): void {
     this.disposables.forEach((disposable) => disposable.dispose());
   }
+}
+
+export interface FakeInfo extends Disposable {
+  fake: FakeIDE;
+}
+
+export function injectFakeIde(graph: Graph): FakeInfo {
+  const original = graph.ide;
+  const fake = new FakeIDE(graph);
+
+  graph.ide = fake;
+
+  return {
+    fake,
+
+    dispose() {
+      graph.ide = original;
+    },
+  };
 }

--- a/src/test/suite/fakes/ide/FakeMessages.ts
+++ b/src/test/suite/fakes/ide/FakeMessages.ts
@@ -1,0 +1,10 @@
+import { Messages } from "../../../../ide/ide.types";
+
+export default class FakeMessages implements Messages {
+  async showWarning(
+    _message: string,
+    ..._options: string[]
+  ): Promise<string | undefined> {
+    return undefined;
+  }
+}

--- a/src/test/suite/recorded.test.ts
+++ b/src/test/suite/recorded.test.ts
@@ -4,6 +4,7 @@ import * as yaml from "js-yaml";
 import * as vscode from "vscode";
 import HatTokenMap from "../../core/HatTokenMap";
 import { ReadOnlyHatMap } from "../../core/IndividualHatMap";
+import { injectSpyIde } from "../../ide/spies/SpyIDE";
 import { extractTargetedMarks } from "../../testUtil/extractTargetedMarks";
 import { plainObjectToTarget } from "../../testUtil/fromPlainObject";
 import serialize from "../../testUtil/serialize";
@@ -25,6 +26,7 @@ import { getCursorlessApi } from "../../util/getExtensionApi";
 import { openNewEditor } from "../openNewEditor";
 import asyncSafety from "../util/asyncSafety";
 import { getRecordedTestPaths } from "../util/getFixturePaths";
+import { injectFakeIde } from "./fakes/ide/FakeIDE";
 import shouldUpdateFixtures from "./shouldUpdateFixtures";
 import { sleepWithBackoff, standardSuiteSetup } from "./standardSuiteSetup";
 
@@ -111,6 +113,9 @@ async function runTest(file: string) {
   // Assert that recorded decorations are present
   checkMarks(fixture.initialState.marks, readableHatMap);
 
+  const { dispose: disposeFakeIde } = injectFakeIde(graph);
+  const { spy: spyIde } = injectSpyIde(graph);
+
   let returnValue: unknown;
 
   try {
@@ -139,6 +144,8 @@ async function runTest(file: string) {
 
     return;
   }
+
+  disposeFakeIde();
 
   if (fixture.thrownError != null) {
     throw Error(
@@ -187,12 +194,15 @@ async function runTest(file: string) {
       ? undefined
       : testDecorationsToPlainObject(graph.editStyles.testDecorations);
 
+  const actualSpyIdeValues = spyIde.getSpyValues();
+
   if (shouldUpdateFixtures()) {
     const outputFixture = {
       ...fixture,
       finalState: resultState,
       decorations: actualDecorations,
       returnValue,
+      ide: actualSpyIdeValues,
       thrownError: undefined,
     };
 
@@ -214,6 +224,12 @@ async function runTest(file: string) {
       returnValue,
       fixture.returnValue,
       "Unexpected return value"
+    );
+
+    assert.deepStrictEqual(
+      actualSpyIdeValues,
+      fixture.ide,
+      "Unexpected ide captured values"
     );
   }
 }

--- a/src/test/suite/tokenGraphemeSplitter.test.ts
+++ b/src/test/suite/tokenGraphemeSplitter.test.ts
@@ -5,7 +5,7 @@ import {
 } from "../../core/TokenGraphemeSplitter";
 import { Graph, TokenHatSplittingMode } from "../../typings/Types";
 import makeGraph, { FactoryMap } from "../../util/makeGraph";
-import { FakeIDE } from "./fakes/ide/FakeIDE";
+import FakeIDE from "./fakes/ide/FakeIDE";
 
 /**
  * Compact representation of a grapheme to make the tests easier to read.
@@ -288,7 +288,9 @@ const tokenHatSplittingDefaults: TokenHatSplittingMode = {
   symbolsToPreserve: [],
 };
 
-graph.ide.configuration.mockConfiguration(
+const ide = graph.ide as FakeIDE;
+
+ide.configuration.mockConfiguration(
   "tokenHatSplittingMode",
   tokenHatSplittingDefaults
 );
@@ -297,7 +299,7 @@ const tokenGraphemeSplitter = graph.tokenGraphemeSplitter;
 
 tests.forEach(({ tokenHatSplittingMode, extraTestCases }) => {
   suite(`getTokenGraphemes(${JSON.stringify(tokenHatSplittingMode)})`, () => {
-    graph.ide.configuration.mockConfiguration("tokenHatSplittingMode", {
+    ide.configuration.mockConfiguration("tokenHatSplittingMode", {
       ...tokenHatSplittingDefaults,
       ...tokenHatSplittingMode,
     });

--- a/src/typings/Types.ts
+++ b/src/typings/Types.ts
@@ -172,8 +172,9 @@ export interface Graph {
 
   /**
    * Used to interact with the ide
+   * NB: We make ide mutable to allow spying
    */
-  readonly ide: IDE;
+  ide: IDE;
 }
 
 export type NodeMatcherValue = {

--- a/src/util/graphFactories.ts
+++ b/src/util/graphFactories.ts
@@ -9,7 +9,7 @@ import { Snippets } from "../core/Snippets";
 import StatusBarItem from "../core/StatusBarItem";
 import { TokenGraphemeSplitter } from "../core/TokenGraphemeSplitter";
 import { RangeUpdater } from "../core/updateSelections/RangeUpdater";
-import { VscodeIDE } from "../ide/vscode/VscodeIDE";
+import VscodeIDE from "../ide/vscode/VscodeIDE";
 import { TestCaseRecorder } from "../testUtil/TestCaseRecorder";
 import { Graph } from "../typings/Types";
 import { FactoryMap } from "./makeGraph";

--- a/src/util/makeGraph.ts
+++ b/src/util/makeGraph.ts
@@ -1,4 +1,5 @@
 import isTesting from "../testUtil/isTesting";
+import { ExtractMutable } from "./typeUtils";
 
 export type FactoryMap<T> = {
   [P in keyof T]: (t: T) => T[P];
@@ -37,13 +38,17 @@ function makeGetter<GraphType, K extends keyof GraphType>(
 }
 
 export default function makeGraph<GraphType extends object>(
-  factoryMap: FactoryMap<GraphType>
+  factoryMap: FactoryMap<GraphType>,
+  writableKeys: ExtractMutable<GraphType>[] = []
 ) {
   const components: Partial<GraphType> = {};
   const graph: Partial<GraphType> = {};
   const lockedKeys: (keyof GraphType)[] = [];
 
   Object.keys(factoryMap).forEach((key: keyof GraphType | PropertyKey) => {
+    const isMutable = (
+      writableKeys as (keyof GraphType | PropertyKey)[]
+    ).includes(key);
     Object.defineProperty(graph, key, {
       get: makeGetter(
         graph as GraphType,
@@ -53,8 +58,14 @@ export default function makeGraph<GraphType extends object>(
         key as keyof GraphType
       ),
 
-      // NB: If we're testing, we make property mutable to allow mocking
-      configurable: isTesting(),
+      set: isMutable
+        ? (value) => {
+            components[key as keyof GraphType] = value;
+          }
+        : undefined,
+
+      // NB: We allow mutable keys for spying
+      configurable: isMutable || isTesting(),
     });
   });
 

--- a/src/util/typeUtils.ts
+++ b/src/util/typeUtils.ts
@@ -11,3 +11,19 @@ export function isSameType<T>(a: T, b: unknown): b is T {
     Object.getPrototypeOf(b).constructor
   );
 }
+
+// From https://stackoverflow.com/a/69160270/2605678
+type IfEquals<T, U, Y = true, N = false> = (<G>() => G extends T
+  ? 1
+  : 2) extends <G>() => G extends U ? 1 : 2
+  ? Y
+  : N;
+
+export type ExtractMutable<T> = {
+  [Prop in keyof T]: IfEquals<
+    Pick<T, Prop>,
+    Record<Prop, T[Prop]>
+  > extends false
+    ? never
+    : Prop;
+}[keyof T];


### PR DESCRIPTION
Adds `ide.messages`, which abstracts showing messages to the user. Also adds support for spying the ide, and uses it to allow spying which messages were sent during recording or while running tests.

## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet_html)
