### PR TITLE
Remove unused off-screen modification protection

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -39,52 +39,6 @@ export async function activate(context: vscode.ExtensionContext) {
   // TODO: Do this using the graph once we migrate its dependencies onto the graph
   new CommandRunner(graph, thatMark, sourceMark);
 
-  // Disabled for now.
-  // See https://github.com/cursorless-dev/cursorless/issues/320
-  // vscode.workspace.onDidChangeTextDocument(checkForEditsOutsideViewport)
-  function _checkForEditsOutsideViewport(
-    event: vscode.TextDocumentChangeEvent
-  ) {
-    // TODO: Only activate this code during the course of a cursorless action
-    // Can register pre/post command hooks the way we do with test case recorder
-    // TODO: Move this thing to a graph component
-    // TODO: Need to move command executor and test case recorder to graph
-    // component while we're doing this stuff so it's easier to register the
-    // hooks
-    // TODO: Should run this code even if document is not in a visible editor
-    // as long as we are during the course of a cursorless command.
-    const editor = vscode.window.activeTextEditor;
-
-    if (
-      editor == null ||
-      editor.document !== event.document ||
-      event.reason === vscode.TextDocumentChangeReason.Undo ||
-      event.reason === vscode.TextDocumentChangeReason.Redo
-    ) {
-      return;
-    }
-
-    const ranges = event.contentChanges
-      .filter(
-        (contentChange) =>
-          !editor.visibleRanges.some(
-            (visibleRange) =>
-              contentChange.range.intersection(visibleRange) != null
-          )
-      )
-      .map(({ range }) => range);
-
-    if (ranges.length > 0) {
-      ranges.sort((a, b) => a.start.line - b.start.line);
-      const linesText = ranges
-        .map((range) => `${range.start.line + 1}-${range.end.line + 1}`)
-        .join(", ");
-      vscode.window.showWarningMessage(
-        `Modification outside of viewport at lines: ${linesText}`
-      );
-    }
-  }
-
   return {
     thatMark,
     sourceMark,


### PR DESCRIPTION
I pasted the code into the description of https://github.com/cursorless-dev/cursorless/issues/45.  No reason to have it polluting our `extension.ts`

## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet_html)
