### PR TITLE
.github/workflows: Bump actions for node16

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -12,10 +12,10 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     environment: production
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: 16
           cache: yarn
@@ -46,7 +46,7 @@ jobs:
     needs: publish-extension
     environment: production
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           token: ${{ secrets.CURSORLESS_BOT_TOKEN }}

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -9,8 +9,8 @@ jobs:
   test-docs-build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: 16
           cache: yarn

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,8 +23,8 @@ jobs:
     env:
       VSCODE_VERSION: ${{ matrix.vscode_version }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: 16
           cache: yarn


### PR DESCRIPTION
This bumps the GitHub Actions using node12 to the latest versions using node16. This should squash ~most~ all of the actions-related warnings, such as the ones seen on https://github.com/cursorless-dev/cursorless/actions/runs/3302625117

## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet_html)
