### PR TITLE
Switch to prettier `trailingComma: "all"`

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "trailingComma": "all"
+}

--- a/src/actions/BringMoveSwap.ts
+++ b/src/actions/BringMoveSwap.ts
@@ -70,11 +70,11 @@ class BringMoveSwap implements Action {
       this.graph.editStyles.displayPendingEditDecorations(
         sources,
         decorationContext.sourceStyle,
-        decorationContext.getSourceRangeCallback
+        decorationContext.getSourceRangeCallback,
       ),
       this.graph.editStyles.displayPendingEditDecorations(
         destinations,
-        decorationContext.destinationStyle
+        decorationContext.destinationStyle,
       ),
     ]);
   }
@@ -150,7 +150,7 @@ class BringMoveSwap implements Action {
   }
 
   private async performEditsAndComputeThatMark(
-    edits: ExtendedEdit[]
+    edits: ExtendedEdit[],
   ): Promise<MarkEntry[]> {
     return flatten(
       await runForEachEditor(
@@ -168,16 +168,16 @@ class BringMoveSwap implements Action {
               getSelectionInfo(
                 editor.document,
                 selectionFromRange(originalTarget.isReversed, range),
-                DecorationRangeBehavior.OpenOpen
-              )
+                DecorationRangeBehavior.OpenOpen,
+              ),
           );
 
           const cursorSelectionInfos = editor.selections.map((selection) =>
             getSelectionInfo(
               editor.document,
               selection,
-              DecorationRangeBehavior.ClosedClosed
-            )
+              DecorationRangeBehavior.ClosedClosed,
+            ),
           );
 
           const [updatedEditSelections, cursorSelections]: Selection[][] =
@@ -185,7 +185,7 @@ class BringMoveSwap implements Action {
               this.graph.rangeUpdater,
               editor,
               filteredEdits.map(({ edit }) => edit),
-              [editSelectionInfos, cursorSelectionInfos]
+              [editSelectionInfos, cursorSelectionInfos],
             );
 
           // NB: We set the selections here because we don't trust vscode to
@@ -204,8 +204,8 @@ class BringMoveSwap implements Action {
               target,
             };
           });
-        }
-      )
+        },
+      ),
     );
   }
 
@@ -217,14 +217,14 @@ class BringMoveSwap implements Action {
       this.graph.editStyles.displayPendingEditDecorations(
         thatMark.filter(({ isSource }) => isSource).map(({ target }) => target),
         decorationContext.sourceStyle,
-        getRange
+        getRange,
       ),
       this.graph.editStyles.displayPendingEditDecorations(
         thatMark
           .filter(({ isSource }) => !isSource)
           .map(({ target }) => target),
         decorationContext.destinationStyle,
-        getRange
+        getRange,
       ),
     ]);
   }
@@ -247,7 +247,7 @@ class BringMoveSwap implements Action {
 
   async run([sources, destinations]: [
     Target[],
-    Target[]
+    Target[],
   ]): Promise<ActionReturnValue> {
     sources = this.broadcastSource(sources, destinations);
 

--- a/src/actions/Call.ts
+++ b/src/actions/Call.ts
@@ -10,7 +10,7 @@ export default class Call implements Action {
 
   async run([sources, destinations]: [
     Target[],
-    Target[]
+    Target[],
   ]): Promise<ActionReturnValue> {
     ensureSingleTarget(sources);
 
@@ -18,7 +18,7 @@ export default class Call implements Action {
       [sources],
       {
         showDecorations: false,
-      }
+      },
     );
 
     // NB: We unwrap and then rewrap the return value here so that we don't include the source mark
@@ -26,7 +26,7 @@ export default class Call implements Action {
       await this.graph.actions.wrapWithPairedDelimiter.run(
         [destinations],
         texts[0] + "(",
-        ")"
+        ")",
       );
 
     return { thatSelections: thatMark };

--- a/src/actions/Clear.ts
+++ b/src/actions/Clear.ts
@@ -20,7 +20,7 @@ export default class Clear implements Action {
           editor: target.editor,
           isReversed: target.isReversed,
           contentRange: target.contentRange,
-        })
+        }),
     );
 
     const { thatSelections: thatMark } = await this.graph.actions.remove.run([
@@ -30,7 +30,7 @@ export default class Clear implements Action {
     if (thatMark != null) {
       await setSelectionsAndFocusEditor(
         editor,
-        thatMark.map(({ selection }) => selection)
+        thatMark.map(({ selection }) => selection),
       );
     }
 

--- a/src/actions/CommandAction.ts
+++ b/src/actions/CommandAction.ts
@@ -40,7 +40,7 @@ export default class CommandAction implements Action {
 
   private async runCommandAndUpdateSelections(
     targets: Target[],
-    options: Required<CommandOptions>
+    options: Required<CommandOptions>,
   ): Promise<Target[]> {
     return flatten(
       await runOnTargetsForEachEditor(targets, async (editor, targets) => {
@@ -48,7 +48,7 @@ export default class CommandAction implements Action {
         const originalEditorVersion = editor.document.version;
 
         const targetSelections = targets.map(
-          (target) => target.contentSelection
+          (target) => target.contentSelection,
         );
 
         // For command to the work we have to have the correct editor focused
@@ -60,7 +60,7 @@ export default class CommandAction implements Action {
             () =>
               commands.executeCommand(options.command, ...options.commandArgs),
             editor.document,
-            [originalSelections, targetSelections]
+            [originalSelections, targetSelections],
           );
 
         // Reset original selections
@@ -81,21 +81,21 @@ export default class CommandAction implements Action {
               selectionToThatTarget({
                 editor,
                 selection,
-              })
+              }),
             );
-      })
+      }),
     );
   }
 
   async run(
     [targets]: [Target[]],
-    options: CommandOptions = {}
+    options: CommandOptions = {},
   ): Promise<ActionReturnValue> {
     const partialOptions = Object.assign(
       {},
       defaultOptions,
       this.options,
-      options
+      options,
     );
 
     if (partialOptions.command == null) {
@@ -107,7 +107,7 @@ export default class CommandAction implements Action {
     if (actualOptions.showDecorations) {
       await this.graph.editStyles.displayPendingEditDecorations(
         targets,
-        this.graph.editStyles.referenced
+        this.graph.editStyles.referenced,
       );
     }
 
@@ -123,7 +123,7 @@ export default class CommandAction implements Action {
 
     const thatTargets = await this.runCommandAndUpdateSelections(
       targets,
-      actualOptions
+      actualOptions,
     );
 
     // If necessary focus back original editor

--- a/src/actions/CutCopy.ts
+++ b/src/actions/CutCopy.ts
@@ -23,18 +23,18 @@ export class Cut implements Action {
             editor: target.editor,
             contentRange: overflow,
             isReversed: target.isReversed,
-          })
+          }),
       );
     });
 
     await Promise.all([
       this.graph.editStyles.displayPendingEditDecorations(
         targets,
-        this.graph.editStyles.referenced
+        this.graph.editStyles.referenced,
       ),
       this.graph.editStyles.displayPendingEditDecorations(
         overflowTargets,
-        this.graph.editStyles.pendingDelete
+        this.graph.editStyles.pendingDelete,
       ),
     ]);
 
@@ -44,7 +44,7 @@ export class Cut implements Action {
 
     const { thatSelections: thatMark } = await this.graph.actions.remove.run(
       [targets],
-      options
+      options,
     );
 
     return { thatSelections: thatMark };

--- a/src/actions/Deselect.ts
+++ b/src/actions/Deselect.ts
@@ -18,14 +18,14 @@ export default class Deselect implements Action {
           !targets.some((target) => {
             const intersection = target.contentRange.intersection(selection);
             return intersection && (!intersection.isEmpty || selection.isEmpty);
-          })
+          }),
       );
       // The editor requires at least one selection. Keep "primary" selection active
       setSelectionsWithoutFocusingEditor(
         editor,
         newSelections.length > 0
           ? newSelections
-          : [new Selection(editor.selection.active, editor.selection.active)]
+          : [new Selection(editor.selection.active, editor.selection.active)],
       );
     });
 

--- a/src/actions/EditNew/EditNew.ts
+++ b/src/actions/EditNew/EditNew.ts
@@ -45,7 +45,7 @@ export class EditNew implements Action {
     state = await runEditTargets(this.graph, editor, state);
 
     const newSelections = state.targets.map((target, index) =>
-      selectionFromRange(target.isReversed, state.cursorRanges[index]!)
+      selectionFromRange(target.isReversed, state.cursorRanges[index]!),
     );
     await setSelectionsAndFocusEditor(editor, newSelections);
 

--- a/src/actions/EditNew/runCommandTargets.ts
+++ b/src/actions/EditNew/runCommandTargets.ts
@@ -17,7 +17,7 @@ import { CommandTarget, State } from "./EditNew.types";
 export async function runCommandTargets(
   graph: Graph,
   editor: TextEditor,
-  state: State
+  state: State,
 ): Promise<State> {
   const commandTargets: CommandTarget[] = state.targets
     .map((target, index) => {
@@ -47,7 +47,7 @@ export async function runCommandTargets(
       graph.rangeUpdater,
       () => commands.executeCommand(command),
       editor.document,
-      [state.targets.map(({ contentRange }) => contentRange), state.thatRanges]
+      [state.targets.map(({ contentRange }) => contentRange), state.thatRanges],
     );
 
   // For each of the given command targets, the cursor will go where it ended
@@ -60,7 +60,7 @@ export async function runCommandTargets(
 
   return {
     targets: state.targets.map((target, index) =>
-      target.withContentRange(updatedTargetRanges[index])
+      target.withContentRange(updatedTargetRanges[index]),
     ),
     thatRanges: updatedThatRanges,
     cursorRanges,

--- a/src/actions/EditNew/runEditTargets.ts
+++ b/src/actions/EditNew/runEditTargets.ts
@@ -20,7 +20,7 @@ import { EditTarget, State } from "./EditNew.types";
 export async function runEditTargets(
   graph: Graph,
   editor: TextEditor,
-  state: State
+  state: State,
 ): Promise<State> {
   const editTargets: EditTarget[] = state.targets
     .map((target, index) => {
@@ -39,7 +39,7 @@ export async function runEditTargets(
   }
 
   const edits = editTargets.map((target) =>
-    target.target.constructChangeEdit("")
+    target.target.constructChangeEdit(""),
   );
 
   const thatSelections = {
@@ -73,7 +73,7 @@ export async function runEditTargets(
     graph.rangeUpdater,
     editor,
     edits,
-    [thatSelections, cursorSelections, editSelections]
+    [thatSelections, cursorSelections, editSelections],
   );
 
   const updatedCursorRanges = [...state.cursorRanges];

--- a/src/actions/EditNew/runNotebookCellTargets.ts
+++ b/src/actions/EditNew/runNotebookCellTargets.ts
@@ -7,7 +7,7 @@ import { ActionReturnValue } from "../actions.types";
 
 export async function runNotebookCellTargets(
   graph: Graph,
-  targets: Target[]
+  targets: Target[],
 ): Promise<ActionReturnValue> {
   // Can only run on one target because otherwise we'd end up with cursors in
   // multiple cells, which is unsupported in VSCode
@@ -21,7 +21,7 @@ export async function runNotebookCellTargets(
   if (command === "jupyter.insertCellAbove") {
     thatMark[0].selection = new Selection(
       thatMark[0].selection.anchor.translate({ lineDelta: 2 }),
-      thatMark[0].selection.active.translate({ lineDelta: 2 })
+      thatMark[0].selection.active.translate({ lineDelta: 2 }),
     );
   }
 

--- a/src/actions/ExecuteCommand.ts
+++ b/src/actions/ExecuteCommand.ts
@@ -17,7 +17,7 @@ export default class ExecuteCommand implements Action {
   async run(
     targets: [Target[]],
     command: string,
-    args: CommandOptions = {}
+    args: CommandOptions = {},
   ): Promise<ActionReturnValue> {
     return this.commandAction.run(targets, { ...args, command });
   }

--- a/src/actions/Fold.ts
+++ b/src/actions/Fold.ts
@@ -19,10 +19,10 @@ class FoldAction implements Action {
     }
 
     const singleLineTargets = targets.filter(
-      (target) => target.contentRange.isSingleLine
+      (target) => target.contentRange.isSingleLine,
     );
     const multiLineTargets = targets.filter(
-      (target) => !target.contentRange.isSingleLine
+      (target) => !target.contentRange.isSingleLine,
     );
     // Don't mix multi and single line targets.
     // This is probably the result of an "every" command
@@ -35,7 +35,7 @@ class FoldAction implements Action {
       levels: 1,
       direction: "down",
       selectionLines: selectedTargets.map(
-        (target) => target.contentRange.start.line
+        (target) => target.contentRange.start.line,
       ),
     });
 

--- a/src/actions/FollowLink.ts
+++ b/src/actions/FollowLink.ts
@@ -15,7 +15,7 @@ export default class FollowLink implements Action {
 
     await this.graph.editStyles.displayPendingEditDecorations(
       targets,
-      this.graph.editStyles.referenced
+      this.graph.editStyles.referenced,
     );
 
     const link = await getLinkForTarget(target);
@@ -25,7 +25,7 @@ export default class FollowLink implements Action {
       await this.graph.actions.executeCommand.run(
         [targets],
         "editor.action.revealDefinition",
-        { restoreSelection: false }
+        { restoreSelection: false },
       );
     }
 

--- a/src/actions/GenerateSnippet/GenerateSnippet.ts
+++ b/src/actions/GenerateSnippet/GenerateSnippet.ts
@@ -55,7 +55,7 @@ export default class GenerateSnippet implements Action {
 
   async run(
     [targets]: [Target[]],
-    snippetName?: string
+    snippetName?: string,
   ): Promise<ActionReturnValue> {
     const target = ensureSingleTarget(targets);
     const editor = target.editor;
@@ -66,7 +66,7 @@ export default class GenerateSnippet implements Action {
     // win the race and have the input box ready for them
     this.graph.editStyles.displayPendingEditDecorations(
       targets,
-      this.graph.editStyles.referenced
+      this.graph.editStyles.referenced,
     );
 
     if (snippetName == null) {
@@ -116,8 +116,8 @@ export default class GenerateSnippet implements Action {
     const linePrefix = editor.document.getText(
       new Range(
         target.contentRange.start.with(undefined, 0),
-        target.contentRange.start
-      )
+        target.contentRange.start,
+      ),
     );
 
     /** The text of the snippet, with placeholders inserted for variables */
@@ -143,9 +143,9 @@ export default class GenerateSnippet implements Action {
             ":",
             defaultName,
             "}",
-          ].join("")
+          ].join(""),
         ),
-      }))
+      })),
     );
 
     const snippetLines = constructSnippetBody(snippetBodyText, linePrefix);
@@ -176,7 +176,7 @@ export default class GenerateSnippet implements Action {
       // string (including quotes) with `{$3}` after json-ification
       const value = substituter.addSubstitution(
         "{$" + currentPlaceholderIndex++ + "}",
-        true
+        true,
       );
 
       return [key, value];
@@ -198,7 +198,7 @@ export default class GenerateSnippet implements Action {
           variables.length === 0
             ? undefined
             : Object.fromEntries(
-                variables.map(constructVariableDescriptionEntry)
+                variables.map(constructVariableDescriptionEntry),
               ),
       },
     };
@@ -209,7 +209,7 @@ export default class GenerateSnippet implements Action {
      * definition
      */
     const snippetText = substituter.makeSubstitutions(
-      JSON.stringify(snippet, null, 2)
+      JSON.stringify(snippet, null, 2),
     );
 
     if (isTesting()) {

--- a/src/actions/GenerateSnippet/constructSnippetBody.ts
+++ b/src/actions/GenerateSnippet/constructSnippetBody.ts
@@ -31,7 +31,7 @@ interface Line {
  */
 export function constructSnippetBody(
   text: string,
-  linePrefix: string
+  linePrefix: string,
 ): string[] {
   const outputLines: string[] = [];
   let currentTabCount = 0;
@@ -64,7 +64,7 @@ export function constructSnippetBody(
 
     const lineContentStart = Math.max(
       firstNonWhitespaceCharacterIndex,
-      startIndex
+      startIndex,
     );
     const snippetIndentationString = repeat("\t", currentTabCount);
     const lineContent = text.slice(lineContentStart);

--- a/src/actions/GetText.ts
+++ b/src/actions/GetText.ts
@@ -13,12 +13,12 @@ export default class GetText implements Action {
     {
       showDecorations = true,
       ensureSingleTarget: doEnsureSingleTarget = false,
-    } = {}
+    } = {},
   ): Promise<ActionReturnValue> {
     if (showDecorations) {
       await this.graph.editStyles.displayPendingEditDecorations(
         targets,
-        this.graph.editStyles.referenced
+        this.graph.editStyles.referenced,
       );
     }
 

--- a/src/actions/Highlight.ts
+++ b/src/actions/Highlight.ts
@@ -10,7 +10,7 @@ export default class Highlight implements Action {
 
   async run(
     [targets]: [Target[]],
-    styleName: EditStyleName = "highlight0"
+    styleName: EditStyleName = "highlight0",
   ): Promise<ActionReturnValue> {
     const style = this.graph.editStyles[styleName];
 

--- a/src/actions/InsertCopy.ts
+++ b/src/actions/InsertCopy.ts
@@ -18,7 +18,7 @@ class InsertCopy implements Action {
 
   async run([targets]: [Target[]]): Promise<ActionReturnValue> {
     const results = flatten(
-      await runOnTargetsForEachEditor(targets, this.runForEditor)
+      await runOnTargetsForEachEditor(targets, this.runForEditor),
     );
 
     await this.graph.editStyles.displayPendingEditDecorationsForRanges(
@@ -26,10 +26,10 @@ class InsertCopy implements Action {
         result.thatMark.map((that) => ({
           editor: that.editor,
           range: that.selection,
-        }))
+        })),
       ),
       this.graph.editStyles.justAdded,
-      true
+      true,
     );
 
     return {
@@ -42,7 +42,7 @@ class InsertCopy implements Action {
     // isBefore is inverted because we want the selections to stay with what is to the user the "copy"
     const position = this.isBefore ? "after" : "before";
     const edits = targets.flatMap((target) =>
-      target.toPositionTarget(position).constructChangeEdit(target.contentText)
+      target.toPositionTarget(position).constructChangeEdit(target.contentText),
     );
 
     const cursorSelections = { selections: editor.selections };
@@ -51,7 +51,7 @@ class InsertCopy implements Action {
     };
     const editSelections = {
       selections: edits.map(
-        ({ range }) => new Selection(range.start, range.end)
+        ({ range }) => new Selection(range.start, range.end),
       ),
       rangeBehavior: DecorationRangeBehavior.OpenOpen,
     };
@@ -64,11 +64,11 @@ class InsertCopy implements Action {
       this.graph.rangeUpdater,
       editor,
       edits,
-      [cursorSelections, contentSelections, editSelections]
+      [cursorSelections, contentSelections, editSelections],
     );
 
     const insertionRanges = zip(edits, updatedEditSelections).map(
-      ([edit, selection]) => edit!.updateRange(selection!)
+      ([edit, selection]) => edit!.updateRange(selection!),
     );
 
     setSelectionsWithoutFocusingEditor(editor, updatedEditorSelections);

--- a/src/actions/InsertEmptyLines.ts
+++ b/src/actions/InsertEmptyLines.ts
@@ -11,7 +11,7 @@ class InsertEmptyLines implements Action {
   constructor(
     private graph: Graph,
     private insertAbove: boolean,
-    private insertBelow: boolean
+    private insertBelow: boolean,
   ) {
     this.run = this.run.bind(this);
   }
@@ -55,7 +55,7 @@ class InsertEmptyLines implements Action {
               targets.map((target) => target.thatTarget.contentSelection),
               ranges.map((range) => new Selection(range.start, range.end)),
               editor.selections,
-            ]
+            ],
           );
 
         setSelectionsWithoutFocusingEditor(editor, updatedCursorSelections);
@@ -71,18 +71,18 @@ class InsertEmptyLines implements Action {
               ranges[index].start.line < editor.document.lineCount - 1
                 ? new Range(
                     selection.start.translate({ lineDelta: -1 }),
-                    selection.end.translate({ lineDelta: -1 })
+                    selection.end.translate({ lineDelta: -1 }),
                   )
                 : selection,
           })),
         };
-      })
+      }),
     );
 
     await this.graph.editStyles.displayPendingEditDecorationsForRanges(
       results.flatMap((result) => result.lineSelections),
       this.graph.editStyles.justAdded,
-      false
+      false,
     );
 
     const thatMark = results.flatMap((result) => result.thatMark);

--- a/src/actions/InsertSnippet.ts
+++ b/src/actions/InsertSnippet.ts
@@ -51,7 +51,7 @@ export default class InsertSnippet implements Action {
   async run(
     [targets]: [Target[]],
     snippetName: string,
-    substitutions: Record<string, string>
+    substitutions: Record<string, string>,
   ): Promise<ActionReturnValue> {
     const snippet = this.graph.snippets.getSnippetStrict(snippetName);
 
@@ -59,7 +59,7 @@ export default class InsertSnippet implements Action {
 
     const definition = findMatchingSnippetDefinitionStrict(
       targets,
-      snippet.definitions
+      snippet.definitions,
     );
 
     const parsedSnippet = this.snippetParser.parse(definition.body.join("\n"));
@@ -79,8 +79,8 @@ export default class InsertSnippet implements Action {
       getSelectionInfo(
         editor.document,
         selection,
-        DecorationRangeBehavior.OpenOpen
-      )
+        DecorationRangeBehavior.OpenOpen,
+      ),
     );
 
     // NB: We used the command "editor.action.insertSnippet" instead of calling editor.insertSnippet
@@ -92,7 +92,7 @@ export default class InsertSnippet implements Action {
           snippet: snippetString,
         }),
       editor.document,
-      [targetSelectionInfos]
+      [targetSelectionInfos],
     );
 
     return {
@@ -116,7 +116,7 @@ export default class InsertSnippet implements Action {
 function formatSubstitutions(
   snippet: Snippet,
   definition: SnippetDefinition,
-  substitutions: Record<string, string>
+  substitutions: Record<string, string>,
 ): Record<string, string> {
   return Object.fromEntries(
     Object.entries(substitutions).map(([variableName, value]) => {
@@ -135,11 +135,11 @@ function formatSubstitutions(
 
       if (formatter == null) {
         throw new Error(
-          `Couldn't find formatter ${formatterName} for variable ${variableName}`
+          `Couldn't find formatter ${formatterName} for variable ${variableName}`,
         );
       }
 
       return [variableName, formatter(value.split(" "))];
-    })
+    }),
   );
 }

--- a/src/actions/Paste.ts
+++ b/src/actions/Paste.ts
@@ -28,7 +28,7 @@ export class Paste {
         await this.graph.actions.editNew.run([targets]);
       },
       targetEditor.document,
-      [targetEditor.selections]
+      [targetEditor.selections],
     );
 
     // Then use VSCode paste command, using open ranges at the place where we
@@ -46,7 +46,7 @@ export class Paste {
             selections: targetEditor.selections,
             rangeBehavior: DecorationRangeBehavior.OpenOpen,
           },
-        ]
+        ],
       );
 
     // Reset cursors on the editor where the edits took place.
@@ -68,7 +68,7 @@ export class Paste {
         range: selection,
       })),
       this.graph.editStyles.justAdded,
-      true
+      true,
     );
 
     return {

--- a/src/actions/Remove.ts
+++ b/src/actions/Remove.ts
@@ -13,7 +13,7 @@ export default class Delete implements Action {
 
   async run(
     [targets]: [Target[]],
-    { showDecorations = true } = {}
+    { showDecorations = true } = {},
   ): Promise<ActionReturnValue> {
     // Unify overlapping targets because of overlapping leading and trailing delimiters.
     targets = unifyRemovalTargets(targets);
@@ -22,7 +22,7 @@ export default class Delete implements Action {
       await this.graph.editStyles.displayPendingEditDecorations(
         targets,
         this.graph.editStyles.pendingDelete,
-        (target) => target.getRemovalHighlightRange()
+        (target) => target.getRemovalHighlightRange(),
       );
     }
 
@@ -35,11 +35,11 @@ export default class Delete implements Action {
           this.graph.rangeUpdater,
           editor,
           edits,
-          [ranges]
+          [ranges],
         );
 
         return createThatMark(targets, updatedRanges);
-      })
+      }),
     );
 
     return { thatSelections: thatMark };

--- a/src/actions/Replace.ts
+++ b/src/actions/Replace.ts
@@ -14,7 +14,7 @@ export default class Replace implements Action {
 
   private getTexts(
     targets: Target[],
-    replaceWith: string[] | RangeGenerator
+    replaceWith: string[] | RangeGenerator,
   ): string[] {
     if (Array.isArray(replaceWith)) {
       // Broadcast single text to each target
@@ -32,11 +32,11 @@ export default class Replace implements Action {
 
   async run(
     [targets]: [Target[]],
-    replaceWith: string[] | RangeGenerator
+    replaceWith: string[] | RangeGenerator,
   ): Promise<ActionReturnValue> {
     await this.graph.editStyles.displayPendingEditDecorations(
       targets,
-      this.graph.editStyles.pendingModification0
+      this.graph.editStyles.pendingModification0,
     );
 
     const texts = this.getTexts(targets, replaceWith);
@@ -59,15 +59,15 @@ export default class Replace implements Action {
             this.graph.rangeUpdater,
             editor,
             edits.map(({ edit }) => edit),
-            [targets.map((target) => target.contentSelection)]
+            [targets.map((target) => target.contentSelection)],
           );
 
           return updatedSelections.map((selection) => ({
             editor,
             selection,
           }));
-        }
-      )
+        },
+      ),
     );
 
     return { thatSelections: thatMark };

--- a/src/actions/Rewrap.ts
+++ b/src/actions/Rewrap.ts
@@ -15,7 +15,7 @@ export default class Rewrap implements Action {
   async run(
     [targets]: [Target[]],
     left: string,
-    right: string
+    right: string,
   ): Promise<ActionReturnValue> {
     const boundaryTargets = targets.flatMap((target) => {
       const boundary = target.getBoundaryStrict();
@@ -29,7 +29,7 @@ export default class Rewrap implements Action {
 
     await this.graph.editStyles.displayPendingEditDecorations(
       boundaryTargets,
-      this.graph.editStyles.pendingModification0
+      this.graph.editStyles.pendingModification0,
     );
 
     const results = await runOnTargetsForEachEditor(
@@ -49,14 +49,14 @@ export default class Rewrap implements Action {
             [
               targets.map((target) => target.thatTarget.contentRange),
               targets.map((target) => target.contentRange),
-            ]
+            ],
           );
 
         return {
           sourceMark: createThatMark(targets, updatedSourceRanges),
           thatMark: createThatMark(targets, updatedThatRanges),
         };
-      }
+      },
     );
 
     return {

--- a/src/actions/Scroll.ts
+++ b/src/actions/Scroll.ts
@@ -51,7 +51,7 @@ class Scroll implements Action {
     await this.graph.editStyles.displayPendingEditDecorationsForTargets(
       decorationTargets,
       this.graph.editStyles.referenced,
-      false
+      false,
     );
 
     return {

--- a/src/actions/Sort.ts
+++ b/src/actions/Sort.ts
@@ -15,14 +15,14 @@ abstract class SortBase implements Action {
     const sortedTargets = targets.map((t) =>
       t
         .slice()
-        .sort((a, b) => a.contentRange.start.compareTo(b.contentRange.start))
+        .sort((a, b) => a.contentRange.start.compareTo(b.contentRange.start)),
     );
 
     const { returnValue: unsortedTexts } = await this.graph.actions.getText.run(
       sortedTargets,
       {
         showDecorations: false,
-      }
+      },
     );
 
     const sortedTexts = this.sortTexts(unsortedTexts);

--- a/src/actions/ToggleBreakpoint.ts
+++ b/src/actions/ToggleBreakpoint.ts
@@ -16,7 +16,7 @@ function getBreakpoints(uri: Uri, range: Range) {
     (breakpoint) =>
       breakpoint instanceof SourceBreakpoint &&
       breakpoint.location.uri.toString() === uri.toString() &&
-      breakpoint.location.range.intersection(range) != null
+      breakpoint.location.range.intersection(range) != null,
   );
 }
 
@@ -32,7 +32,7 @@ export default class ToggleBreakpoint implements Action {
 
     await this.graph.editStyles.displayPendingEditDecorations(
       thatTargets,
-      this.graph.editStyles.referenced
+      this.graph.editStyles.referenced,
     );
 
     const toAdd: Breakpoint[] = [];

--- a/src/actions/Wrap.ts
+++ b/src/actions/Wrap.ts
@@ -18,7 +18,7 @@ export default class Wrap implements Action {
   async run(
     [targets]: [Target[]],
     left: string,
-    right: string
+    right: string,
   ): Promise<ActionReturnValue> {
     const results = await runOnTargetsForEachEditor(
       targets,
@@ -27,7 +27,7 @@ export default class Wrap implements Action {
         const boundaries = targets.map((target) => ({
           start: new Selection(
             target.contentRange.start,
-            target.contentRange.start
+            target.contentRange.start,
           ),
           end: new Selection(target.contentRange.end, target.contentRange.end),
         }));
@@ -50,39 +50,39 @@ export default class Wrap implements Action {
               getSelectionInfo(
                 document,
                 start,
-                DecorationRangeBehavior.OpenClosed
+                DecorationRangeBehavior.OpenClosed,
               ),
               getSelectionInfo(
                 document,
                 end,
-                DecorationRangeBehavior.ClosedOpen
+                DecorationRangeBehavior.ClosedOpen,
               ),
             ];
-          }
+          },
         );
 
         const cursorSelectionInfos = editor.selections.map((selection) =>
           getSelectionInfo(
             document,
             selection,
-            DecorationRangeBehavior.ClosedClosed
-          )
+            DecorationRangeBehavior.ClosedClosed,
+          ),
         );
 
         const sourceMarkSelectionInfos = targets.map((target) =>
           getSelectionInfo(
             document,
             target.contentSelection,
-            DecorationRangeBehavior.ClosedClosed
-          )
+            DecorationRangeBehavior.ClosedClosed,
+          ),
         );
 
         const thatMarkSelectionInfos = targets.map((target) =>
           getSelectionInfo(
             document,
             target.contentSelection,
-            DecorationRangeBehavior.OpenOpen
-          )
+            DecorationRangeBehavior.OpenOpen,
+          ),
         );
 
         const [
@@ -99,7 +99,7 @@ export default class Wrap implements Action {
             cursorSelectionInfos,
             sourceMarkSelectionInfos,
             thatMarkSelectionInfos,
-          ]
+          ],
         );
 
         setSelectionsWithoutFocusingEditor(editor, cursorSelections);
@@ -110,7 +110,7 @@ export default class Wrap implements Action {
             range: selection,
           })),
           this.graph.editStyles.justAdded,
-          true
+          true,
         );
 
         return {
@@ -123,7 +123,7 @@ export default class Wrap implements Action {
             selection,
           })),
         };
-      }
+      },
     );
 
     return {

--- a/src/actions/WrapWithSnippet.ts
+++ b/src/actions/WrapWithSnippet.ts
@@ -46,7 +46,7 @@ export default class WrapWithSnippet implements Action {
 
   async run(
     [targets]: [Target[]],
-    snippetLocation: string
+    snippetLocation: string,
   ): Promise<ActionReturnValue> {
     const [snippetName, placeholderName] =
       parseSnippetLocation(snippetLocation);
@@ -57,7 +57,7 @@ export default class WrapWithSnippet implements Action {
 
     const definition = findMatchingSnippetDefinitionStrict(
       targets,
-      snippet.definitions
+      snippet.definitions,
     );
 
     const parsedSnippet = this.snippetParser.parse(definition.body.join("\n"));
@@ -68,7 +68,7 @@ export default class WrapWithSnippet implements Action {
 
     await this.graph.editStyles.displayPendingEditDecorations(
       targets,
-      this.graph.editStyles.pendingModification0
+      this.graph.editStyles.pendingModification0,
     );
 
     const targetSelections = targets.map((target) => target.contentSelection);
@@ -84,7 +84,7 @@ export default class WrapWithSnippet implements Action {
           snippet: snippetString,
         }),
       editor.document,
-      [targetSelections]
+      [targetSelections],
     );
 
     return {

--- a/src/core/Cheatsheet.ts
+++ b/src/core/Cheatsheet.ts
@@ -41,12 +41,12 @@ export default class Cheatsheet {
     this.disposables.push(
       vscode.commands.registerCommand(
         "cursorless.showCheatsheet",
-        this.showCheatsheet
+        this.showCheatsheet,
       ),
       vscode.commands.registerCommand(
         "cursorless.internal.updateCheatsheetDefaults",
-        this.updateDefaults
-      )
+        this.updateDefaults,
+      ),
     );
   }
 
@@ -65,7 +65,7 @@ export default class Cheatsheet {
       "dist",
       "apps",
       "cheatsheet-local",
-      "index.html"
+      "index.html",
     );
 
     const cheatsheetContent = (await readFile(cheatsheetPath)).toString();
@@ -73,9 +73,9 @@ export default class Cheatsheet {
     const root = parse(cheatsheetContent);
 
     root.getElementById(
-      "cheatsheet-data"
+      "cheatsheet-data",
     ).textContent = `document.cheatsheetData = ${JSON.stringify(
-      spokenFormInfo
+      spokenFormInfo,
     )};`;
 
     await writeFile(outputPath, root.toString());
@@ -95,7 +95,7 @@ export default class Cheatsheet {
 
     if (workspacePath == null) {
       throw new Error(
-        "Please update defaults from Cursorless workspace or running in debug"
+        "Please update defaults from Cursorless workspace or running in debug",
       );
     }
 
@@ -108,7 +108,7 @@ export default class Cheatsheet {
       "lib",
       "data",
       "sampleSpokenFormInfos",
-      "defaults.json"
+      "defaults.json",
     );
 
     const outputObject = produce(spokenFormInfo, (draft) => {

--- a/src/core/Debug.ts
+++ b/src/core/Debug.ts
@@ -34,7 +34,7 @@ export default class Debug {
       case ExtensionMode.Production:
         this.evaluateSetting();
         this.disposableConfiguration = workspace.onDidChangeConfiguration(
-          this.evaluateSetting
+          this.evaluateSetting,
         );
         break;
     }
@@ -62,7 +62,7 @@ export default class Debug {
   private enableDebugLog() {
     this.active = true;
     this.disposableSelection = window.onDidChangeTextEditorSelection(
-      this.logBranchTypes
+      this.logBranchTypes,
     );
   }
 
@@ -88,7 +88,7 @@ export default class Debug {
   private logBranchTypes(event: TextEditorSelectionChangeEvent) {
     const location = new Location(
       window.activeTextEditor!.document.uri,
-      event.selections[0]
+      event.selections[0],
     );
 
     let node: SyntaxNode;

--- a/src/core/Decorations.ts
+++ b/src/core/Decorations.ts
@@ -52,10 +52,10 @@ export default class Decorations {
         () => {
           graph.fontMeasurements.clearCache();
           this.recomputeDecorationStyles();
-        }
+        },
       ),
 
-      vscode.workspace.onDidChangeConfiguration(this.recomputeDecorationStyles)
+      vscode.workspace.onDidChangeConfiguration(this.recomputeDecorationStyles),
     );
   }
 
@@ -130,10 +130,10 @@ export default class Decorations {
             fontMeasurements,
             shape,
             scaleFactor,
-            finalVerticalOffsetEm
+            finalVerticalOffsetEm,
           ),
         ];
-      })
+      }),
     );
 
     this.decorations = this.hatStyleNames.map((styleName) => {
@@ -166,7 +166,7 @@ export default class Decorations {
     });
 
     this.decorationMap = Object.fromEntries(
-      this.decorations.map(({ name, decoration }) => [name, decoration])
+      this.decorations.map(({ name, decoration }) => [name, decoration]),
     );
 
     this.decorationChangeListeners.forEach((listener) => listener());
@@ -199,20 +199,20 @@ export default class Decorations {
       ? HAT_COLORS.filter((color) => !color.startsWith("user"))
       : HAT_COLORS.filter((color) => colorEnablement[color]);
     const activeNonDefaultHatShapes = HAT_NON_DEFAULT_SHAPES.filter(
-      (shape) => shapeEnablement[shape]
+      (shape) => shapeEnablement[shape],
     );
 
     this.hatStyleMap = {
       ...Object.fromEntries(
-        activeHatColors.map((color) => [color, { color, shape: "default" }])
+        activeHatColors.map((color) => [color, { color, shape: "default" }]),
       ),
       ...Object.fromEntries(
         activeHatColors.flatMap((color) =>
           activeNonDefaultHatShapes.map((shape) => [
             `${color}-${shape}`,
             { color, shape },
-          ])
-        )
+          ]),
+        ),
       ),
     } as Record<HatStyleName, HatStyle>;
 
@@ -223,8 +223,8 @@ export default class Decorations {
             Object.entries(this.hatStyleMap),
             ([_, hatStyle]) =>
               colorPenalties[hatStyle.color] + shapePenalties[hatStyle.shape] <=
-              maxPenalty
-          )
+              maxPenalty,
+          ),
         ),
       } as Record<HatStyleName, HatStyle>;
     }
@@ -232,7 +232,7 @@ export default class Decorations {
     this.hatStyleNames = sortBy(
       Object.entries(this.hatStyleMap),
       ([_, hatStyle]) =>
-        colorPenalties[hatStyle.color] + shapePenalties[hatStyle.shape]
+        colorPenalties[hatStyle.color] + shapePenalties[hatStyle.shape],
     ).map(([hatStyleName, _]) => hatStyleName as HatStyleName);
   }
 
@@ -268,13 +268,13 @@ export default class Decorations {
     fontMeasurements: FontMeasurements,
     shape: HatShape,
     scaleFactor: number,
-    hatVerticalOffsetEm: number
+    hatVerticalOffsetEm: number,
   ) {
     const iconPath = join(
       this.graph.extensionContext.extensionPath,
       "images",
       "hats",
-      `${shape}.svg`
+      `${shape}.svg`,
     );
     const rawSvg = readFileSync(iconPath, "utf8");
     const { characterWidth, characterHeight, fontSize } = fontMeasurements;

--- a/src/core/FontMeasurements.ts
+++ b/src/core/FontMeasurements.ts
@@ -67,7 +67,7 @@ function getFontRatios() {
     },
     {
       enableScripts: true,
-    }
+    },
   );
 
   panel.webview.html = getWebviewContent();

--- a/src/core/HatAllocator.ts
+++ b/src/core/HatAllocator.ts
@@ -27,14 +27,14 @@ export class HatAllocator {
 
     this.disposalFunctions.push(
       graph.decorations.registerDecorationChangeListener(
-        this.addDecorationsDebounced
-      )
+        this.addDecorationsDebounced,
+      ),
     );
 
     this.disposables.push(
       vscode.commands.registerCommand(
         "cursorless.toggleDecorations",
-        this.toggleDecorations
+        this.toggleDecorations,
       ),
 
       // An event that fires when a text document opens
@@ -49,17 +49,17 @@ export class HatAllocator {
       vscode.workspace.onDidChangeTextDocument(this.addDecorationsDebounced),
       // An Event which fires when the selection in an editor has changed.
       vscode.window.onDidChangeTextEditorSelection(
-        this.addDecorationsDebounced
+        this.addDecorationsDebounced,
       ),
       // An Event which fires when the visible ranges of an editor has changed.
       vscode.window.onDidChangeTextEditorVisibleRanges(
-        this.addDecorationsDebounced
+        this.addDecorationsDebounced,
       ),
       // Re-draw hats on grapheme splitting algorithm change in case they
       // changed their token hat splitting setting.
       graph.tokenGraphemeSplitter.registerAlgorithmChangeListener(
-        this.addDecorationsDebounced
-      )
+        this.addDecorationsDebounced,
+      ),
     );
   }
 
@@ -76,7 +76,7 @@ export class HatAllocator {
       addDecorationsToEditors(
         activeMap,
         this.graph.decorations,
-        this.graph.tokenGraphemeSplitter
+        this.graph.tokenGraphemeSplitter,
       );
     } else {
       vscode.window.visibleTextEditors.forEach(this.clearEditorDecorations);

--- a/src/core/HatTokenMap.ts
+++ b/src/core/HatTokenMap.ts
@@ -91,14 +91,14 @@ export default class HatTokenMap {
     if (usePrePhraseSnapshot) {
       if (this.lastSignalVersion == null) {
         console.error(
-          "Pre phrase snapshot requested but no signal was present; please upgrade command client"
+          "Pre phrase snapshot requested but no signal was present; please upgrade command client",
         );
         return this.activeMap;
       }
 
       if (this.prePhraseMapSnapshot == null) {
         console.error(
-          "Navigation map pre-phrase snapshot requested, but no snapshot has been taken"
+          "Navigation map pre-phrase snapshot requested, but no snapshot has been taken",
         );
         return this.activeMap;
       }
@@ -108,7 +108,7 @@ export default class HatTokenMap {
         PRE_PHRASE_SNAPSHOT_MAX_AGE_NS
       ) {
         console.error(
-          "Navigation map pre-phrase snapshot requested, but snapshot is more than a minute old"
+          "Navigation map pre-phrase snapshot requested, but snapshot is more than a minute old",
         );
         return this.activeMap;
       }

--- a/src/core/IndividualHatMap.ts
+++ b/src/core/IndividualHatMap.ts
@@ -27,7 +27,7 @@ export class IndividualHatMap implements ReadOnlyHatMap {
       currentValue = [];
       this.documentTokenLists.set(key, currentValue);
       this.deregisterFunctions.push(
-        this.graph.rangeUpdater.registerRangeInfoList(document, currentValue)
+        this.graph.rangeUpdater.registerRangeInfoList(document, currentValue),
       );
     }
 
@@ -63,7 +63,7 @@ export class IndividualHatMap implements ReadOnlyHatMap {
     return this.map[
       HatTokenMap.getKey(
         hatStyle,
-        this.graph.tokenGraphemeSplitter.normalizeGrapheme(character)
+        this.graph.tokenGraphemeSplitter.normalizeGrapheme(character),
       )
     ];
   }

--- a/src/core/Snippets.ts
+++ b/src/core/Snippets.ts
@@ -59,7 +59,7 @@ export class Snippets {
 
     const timer = setInterval(
       this.updateUserSnippets,
-      SNIPPET_DIR_REFRESH_INTERVAL_MS
+      SNIPPET_DIR_REFRESH_INTERVAL_MS,
     );
 
     graph.extensionContext.subscriptions.push(
@@ -72,7 +72,7 @@ export class Snippets {
         dispose() {
           clearInterval(timer);
         },
-      }
+      },
     );
   }
 
@@ -83,9 +83,9 @@ export class Snippets {
     this.coreSnippets = mergeStrict(
       ...(await Promise.all(
         snippetFiles.map(async (path) =>
-          JSON.parse(await readFile(path, "utf8"))
-        )
-      ))
+          JSON.parse(await readFile(path, "utf8")),
+        ),
+      )),
     );
     await this.updateUserSnippets();
   }
@@ -106,7 +106,7 @@ export class Snippets {
         "test",
         "suite",
         "fixtures",
-        "cursorless-snippets"
+        "cursorless-snippets",
       );
     } else {
       newUserSnippetsDir = workspace
@@ -160,8 +160,8 @@ export class Snippets {
     const maxSnippetMtime =
       max(
         (await Promise.all(snippetFiles.map((file) => stat(file)))).map(
-          (stat) => stat.mtimeMs
-        )
+          (stat) => stat.mtimeMs,
+        ),
       ) ?? 0;
 
     if (maxSnippetMtime <= this.maxSnippetMtimeMs) {
@@ -186,7 +186,7 @@ export class Snippets {
             window.showErrorMessage(
               `Error with cursorless snippets file "${path}": ${
                 (err as Error).message
-              }`
+              }`,
             );
 
             // We don't want snippets from all files to stop working if there is
@@ -194,8 +194,8 @@ export class Snippets {
             // once we've shown an error message
             return {};
           }
-        })
-      ))
+        }),
+      )),
     );
 
     this.mergeSnippets();
@@ -227,7 +227,7 @@ export class Snippets {
     const entries = [
       ...Object.entries(cloneDeep(this.coreSnippets)),
       ...Object.values(this.thirdPartySnippets).flatMap((snippets) =>
-        Object.entries(cloneDeep(snippets))
+        Object.entries(cloneDeep(snippets)),
       ),
       ...Object.entries(cloneDeep(this.userSnippets)),
     ];
@@ -240,7 +240,7 @@ export class Snippets {
         // NB: We make sure that the new definitions appear before the previous
         // ones so that they take precedence
         mergedSnippet.definitions = definitions.concat(
-          ...mergedSnippet.definitions
+          ...mergedSnippet.definitions,
         );
 
         merge(mergedSnippet, rest);
@@ -276,6 +276,6 @@ export class Snippets {
 
 async function getSnippetPaths(snippetsDir: string) {
   return (await walkFiles(snippetsDir)).filter((path) =>
-    path.endsWith(CURSORLESS_SNIPPETS_SUFFIX)
+    path.endsWith(CURSORLESS_SNIPPETS_SUFFIX),
   );
 }

--- a/src/core/StatusBarItem.ts
+++ b/src/core/StatusBarItem.ts
@@ -12,7 +12,7 @@ export default class StatusBarItem {
     const commandId = "cursorless.showQuickPick";
     const statusBarItem = vscode.window.createStatusBarItem(
       vscode.StatusBarAlignment.Right,
-      100
+      100,
     );
     statusBarItem.command = commandId;
     statusBarItem.text = "$(cursorless-icon) Cursorless";
@@ -21,11 +21,11 @@ export default class StatusBarItem {
     this.disposables.push(
       vscode.commands.registerCommand("cursorless.showDocumentation", () =>
         vscode.env.openExternal(
-          vscode.Uri.parse("https://www.cursorless.org/docs/")
-        )
+          vscode.Uri.parse("https://www.cursorless.org/docs/"),
+        ),
       ),
       vscode.commands.registerCommand(commandId, this.showQuickOpen),
-      statusBarItem
+      statusBarItem,
     );
   }
 

--- a/src/core/TokenGraphemeSplitter.ts
+++ b/src/core/TokenGraphemeSplitter.ts
@@ -45,7 +45,7 @@ const KNOWN_SYMBOLS = [
 const KNOWN_SYMBOL_REGEXP_STR = KNOWN_SYMBOLS.map(escapeRegExp).join("|");
 
 const KNOWN_GRAPHEME_REGEXP_STR = ["[a-zA-Z0-9]", KNOWN_SYMBOL_REGEXP_STR].join(
-  "|"
+  "|",
 );
 
 /**
@@ -55,7 +55,7 @@ const KNOWN_GRAPHEME_REGEXP_STR = ["[a-zA-Z0-9]", KNOWN_SYMBOL_REGEXP_STR].join(
  */
 const KNOWN_GRAPHEME_MATCHER = new RegExp(
   `^(${KNOWN_GRAPHEME_REGEXP_STR})$`,
-  "u"
+  "u",
 );
 
 /**
@@ -88,23 +88,23 @@ export class TokenGraphemeSplitter {
       // Notify listeners in case the user changed their token hat splitting
       // setting.
       this.graph.ide.configuration.onDidChangeConfiguration(
-        this.updateTokenHatSplittingMode
-      )
+        this.updateTokenHatSplittingMode,
+      ),
     );
   }
 
   private updateTokenHatSplittingMode() {
     const { lettersToPreserve, symbolsToPreserve, ...rest } =
       this.graph.ide.configuration.getOwnConfiguration(
-        "tokenHatSplittingMode"
+        "tokenHatSplittingMode",
       )!;
 
     this.tokenHatSplittingMode = {
       lettersToPreserve: lettersToPreserve.map((grapheme) =>
-        grapheme.toLowerCase().normalize("NFC")
+        grapheme.toLowerCase().normalize("NFC"),
       ),
       symbolsToPreserve: symbolsToPreserve.map((grapheme) =>
-        grapheme.normalize("NFC")
+        grapheme.normalize("NFC"),
       ),
       ...rest,
     };

--- a/src/core/commandRunner/CommandRunner.ts
+++ b/src/core/commandRunner/CommandRunner.ts
@@ -27,7 +27,7 @@ export default class CommandRunner {
   constructor(
     private graph: Graph,
     private thatMark: ThatMark,
-    private sourceMark: ThatMark
+    private sourceMark: ThatMark,
   ) {
     graph.extensionContext.subscriptions.push(this);
 
@@ -37,8 +37,8 @@ export default class CommandRunner {
     this.disposables.push(
       vscode.commands.registerCommand(
         "cursorless.command",
-        this.runCommandBackwardCompatible
-      )
+        this.runCommandBackwardCompatible,
+      ),
     );
   }
 
@@ -81,7 +81,7 @@ export default class CommandRunner {
       } = commandComplete;
 
       const readableHatMap = await this.graph.hatTokenMap.getReadableMap(
-        usePrePhraseSnapshot
+        usePrePhraseSnapshot,
       );
 
       const action = this.graph.actions[actionName];
@@ -134,7 +134,7 @@ export default class CommandRunner {
         };
         await this.graph.testCaseRecorder.preCommandHook(
           commandComplete,
-          context
+          context,
         );
       }
 
@@ -144,7 +144,7 @@ export default class CommandRunner {
 
       const targets = processTargets(
         processedTargetsContext,
-        targetDescriptors
+        targetDescriptors,
       );
 
       const {
@@ -157,7 +157,7 @@ export default class CommandRunner {
 
       this.thatMark.set(constructThatTarget(newThatTargets, newThatSelections));
       this.sourceMark.set(
-        constructThatTarget(newSourceTargets, newSourceSelections)
+        constructThatTarget(newSourceTargets, newSourceSelections),
       );
 
       if (this.graph.testCaseRecorder.isActive()) {
@@ -184,7 +184,7 @@ export default class CommandRunner {
   async showUpdateExtensionErrorMessage(err: OutdatedExtensionError) {
     const item = await vscode.window.showErrorMessage(
       err.message,
-      "Check for updates"
+      "Check for updates",
     );
 
     if (item == null) {
@@ -192,7 +192,7 @@ export default class CommandRunner {
     }
 
     await vscode.commands.executeCommand(
-      "workbench.extensions.action.checkForUpdates"
+      "workbench.extensions.action.checkForUpdates",
     );
   }
 
@@ -207,7 +207,7 @@ export default class CommandRunner {
       const [action, targets, ...extraArgs] = rest as [
         ActionType,
         PartialTargetV0V1[],
-        ...unknown[]
+        ...unknown[],
       ];
 
       command = {
@@ -232,11 +232,11 @@ export default class CommandRunner {
 
 function constructThatTarget(
   targets: Target[] | undefined,
-  selections: SelectionWithEditor[] | undefined
+  selections: SelectionWithEditor[] | undefined,
 ) {
   if (targets != null && selections != null) {
     throw Error(
-      "Actions may only return full targets or selections for that mark"
+      "Actions may only return full targets or selections for that mark",
     );
   }
 

--- a/src/core/commandVersionUpgrades/canonicalizeAndValidateCommand.ts
+++ b/src/core/commandVersionUpgrades/canonicalizeAndValidateCommand.ts
@@ -27,7 +27,7 @@ import { upgradeV2ToV3 } from "./upgradeV2ToV3";
  * @returns The normalized command argument
  */
 export function canonicalizeAndValidateCommand(
-  command: Command
+  command: Command,
 ): CommandComplete {
   const commandUpgraded = upgradeCommand(command);
   const {
@@ -73,7 +73,7 @@ function upgradeCommand(command: Command): CommandLatest {
         break;
       default:
         throw new Error(
-          `Can't upgrade from unknown version ${command.version}`
+          `Can't upgrade from unknown version ${command.version}`,
         );
     }
   }
@@ -87,34 +87,34 @@ function upgradeCommand(command: Command): CommandLatest {
 
 function validateCommand(
   actionName: ActionType,
-  partialTargets: PartialTargetDescriptor[]
+  partialTargets: PartialTargetDescriptor[],
 ) {
   if (
     usesScopeType("notebookCell", partialTargets) &&
     !["editNewLineBefore", "editNewLineAfter"].includes(actionName)
   ) {
     throw new Error(
-      "The notebookCell scope type is currently only supported with the actions editNewLineAbove and editNewLineBelow"
+      "The notebookCell scope type is currently only supported with the actions editNewLineAbove and editNewLineBelow",
     );
   }
 }
 
 function usesScopeType(
   scopeTypeType: SimpleScopeTypeType,
-  partialTargets: PartialTargetDescriptor[]
+  partialTargets: PartialTargetDescriptor[],
 ) {
   return getPartialPrimitiveTargets(partialTargets).some((partialTarget) =>
     partialTarget.modifiers?.find(
       (mod: Modifier) =>
         (mod.type === "containingScope" || mod.type === "everyScope") &&
-        mod.scopeType.type === scopeTypeType
-    )
+        mod.scopeType.type === scopeTypeType,
+    ),
   );
 }
 
 export async function checkForOldInference(
   graph: Graph,
-  partialTargets: PartialTargetDescriptor[]
+  partialTargets: PartialTargetDescriptor[],
 ) {
   const hasOldInference = partialTargets.some((target) => {
     return (
@@ -127,14 +127,14 @@ export async function checkForOldInference(
 
   if (hasOldInference) {
     const hideInferenceWarning = graph.ide.globalState.get(
-      "hideInferenceWarning"
+      "hideInferenceWarning",
     );
 
     if (!hideInferenceWarning) {
       const pressed = await graph.ide.messages.showWarning(
         "deprecatedPositionInference",
         'The "past start of" / "past end of" form has changed behavior.  For the old behavior, update cursorless-talon (https://www.cursorless.org/docs/user/updating/), and then you can now say "past start of its" / "past end of its". For example, "take air past end of its line".  You may also consider using "head" / "tail" instead; see https://www.cursorless.org/docs/#head-and-tail',
-        "Don't show again"
+        "Don't show again",
       );
 
       if (pressed) {

--- a/src/core/commandVersionUpgrades/canonicalizeTargets.ts
+++ b/src/core/commandVersionUpgrades/canonicalizeTargets.ts
@@ -20,7 +20,7 @@ const COLOR_CANONICALIZATION_MAPPING: Record<string, HatStyleName> = {
 };
 
 const canonicalizeScopeTypes = (
-  target: PartialPrimitiveTargetDescriptor
+  target: PartialPrimitiveTargetDescriptor,
 ): PartialPrimitiveTargetDescriptor => {
   target.modifiers?.forEach((mod) => {
     if (mod.type === "containingScope" || mod.type === "everyScope") {
@@ -33,7 +33,7 @@ const canonicalizeScopeTypes = (
 };
 
 const canonicalizeColors = (
-  target: PartialPrimitiveTargetDescriptor
+  target: PartialPrimitiveTargetDescriptor,
 ): PartialPrimitiveTargetDescriptor =>
   target.mark?.type === "decoratedSymbol"
     ? update(target, {
@@ -45,10 +45,10 @@ const canonicalizeColors = (
     : target;
 
 export default function canonicalizeTargets(
-  partialTargets: PartialTargetDescriptor[]
+  partialTargets: PartialTargetDescriptor[],
 ) {
   return transformPartialPrimitiveTargets(
     partialTargets,
-    flow(canonicalizeScopeTypes, canonicalizeColors)
+    flow(canonicalizeScopeTypes, canonicalizeColors),
   );
 }

--- a/src/core/commandVersionUpgrades/upgradeV1ToV2/upgradeStrictHere.ts
+++ b/src/core/commandVersionUpgrades/upgradeV1ToV2/upgradeStrictHere.ts
@@ -14,6 +14,6 @@ const IMPLICIT_TARGET: PartialPrimitiveTargetDescriptorV2 = {
   isImplicit: true,
 };
 export const upgradeStrictHere = (
-  target: PartialPrimitiveTargetDescriptorV2
+  target: PartialPrimitiveTargetDescriptorV2,
 ): PartialPrimitiveTargetDescriptorV2 =>
   isDeepStrictEqual(target, STRICT_HERE) ? IMPLICIT_TARGET : target;

--- a/src/core/commandVersionUpgrades/upgradeV1ToV2/upgradeV1ToV2.ts
+++ b/src/core/commandVersionUpgrades/upgradeV1ToV2/upgradeV1ToV2.ts
@@ -90,7 +90,7 @@ function upgradeModifier(modifier: ModifierV0V1): ModifierV2[] {
 
 function upgradePrimitiveTarget(
   target: PartialPrimitiveTargetV0V1,
-  action: ActionType
+  action: ActionType,
 ): PartialPrimitiveTargetDescriptorV2 {
   const {
     type,
@@ -159,7 +159,7 @@ function upgradePrimitiveTarget(
 
 function upgradeTarget(
   target: PartialTargetV0V1,
-  action: ActionType
+  action: ActionType,
 ): PartialTargetDescriptorV2 {
   switch (target.type) {
     case "list":
@@ -169,7 +169,7 @@ function upgradeTarget(
           (target) =>
             upgradeTarget(target, action) as
               | PartialPrimitiveTargetDescriptorV2
-              | PartialRangeTargetDescriptorV2
+              | PartialRangeTargetDescriptorV2,
         ),
       };
     case "range": {
@@ -190,11 +190,11 @@ function upgradeTarget(
 
 function upgradeTargets(
   partialTargets: PartialTargetV0V1[],
-  action: ActionType
+  action: ActionType,
 ): PartialTargetDescriptorV2[] {
   return partialTargets
     .map((target) => upgradeTarget(target, action))
     .map((target) =>
-      target.type === "primitive" ? upgradeStrictHere(target) : target
+      target.type === "primitive" ? upgradeStrictHere(target) : target,
     );
 }

--- a/src/core/commandVersionUpgrades/upgradeV2ToV3/upgradeV2ToV3.ts
+++ b/src/core/commandVersionUpgrades/upgradeV2ToV3/upgradeV2ToV3.ts
@@ -32,7 +32,7 @@ export function upgradeV2ToV3(command: CommandV2): CommandV3 {
 }
 
 function upgradeTarget(
-  target: PartialTargetDescriptorV2
+  target: PartialTargetDescriptorV2,
 ): PartialTargetDescriptor {
   switch (target.type) {
     case "list":
@@ -42,7 +42,7 @@ function upgradeTarget(
           (target) =>
             upgradeTarget(target) as
               | PartialPrimitiveTargetDescriptor
-              | PartialRangeTargetDescriptor
+              | PartialRangeTargetDescriptor,
         ),
       };
     case "range": {
@@ -59,7 +59,7 @@ function upgradeTarget(
 }
 
 function upgradePrimitiveTarget(
-  target: PartialPrimitiveTargetDescriptorV2
+  target: PartialPrimitiveTargetDescriptorV2,
 ): PartialPrimitiveTargetDescriptor {
   return {
     ...target,
@@ -90,7 +90,7 @@ function updateModifier(modifier: ModifierV2): Modifier {
 }
 
 function createLineNumberMark(
-  mark: LineNumberMarkV2
+  mark: LineNumberMarkV2,
 ): LineNumberMark | RangeMark {
   if (isEqual(mark.anchor, mark.active)) {
     return createLineNumberMarkFromPos(mark.anchor);
@@ -104,7 +104,7 @@ function createLineNumberMark(
 }
 
 function createOrdinalModifier(
-  modifier: OrdinalRangeModifierV2
+  modifier: OrdinalRangeModifierV2,
 ): OrdinalScopeModifier | RangeModifier {
   if (modifier.anchor === modifier.active) {
     return createAbsoluteOrdinalModifier(modifier.scopeType, modifier.anchor);
@@ -120,7 +120,7 @@ function createOrdinalModifier(
 }
 
 function createLineNumberMarkFromPos(
-  position: LineNumberPositionV2
+  position: LineNumberPositionV2,
 ): LineNumberMark {
   return {
     type: "lineNumber",
@@ -131,7 +131,7 @@ function createLineNumberMarkFromPos(
 
 function createAbsoluteOrdinalModifier(
   scopeType: ScopeTypeV2,
-  start: number
+  start: number,
 ): OrdinalScopeModifier {
   return {
     type: "ordinalScope",

--- a/src/core/editStyles.ts
+++ b/src/core/editStyles.ts
@@ -88,7 +88,7 @@ export class EditStyles implements Record<EditStyleName, EditStyle> {
   async displayPendingEditDecorations(
     targets: Target[],
     style: EditStyle,
-    getRange: (target: Target) => Range | undefined = getContentRange
+    getRange: (target: Target) => Range | undefined = getContentRange,
   ) {
     await this.setDecorations(targets, style, getRange);
 
@@ -100,7 +100,7 @@ export class EditStyles implements Record<EditStyleName, EditStyle> {
   displayPendingEditDecorationsForTargets(
     targets: Target[],
     style: EditStyle,
-    isToken: boolean
+    isToken: boolean,
   ) {
     return this.displayPendingEditDecorationsForRanges(
       targets.map(({ editor, contentRange }) => ({
@@ -108,14 +108,14 @@ export class EditStyles implements Record<EditStyleName, EditStyle> {
         range: contentRange,
       })),
       style,
-      isToken
+      isToken,
     );
   }
 
   async displayPendingEditDecorationsForRanges(
     ranges: RangeWithEditor[],
     style: EditStyle,
-    isToken: boolean
+    isToken: boolean,
   ) {
     await runForEachEditor(
       ranges,
@@ -125,9 +125,9 @@ export class EditStyles implements Record<EditStyleName, EditStyle> {
           editor,
           style,
           isToken,
-          ranges.map((range) => range.range)
+          ranges.map((range) => range.range),
         );
-      }
+      },
     );
 
     await decorationSleep();
@@ -137,14 +137,14 @@ export class EditStyles implements Record<EditStyleName, EditStyle> {
       (range) => range.editor,
       async (editor) => {
         editor.setDecorations(style.getDecoration(isToken), []);
-      }
+      },
     );
   }
 
   setDecorations(
     targets: Target[],
     style: EditStyle,
-    getRange: (target: Target) => Range | undefined = getContentRange
+    getRange: (target: Target) => Range | undefined = getContentRange,
   ) {
     return runOnTargetsForEachEditor(targets, async (editor, targets) => {
       this.setEditorDecorations(
@@ -154,7 +154,7 @@ export class EditStyles implements Record<EditStyleName, EditStyle> {
         targets
           .filter((target) => !target.isLine)
           .map(getRange)
-          .filter((range): range is Range => !!range)
+          .filter((range): range is Range => !!range),
       );
       this.setEditorDecorations(
         editor,
@@ -163,7 +163,7 @@ export class EditStyles implements Record<EditStyleName, EditStyle> {
         targets
           .filter((target) => target.isLine)
           .map(getRange)
-          .filter((range): range is Range => !!range)
+          .filter((range): range is Range => !!range),
       );
     });
   }
@@ -179,7 +179,7 @@ export class EditStyles implements Record<EditStyleName, EditStyle> {
     editor: TextEditor,
     style: EditStyle,
     isToken: boolean,
-    ranges: Range[]
+    ranges: Range[],
   ) {
     if (this.graph.testCaseRecorder.isActive() || isTesting()) {
       ranges.forEach((range) => {

--- a/src/core/inferFullTargets.ts
+++ b/src/core/inferFullTargets.ts
@@ -21,16 +21,16 @@ import {
  * @returns Target objects fully filled out and ready to be processed by {@link processTargets}.
  */
 export default function inferFullTargets(
-  targets: PartialTargetDescriptor[]
+  targets: PartialTargetDescriptor[],
 ): TargetDescriptor[] {
   return targets.map((target, index) =>
-    inferTarget(target, targets.slice(0, index))
+    inferTarget(target, targets.slice(0, index)),
   );
 }
 
 function inferTarget(
   target: PartialTargetDescriptor,
-  previousTargets: PartialTargetDescriptor[]
+  previousTargets: PartialTargetDescriptor[],
 ): TargetDescriptor {
   switch (target.type) {
     case "list":
@@ -43,22 +43,22 @@ function inferTarget(
 
 function inferListTarget(
   target: PartialListTargetDescriptor,
-  previousTargets: PartialTargetDescriptor[]
+  previousTargets: PartialTargetDescriptor[],
 ): TargetDescriptor {
   return {
     ...target,
     elements: target.elements.map((element, index) =>
       inferNonListTarget(
         element,
-        previousTargets.concat(target.elements.slice(0, index))
-      )
+        previousTargets.concat(target.elements.slice(0, index)),
+      ),
     ),
   };
 }
 
 function inferNonListTarget(
   target: PartialPrimitiveTargetDescriptor | PartialRangeTargetDescriptor,
-  previousTargets: PartialTargetDescriptor[]
+  previousTargets: PartialTargetDescriptor[],
 ): PrimitiveTargetDescriptor | RangeTargetDescriptor {
   switch (target.type) {
     case "primitive":
@@ -70,7 +70,7 @@ function inferNonListTarget(
 
 function inferRangeTarget(
   target: PartialRangeTargetDescriptor,
-  previousTargets: PartialTargetDescriptor[]
+  previousTargets: PartialTargetDescriptor[],
 ): RangeTargetDescriptor {
   return {
     type: "range",
@@ -80,14 +80,14 @@ function inferRangeTarget(
     anchor: inferPrimitiveTarget(target.anchor, previousTargets),
     active: inferPrimitiveTarget(
       target.active,
-      previousTargets.concat(target.anchor)
+      previousTargets.concat(target.anchor),
     ),
   };
 }
 
 function inferPrimitiveTarget(
   target: PartialPrimitiveTargetDescriptor,
-  previousTargets: PartialTargetDescriptor[]
+  previousTargets: PartialTargetDescriptor[],
 ): PrimitiveTargetDescriptor {
   if (target.isImplicit) {
     return {
@@ -122,14 +122,14 @@ function inferPrimitiveTarget(
 }
 
 function getPositionModifier(
-  target: PartialPrimitiveTargetDescriptor
+  target: PartialPrimitiveTargetDescriptor,
 ): PositionModifier | undefined {
   if (target.modifiers == null) {
     return undefined;
   }
 
   const positionModifierIndex = target.modifiers.findIndex(
-    (modifier) => modifier.type === "position"
+    (modifier) => modifier.type === "position",
   );
 
   if (positionModifierIndex > 0) {
@@ -142,7 +142,7 @@ function getPositionModifier(
 }
 
 function shouldInferPreviousMark(
-  target: PartialPrimitiveTargetDescriptor
+  target: PartialPrimitiveTargetDescriptor,
 ): boolean {
   return target.modifiers?.some((m) => m.type === "inferPreviousMark") ?? false;
 }
@@ -160,10 +160,10 @@ function shouldInferPreviousMark(
  * @returns A list of preserved modifiers or `undefined` if there are none
  */
 function getPreservedModifiers(
-  target: PartialPrimitiveTargetDescriptor
+  target: PartialPrimitiveTargetDescriptor,
 ): Modifier[] | undefined {
   const preservedModifiers = target.modifiers?.filter(
-    (modifier) => !["position", "inferPreviousMark"].includes(modifier.type)
+    (modifier) => !["position", "inferPreviousMark"].includes(modifier.type),
   );
   return preservedModifiers == null || preservedModifiers.length === 0
     ? undefined
@@ -171,22 +171,22 @@ function getPreservedModifiers(
 }
 
 function getPreviousMark(
-  previousTargets: PartialTargetDescriptor[]
+  previousTargets: PartialTargetDescriptor[],
 ): Mark | undefined {
   return getPreviousTargetAttribute(
     previousTargets,
-    (target: PartialPrimitiveTargetDescriptor) => target.mark
+    (target: PartialPrimitiveTargetDescriptor) => target.mark,
   );
 }
 
 function getPreviousPreservedModifiers(
-  previousTargets: PartialTargetDescriptor[]
+  previousTargets: PartialTargetDescriptor[],
 ): Modifier[] | undefined {
   return getPreviousTargetAttribute(previousTargets, getPreservedModifiers);
 }
 
 function getPreviousPositionModifier(
-  previousTargets: PartialTargetDescriptor[]
+  previousTargets: PartialTargetDescriptor[],
 ): PositionModifier | undefined {
   return getPreviousTargetAttribute(previousTargets, getPositionModifier);
 }
@@ -203,7 +203,7 @@ function getPreviousPositionModifier(
  */
 function getPreviousTargetAttribute<T>(
   previousTargets: PartialTargetDescriptor[],
-  getAttribute: (target: PartialPrimitiveTargetDescriptor) => T | undefined
+  getAttribute: (target: PartialPrimitiveTargetDescriptor) => T | undefined,
 ): T | undefined {
   // Search from back(last) to front(first)
   for (let i = previousTargets.length - 1; i > -1; --i) {
@@ -226,7 +226,7 @@ function getPreviousTargetAttribute<T>(
       case "list": {
         const attributeValue = getPreviousTargetAttribute(
           target.elements,
-          getAttribute
+          getAttribute,
         );
         if (attributeValue != null) {
           return attributeValue;

--- a/src/core/tokenizer.ts
+++ b/src/core/tokenizer.ts
@@ -66,7 +66,7 @@ interface Matcher {
 const defaultMatcher = generateMatcher();
 
 function generateMatcher(
-  languageOverrides: LanguageTokenizerOverrides = {}
+  languageOverrides: LanguageTokenizerOverrides = {},
 ): Matcher {
   const {
     fixedTokens,
@@ -88,7 +88,7 @@ function generateMatcher(
   const fixedTokensRegex = fixedTokens.map(escapeRegExp).join("|");
 
   const identifierComponents = identifierWordRegexes.concat(
-    identifierWordDelimiters.map(escapeRegExp)
+    identifierWordDelimiters.map(escapeRegExp),
   );
   const identifiersRegex = `(${identifierComponents.join("|")})+`;
   const wordRegex = `(${identifierWordRegexes.join("|")})+`;
@@ -119,7 +119,7 @@ const languageTokenizerOverrides: Partial<
 
 const tokenMatchersForLanguage: Partial<Record<LanguageId, Matcher>> =
   mapValues(languageTokenizerOverrides, (val: LanguageTokenizerComponents) =>
-    generateMatcher(val)
+    generateMatcher(val),
   );
 
 export function getMatcher(languageId: string): Matcher {
@@ -132,7 +132,7 @@ export function getMatcher(languageId: string): Matcher {
 export function tokenize<T>(
   text: string,
   languageId: string,
-  mapfn: (v: RegExpMatchArray, k: number) => T
+  mapfn: (v: RegExpMatchArray, k: number) => T,
 ) {
   return matchAll(text, getMatcher(languageId).tokenMatcher, mapfn);
 }

--- a/src/core/updateSelections/RangeUpdater.ts
+++ b/src/core/updateSelections/RangeUpdater.ts
@@ -43,7 +43,7 @@ export class RangeUpdater {
    */
   registerRangeInfoList(
     document: TextDocument,
-    rangeInfoList: FullRangeInfo[]
+    rangeInfoList: FullRangeInfo[],
   ): () => void {
     const documentRangeInfoLists = this.getDocumentRangeInfoLists(document);
 
@@ -70,7 +70,7 @@ export class RangeUpdater {
    */
   registerReplaceEditList(
     document: TextDocument,
-    replaceEditList: Edit[]
+    replaceEditList: Edit[],
   ): () => void {
     const documentReplaceEditLists = this.getDocumentReplaceEditLists(document);
 
@@ -93,7 +93,7 @@ export class RangeUpdater {
     this.disposable = workspace.onDidChangeTextDocument(
       (event: TextDocumentChangeEvent) => {
         const documentReplaceEditLists = this.getDocumentReplaceEditLists(
-          event.document
+          event.document,
         );
 
         const extendedEvent: ExtendedTextDocumentChangeEvent = {
@@ -104,15 +104,15 @@ export class RangeUpdater {
                   ...change,
                   isReplace: true,
                 }
-              : change
+              : change,
           ),
         };
 
         updateRangeInfos(
           extendedEvent,
-          this.documentRangeInfoGenerator(event.document)
+          this.documentRangeInfoGenerator(event.document),
         );
-      }
+      },
     );
   }
 
@@ -123,7 +123,7 @@ export class RangeUpdater {
 
 function isReplace(
   documentReplaceEditLists: Edit[][],
-  change: TextDocumentContentChangeEvent
+  change: TextDocumentContentChangeEvent,
 ) {
   for (const replaceEditLists of documentReplaceEditLists) {
     for (const replaceEdit of replaceEditLists) {

--- a/src/core/updateSelections/getOffsetsForDeleteOrReplace.ts
+++ b/src/core/updateSelections/getOffsetsForDeleteOrReplace.ts
@@ -28,7 +28,7 @@ import {
  */
 export default function getOffsetsForDeleteOrReplace(
   changeEventInfo: ChangeEventInfo,
-  rangeInfo: FullRangeInfo
+  rangeInfo: FullRangeInfo,
 ): RangeOffsets {
   const {
     originalOffsets: {
@@ -44,12 +44,12 @@ export default function getOffsetsForDeleteOrReplace(
 
   invariant(
     changeOriginalEndOffset > changeOriginalStartOffset,
-    () => "Change range expected to be nonempty"
+    () => "Change range expected to be nonempty",
   );
   invariant(
     changeOriginalEndOffset >= rangeStart &&
       changeOriginalStartOffset <= rangeEnd,
-    () => "Change range expected to intersect with selection range"
+    () => "Change range expected to intersect with selection range",
   );
 
   return {

--- a/src/core/updateSelections/getOffsetsForEmptyRangeInsert.ts
+++ b/src/core/updateSelections/getOffsetsForEmptyRangeInsert.ts
@@ -33,7 +33,7 @@ import {
  */
 export default function getOffsetsForEmptyRangeInsert(
   changeEventInfo: ChangeEventInfo,
-  rangeInfo: FullRangeInfo
+  rangeInfo: FullRangeInfo,
 ): RangeOffsets {
   const {
     event: { text, isReplace },
@@ -44,7 +44,7 @@ export default function getOffsetsForEmptyRangeInsert(
     start === changeEventInfo.originalOffsets.end &&
       start === rangeInfo.offsets.start &&
       start === rangeInfo.offsets.end,
-    () => "Selection range and change range expected to be same empty range"
+    () => "Selection range and change range expected to be same empty range",
   );
 
   if (isReplace) {

--- a/src/core/updateSelections/getOffsetsForNonEmptyRangeInsert.ts
+++ b/src/core/updateSelections/getOffsetsForNonEmptyRangeInsert.ts
@@ -33,7 +33,7 @@ import {
  */
 export default function getOffsetsForNonEmptyRangeInsert(
   changeEventInfo: ChangeEventInfo,
-  rangeInfo: FullRangeInfo
+  rangeInfo: FullRangeInfo,
 ): RangeOffsets {
   const {
     event: { text: insertedText },
@@ -47,11 +47,11 @@ export default function getOffsetsForNonEmptyRangeInsert(
 
   invariant(
     rangeEnd > rangeStart,
-    () => "Selection range expected to be nonempty"
+    () => "Selection range expected to be nonempty",
   );
   invariant(
     insertOffset >= rangeStart && insertOffset <= rangeEnd,
-    () => "Insertion offset expected to intersect with selection range"
+    () => "Insertion offset expected to intersect with selection range",
   );
 
   if (insertOffset > rangeStart && insertOffset < rangeEnd) {

--- a/src/core/updateSelections/getUpdatedText.ts
+++ b/src/core/updateSelections/getUpdatedText.ts
@@ -20,7 +20,7 @@ import {
 export function getUpdatedText(
   changeEventInfo: ChangeEventInfo,
   rangeInfo: FullRangeInfo,
-  newOffsets: RangeOffsets
+  newOffsets: RangeOffsets,
 ): string {
   const { start: changeOriginalOffsetsStart, end: changeOriginalOffsetsEnd } =
     changeEventInfo.originalOffsets;
@@ -29,7 +29,7 @@ export function getUpdatedText(
 
   const newTextStartOffset = Math.min(
     changeOriginalOffsetsStart,
-    rangeOriginalOffsetsStart
+    rangeOriginalOffsetsStart,
   );
 
   let result = "";
@@ -38,7 +38,7 @@ export function getUpdatedText(
   if (rangeOriginalOffsetsStart < changeOriginalOffsetsStart) {
     result += rangeInfo.text.substring(
       0,
-      changeOriginalOffsetsStart - rangeOriginalOffsetsStart
+      changeOriginalOffsetsStart - rangeOriginalOffsetsStart,
     );
   }
 
@@ -49,13 +49,13 @@ export function getUpdatedText(
   if (changeOriginalOffsetsEnd < rangeOriginalOffsetsEnd) {
     result += rangeInfo.text.substring(
       rangeOriginalOffsetsEnd - changeOriginalOffsetsEnd,
-      rangeInfo.text.length
+      rangeInfo.text.length,
     );
   }
 
   // Then take a substring based on the range's new offsets
   return result.substring(
     newOffsets.start - newTextStartOffset,
-    newOffsets.end - newTextStartOffset
+    newOffsets.end - newTextStartOffset,
   );
 }

--- a/src/core/updateSelections/updateRangeInfos.ts
+++ b/src/core/updateSelections/updateRangeInfos.ts
@@ -28,7 +28,7 @@ import { getUpdatedText } from "./getUpdatedText";
  */
 export function updateRangeInfos(
   changeEvent: ExtendedTextDocumentChangeEvent,
-  rangeInfoGenerator: Generator<FullRangeInfo, void, unknown>
+  rangeInfoGenerator: Generator<FullRangeInfo, void, unknown>,
 ) {
   const { document, contentChanges } = changeEvent;
 
@@ -91,12 +91,12 @@ export function updateRangeInfos(
         if (rangeInfo.range.isEmpty) {
           newOffsets = getOffsetsForEmptyRangeInsert(
             changeEventInfo,
-            rangeInfo
+            rangeInfo,
           );
         } else {
           newOffsets = getOffsetsForNonEmptyRangeInsert(
             changeEventInfo,
-            rangeInfo
+            rangeInfo,
           );
         }
       } else {
@@ -123,7 +123,7 @@ export function updateRangeInfos(
     // Do final range and offset update
     rangeInfo.range = rangeInfo.range.with(
       document.positionAt(newOffsets.start),
-      document.positionAt(newOffsets.end)
+      document.positionAt(newOffsets.end),
     );
     rangeInfo.offsets = newOffsets;
   }

--- a/src/core/updateSelections/updateSelections.ts
+++ b/src/core/updateSelections/updateSelections.ts
@@ -32,13 +32,13 @@ interface SelectionsWithBehavior {
 export function getSelectionInfo(
   document: TextDocument,
   selection: Selection,
-  rangeBehavior: DecorationRangeBehavior
+  rangeBehavior: DecorationRangeBehavior,
 ): FullSelectionInfo {
   return getSelectionInfoInternal(
     document,
     selection,
     isForward(selection),
-    rangeBehavior
+    rangeBehavior,
   );
 }
 
@@ -46,7 +46,7 @@ function getSelectionInfoInternal(
   document: TextDocument,
   range: Range,
   isForward: boolean,
-  rangeBehavior: DecorationRangeBehavior
+  rangeBehavior: DecorationRangeBehavior,
 ): FullSelectionInfo {
   return {
     range,
@@ -86,30 +86,30 @@ function getSelectionInfoInternal(
 function selectionsToSelectionInfos(
   document: TextDocument,
   selectionMatrix: (readonly Selection[])[],
-  rangeBehavior: DecorationRangeBehavior = DecorationRangeBehavior.ClosedClosed
+  rangeBehavior: DecorationRangeBehavior = DecorationRangeBehavior.ClosedClosed,
 ): FullSelectionInfo[][] {
   return selectionMatrix.map((selections) =>
     selections.map((selection) =>
-      getSelectionInfo(document, selection, rangeBehavior)
-    )
+      getSelectionInfo(document, selection, rangeBehavior),
+    ),
   );
 }
 
 function rangesToSelectionInfos(
   document: TextDocument,
   rangeMatrix: (readonly Range[])[],
-  rangeBehavior: DecorationRangeBehavior = DecorationRangeBehavior.ClosedClosed
+  rangeBehavior: DecorationRangeBehavior = DecorationRangeBehavior.ClosedClosed,
 ): FullSelectionInfo[][] {
   return rangeMatrix.map((ranges) =>
     ranges.map((range) =>
-      getSelectionInfoInternal(document, range, false, rangeBehavior)
-    )
+      getSelectionInfoInternal(document, range, false, rangeBehavior),
+    ),
   );
 }
 
 function fillOutSelectionInfos(
   document: TextDocument,
-  selectionInfoMatrix: SelectionInfo[][]
+  selectionInfoMatrix: SelectionInfo[][],
 ): selectionInfoMatrix is FullSelectionInfo[][] {
   selectionInfoMatrix.forEach((selectionInfos) =>
     selectionInfos.map((selectionInfo) => {
@@ -121,18 +121,18 @@ function fillOutSelectionInfos(
         },
         text: document.getText(range),
       });
-    })
+    }),
   );
   return true;
 }
 
 function selectionInfosToSelections(
-  selectionInfoMatrix: SelectionInfo[][]
+  selectionInfoMatrix: SelectionInfo[][],
 ): Selection[][] {
   return selectionInfoMatrix.map((selectionInfos) =>
     selectionInfos.map(({ range: { start, end }, isForward }) =>
-      isForward ? new Selection(start, end) : new Selection(end, start)
-    )
+      isForward ? new Selection(start, end) : new Selection(end, start),
+    ),
   );
 }
 
@@ -149,18 +149,18 @@ export async function callFunctionAndUpdateSelections(
   rangeUpdater: RangeUpdater,
   func: () => Thenable<void>,
   document: TextDocument,
-  selectionMatrix: (readonly Selection[])[]
+  selectionMatrix: (readonly Selection[])[],
 ): Promise<Selection[][]> {
   const selectionInfoMatrix = selectionsToSelectionInfos(
     document,
-    selectionMatrix
+    selectionMatrix,
   );
 
   return await callFunctionAndUpdateSelectionInfos(
     rangeUpdater,
     func,
     document,
-    selectionInfoMatrix
+    selectionInfoMatrix,
   );
 }
 
@@ -168,7 +168,7 @@ export async function callFunctionAndUpdateRanges(
   rangeUpdater: RangeUpdater,
   func: () => Thenable<void>,
   document: TextDocument,
-  rangeMatrix: (readonly Range[])[]
+  rangeMatrix: (readonly Range[])[],
 ): Promise<Range[][]> {
   const selectionInfoMatrix = rangesToSelectionInfos(document, rangeMatrix);
 
@@ -176,7 +176,7 @@ export async function callFunctionAndUpdateRanges(
     rangeUpdater,
     func,
     document,
-    selectionInfoMatrix
+    selectionInfoMatrix,
   );
 }
 
@@ -193,11 +193,11 @@ export async function callFunctionAndUpdateSelectionInfos(
   rangeUpdater: RangeUpdater,
   func: () => Thenable<void>,
   document: TextDocument,
-  selectionInfoMatrix: FullSelectionInfo[][]
+  selectionInfoMatrix: FullSelectionInfo[][],
 ) {
   const unsubscribe = rangeUpdater.registerRangeInfoList(
     document,
-    flatten(selectionInfoMatrix)
+    flatten(selectionInfoMatrix),
   );
 
   await func();
@@ -220,7 +220,7 @@ export function callFunctionAndUpdateSelectionsWithBehavior(
   rangeUpdater: RangeUpdater,
   func: () => Thenable<void>,
   document: TextDocument,
-  originalSelections: SelectionsWithBehavior[]
+  originalSelections: SelectionsWithBehavior[],
 ) {
   return callFunctionAndUpdateSelectionInfos(
     rangeUpdater,
@@ -232,10 +232,10 @@ export function callFunctionAndUpdateSelectionsWithBehavior(
           document,
           selection,
           selectionsWithBehavior.rangeBehavior ??
-            DecorationRangeBehavior.ClosedClosed
-        )
-      )
-    )
+            DecorationRangeBehavior.ClosedClosed,
+        ),
+      ),
+    ),
   );
 }
 
@@ -252,18 +252,18 @@ export async function performEditsAndUpdateSelections(
   rangeUpdater: RangeUpdater,
   editor: TextEditor,
   edits: Edit[],
-  originalSelections: (readonly Selection[])[]
+  originalSelections: (readonly Selection[])[],
 ) {
   const document = editor.document;
   const selectionInfoMatrix = selectionsToSelectionInfos(
     document,
-    originalSelections
+    originalSelections,
   );
   return performEditsAndUpdateInternal(
     rangeUpdater,
     editor,
     edits,
-    selectionInfoMatrix
+    selectionInfoMatrix,
   );
 }
 
@@ -281,7 +281,7 @@ export function performEditsAndUpdateSelectionsWithBehavior(
   rangeUpdater: RangeUpdater,
   editor: TextEditor,
   edits: Edit[],
-  originalSelections: SelectionsWithBehavior[]
+  originalSelections: SelectionsWithBehavior[],
 ) {
   return performEditsAndUpdateFullSelectionInfos(
     rangeUpdater,
@@ -293,10 +293,10 @@ export function performEditsAndUpdateSelectionsWithBehavior(
           editor.document,
           selection,
           selectionsWithBehavior.rangeBehavior ??
-            DecorationRangeBehavior.ClosedClosed
-        )
-      )
-    )
+            DecorationRangeBehavior.ClosedClosed,
+        ),
+      ),
+    ),
   );
 }
 
@@ -304,7 +304,7 @@ export async function performEditsAndUpdateRanges(
   rangeUpdater: RangeUpdater,
   editor: TextEditor,
   edits: Edit[],
-  originalRanges: (readonly Range[])[]
+  originalRanges: (readonly Range[])[],
 ): Promise<Range[][]> {
   const document = editor.document;
   const selectionInfoMatrix = rangesToSelectionInfos(document, originalRanges);
@@ -312,7 +312,7 @@ export async function performEditsAndUpdateRanges(
     rangeUpdater,
     editor,
     edits,
-    selectionInfoMatrix
+    selectionInfoMatrix,
   );
 }
 
@@ -320,13 +320,13 @@ async function performEditsAndUpdateInternal(
   rangeUpdater: RangeUpdater,
   editor: TextEditor,
   edits: Edit[],
-  selectionInfoMatrix: FullSelectionInfo[][]
+  selectionInfoMatrix: FullSelectionInfo[][],
 ) {
   await performEditsAndUpdateFullSelectionInfos(
     rangeUpdater,
     editor,
     edits,
-    selectionInfoMatrix
+    selectionInfoMatrix,
   );
   return selectionInfosToSelections(selectionInfoMatrix);
 }
@@ -336,7 +336,7 @@ export async function performEditsAndUpdateSelectionInfos(
   rangeUpdater: RangeUpdater,
   editor: TextEditor,
   edits: Edit[],
-  originalSelectionInfos: SelectionInfo[][]
+  originalSelectionInfos: SelectionInfo[][],
 ): Promise<Selection[][]> {
   fillOutSelectionInfos(editor.document, originalSelectionInfos);
 
@@ -344,7 +344,7 @@ export async function performEditsAndUpdateSelectionInfos(
     rangeUpdater,
     editor,
     edits,
-    originalSelectionInfos as FullSelectionInfo[][]
+    originalSelectionInfos as FullSelectionInfo[][],
   );
 }
 
@@ -361,7 +361,7 @@ export async function performEditsAndUpdateFullSelectionInfos(
   rangeUpdater: RangeUpdater,
   editor: TextEditor,
   edits: Edit[],
-  originalSelectionInfos: FullSelectionInfo[][]
+  originalSelectionInfos: FullSelectionInfo[][],
 ): Promise<Selection[][]> {
   // NB: We do everything using VSCode listeners.  We can associate changes
   // with our changes just by looking at their offets / text in order to
@@ -390,7 +390,7 @@ export async function performEditsAndUpdateFullSelectionInfos(
     const wereEditsApplied = await performDocumentEdits(
       rangeUpdater,
       editor,
-      edits
+      edits,
     );
 
     if (!wereEditsApplied) {
@@ -402,7 +402,7 @@ export async function performEditsAndUpdateFullSelectionInfos(
     rangeUpdater,
     func,
     editor.document,
-    originalSelectionInfos
+    originalSelectionInfos,
   );
 
   return selectionInfosToSelections(originalSelectionInfos);

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,7 +1,7 @@
 export class UnsupportedLanguageError extends Error {
   constructor(languageId: string) {
     super(
-      `Language '${languageId}' is not implemented yet; See https://www.cursorless.org/docs/contributing/adding-a-new-language/`
+      `Language '${languageId}' is not implemented yet; See https://www.cursorless.org/docs/contributing/adding-a-new-language/`,
     );
     this.name = "UnsupportedLanguageError";
   }
@@ -17,7 +17,7 @@ export class UnsupportedError extends Error {
 export class OutdatedExtensionError extends Error {
   constructor() {
     super(
-      "Cursorless Talon version is ahead of Cursorless VSCode extension version. Please update Cursorless VSCode."
+      "Cursorless Talon version is ahead of Cursorless VSCode extension version. Please update Cursorless VSCode.",
     );
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -26,7 +26,7 @@ export async function activate(context: vscode.ExtensionContext) {
       commandServerApi: () => commandServerApi,
       getNodeAtLocation: () => getNodeAtLocation,
     } as FactoryMap<Graph>,
-    ["ide"]
+    ["ide"],
   );
   graph.debug.init();
   graph.snippets.init();

--- a/src/ide/ide.types.ts
+++ b/src/ide/ide.types.ts
@@ -22,7 +22,7 @@ export type CursorlessConfigKey = keyof CursorlessConfiguration;
 
 export interface Configuration {
   getOwnConfiguration<T extends CursorlessConfigKey>(
-    key: T
+    key: T,
   ): CursorlessConfiguration[T] | undefined;
   onDidChangeConfiguration(listener: Listener): Disposable;
 }

--- a/src/ide/vscode/VscodeConfiguration.ts
+++ b/src/ide/vscode/VscodeConfiguration.ts
@@ -14,12 +14,12 @@ export default class VscodeConfiguration implements Configuration {
     this.onDidChangeConfiguration = this.onDidChangeConfiguration.bind(this);
 
     ide.disposeOnExit(
-      vscode.workspace.onDidChangeConfiguration(this.notifier.notifyListeners)
+      vscode.workspace.onDidChangeConfiguration(this.notifier.notifyListeners),
     );
   }
 
   getOwnConfiguration<T extends CursorlessConfigKey>(
-    key: T
+    key: T,
   ): CursorlessConfiguration[T] | undefined {
     return vscode.workspace
       .getConfiguration("cursorless")

--- a/src/languages/clojure.ts
+++ b/src/languages/clojure.ts
@@ -24,7 +24,7 @@ import { patternFinder } from "../util/nodeFinders";
 function parityNodeFinder(parentFinder: NodeFinder, parity: 0 | 1) {
   return indexNodeFinder(
     parentFinder,
-    (nodeIndex: number) => Math.floor(nodeIndex / 2) * 2 + parity
+    (nodeIndex: number) => Math.floor(nodeIndex / 2) * 2 + parity,
   );
 }
 
@@ -44,7 +44,7 @@ function mapParityNodeFinder(parity: 0 | 1) {
  */
 function indexNodeFinder(
   parentFinder: NodeFinder,
-  indexTransform: (index: number) => number
+  indexTransform: (index: number) => number,
 ) {
   return (node: SyntaxNode) => {
     const parent = node.parent;
@@ -76,7 +76,7 @@ function indexNodeFinder(
 function itemFinder() {
   return indexNodeFinder(
     (node) => node,
-    (nodeIndex: number) => nodeIndex
+    (nodeIndex: number) => nodeIndex,
   );
 }
 
@@ -125,7 +125,7 @@ const ifStatementFinder = functionNameBasedFinder(
   "if",
   "if-let",
   "when",
-  "when-let"
+  "when-let",
 );
 
 const ifStatementMatcher = matcher(ifStatementFinder);
@@ -145,20 +145,20 @@ const nodeMatchers: Partial<
         (node) => node.type === "{" || node.type === "}",
         ", ",
         identity,
-        mapParityNodeFinder(1) as (node: SyntaxNode) => SyntaxNode
-      )
+        mapParityNodeFinder(1) as (node: SyntaxNode) => SyntaxNode,
+      ),
     ),
 
     // Otherwise just treat every item within a list as an item
-    matcher(itemFinder())
+    matcher(itemFinder()),
   ),
   value: matcher(mapParityNodeFinder(1)),
 
   // TODO: Handle formal parameters
   argumentOrParameter: matcher(
     indexNodeFinder(patternFinder(functionCallPattern), (nodeIndex: number) =>
-      nodeIndex !== 0 ? nodeIndex : -1
-    )
+      nodeIndex !== 0 ? nodeIndex : -1,
+    ),
   ),
 
   // A list is either a vector literal or a quoted list literal
@@ -181,7 +181,7 @@ const nodeMatchers: Partial<
 
   anonymousFunction: cascadingMatcher(
     functionNameBasedMatcher("fn"),
-    patternMatcher("anon_fn_lit")
+    patternMatcher("anon_fn_lit"),
   ),
 
   ifStatement: ifStatementMatcher,

--- a/src/languages/cpp.ts
+++ b/src/languages/cpp.ts
@@ -111,7 +111,7 @@ const nodeMatchers: Partial<
       "assignment_expression[right]",
       "optional_parameter_declaration[default_value]",
     ],
-    [":", "=", "+=", "-=", "*=", "/=", "%=", "&=", "|=", "^=", "<<=", ">>="]
+    [":", "=", "+=", "-=", "*=", "/=", "%=", "&=", "|=", "^=", "<<=", ">>="],
   ),
   argumentOrParameter: argumentMatcher("parameter_list", "argument_list"),
   attribute: "attribute",

--- a/src/languages/csharp.ts
+++ b/src/languages/csharp.ts
@@ -99,7 +99,7 @@ const makeDelimitedSelector = (leftType: string, rightType: string) =>
   delimitedSelector(
     (node) =>
       node.type === "," || node.type === leftType || node.type === rightType,
-    ", "
+    ", ",
   );
 
 const getMapMatchers = {
@@ -111,7 +111,7 @@ const getMapMatchers = {
     chainedMatcher([
       typedNodeFinder("object_creation_expression"),
       getInitializerNode,
-    ])
+    ]),
   ),
   collectionKey: chainedMatcher([
     typedNodeFinder("assignment_expression"),
@@ -122,7 +122,7 @@ const getMapMatchers = {
       "variable_declaration?.variable_declarator[1][0]!",
       "assignment_expression[right]",
     ],
-    ["assignment_operator"]
+    ["assignment_operator"],
   ),
   list: cascadingMatcher(
     chainedMatcher([
@@ -132,7 +132,7 @@ const getMapMatchers = {
     chainedMatcher([
       typedNodeFinder("object_creation_expression"),
       (node: SyntaxNode) => node.childForFieldName("initializer"),
-    ])
+    ]),
   ),
   string: typeMatcher("string_literal"),
 };
@@ -146,7 +146,7 @@ const nodeMatchers: Partial<
   className: "class_declaration[name]",
   condition: cascadingMatcher(
     conditionMatcher("*[condition]"),
-    patternMatcher("while_statement[0]")
+    patternMatcher("while_statement[0]"),
   ),
   statement: STATEMENT_TYPES,
   anonymousFunction: "lambda_expression",
@@ -155,15 +155,15 @@ const nodeMatchers: Partial<
     patternMatcher("invocation_expression[function]"),
     matcher(
       patternFinder("object_creation_expression"),
-      childRangeSelector(["argument_list"], [])
-    )
+      childRangeSelector(["argument_list"], []),
+    ),
   ),
   argumentOrParameter: matcher(
     nodeFinder(
       (node) =>
-        node.parent?.type === "argument_list" || node.type === "parameter"
+        node.parent?.type === "argument_list" || node.type === "parameter",
     ),
-    makeDelimitedSelector("(", ")")
+    makeDelimitedSelector("(", ")"),
   ),
   namedFunction: NAMED_FUNCTION_TYPES,
   functionName: NAMED_FUNCTION_TYPES.map((t) => t + "[name]"),

--- a/src/languages/getNodeMatcher.ts
+++ b/src/languages/getNodeMatcher.ts
@@ -29,7 +29,7 @@ import { SupportedLanguageId } from "./constants";
 export function getNodeMatcher(
   languageId: string,
   scopeTypeType: SimpleScopeTypeType,
-  includeSiblings: boolean
+  includeSiblings: boolean,
 ): NodeMatcher {
   const matchers = languageMatchers[languageId as SupportedLanguageId];
 
@@ -82,7 +82,7 @@ const languageMatchers: Record<
 function matcherIncludeSiblings(matcher: NodeMatcher): NodeMatcher {
   return (
     selection: SelectionWithEditor,
-    node: SyntaxNode
+    node: SyntaxNode,
   ): NodeMatcherValue[] | null => {
     let matches = matcher(selection, node);
     if (matches == null) {
@@ -92,8 +92,8 @@ function matcherIncludeSiblings(matcher: NodeMatcher): NodeMatcher {
       iterateNearestIterableAncestor(
         match.node,
         selectionWithEditorFromRange(selection, match.selection.selection),
-        matcher
-      )
+        matcher,
+      ),
     ) as NodeMatcherValue[];
     if (matches.length > 0) {
       return matches;
@@ -105,7 +105,7 @@ function matcherIncludeSiblings(matcher: NodeMatcher): NodeMatcher {
 function iterateNearestIterableAncestor(
   node: SyntaxNode,
   selection: SelectionWithEditor,
-  nodeMatcher: NodeMatcher
+  nodeMatcher: NodeMatcher,
 ) {
   let parent: SyntaxNode | null = node.parent;
   while (parent != null) {

--- a/src/languages/getTextFragmentExtractor.ts
+++ b/src/languages/getTextFragmentExtractor.ts
@@ -15,12 +15,12 @@ import { notSupported } from "../util/nodeMatchers";
 
 export type TextFragmentExtractor = (
   node: SyntaxNode,
-  selection: SelectionWithEditor
+  selection: SelectionWithEditor,
 ) => Range | null;
 
 function constructDefaultTextFragmentExtractor(
   languageId: SupportedLanguageId,
-  stringTextFragmentExtractor?: TextFragmentExtractor
+  stringTextFragmentExtractor?: TextFragmentExtractor,
 ): TextFragmentExtractor {
   const commentNodeMatcher = getNodeMatcher(languageId, "comment", false);
   stringTextFragmentExtractor =
@@ -52,7 +52,7 @@ function constructDefaultTextFragmentExtractor(
 }
 
 function constructDefaultStringTextFragmentExtractor(
-  languageId: SupportedLanguageId
+  languageId: SupportedLanguageId,
 ): TextFragmentExtractor {
   const stringNodeMatcher = getNodeMatcher(languageId, "string", false);
 
@@ -80,7 +80,7 @@ function constructDefaultStringTextFragmentExtractor(
  * @returns The range of the string text or null if the node is not a string
  */
 function constructHackedStringTextFragmentExtractor(
-  languageId: SupportedLanguageId
+  languageId: SupportedLanguageId,
 ) {
   const stringNodeMatcher = getNodeMatcher(languageId, "string", false);
 
@@ -104,7 +104,7 @@ function constructHackedStringTextFragmentExtractor(
  * @returns The text fragment extractor for the given language
  */
 export default function getTextFragmentExtractor(
-  languageId: string
+  languageId: string,
 ): TextFragmentExtractor {
   const extractor = textFragmentExtractors[languageId as SupportedLanguageId];
 
@@ -128,69 +128,69 @@ const textFragmentExtractors: Record<
   c: constructDefaultTextFragmentExtractor("c"),
   clojure: constructDefaultTextFragmentExtractor(
     "clojure",
-    constructHackedStringTextFragmentExtractor("clojure")
+    constructHackedStringTextFragmentExtractor("clojure"),
   ),
   cpp: constructDefaultTextFragmentExtractor("cpp"),
   csharp: constructDefaultTextFragmentExtractor("csharp"),
   css: constructDefaultTextFragmentExtractor(
     "css",
-    scssStringTextFragmentExtractor
+    scssStringTextFragmentExtractor,
   ),
   go: constructDefaultTextFragmentExtractor("go"),
   html: constructDefaultTextFragmentExtractor(
     "html",
-    htmlStringTextFragmentExtractor
+    htmlStringTextFragmentExtractor,
   ),
   java: constructDefaultTextFragmentExtractor(
     "java",
-    constructHackedStringTextFragmentExtractor("java")
+    constructHackedStringTextFragmentExtractor("java"),
   ),
   javascript: constructDefaultTextFragmentExtractor(
     "javascript",
-    typescriptStringTextFragmentExtractor
+    typescriptStringTextFragmentExtractor,
   ),
   javascriptreact: constructDefaultTextFragmentExtractor(
     "javascriptreact",
-    typescriptStringTextFragmentExtractor
+    typescriptStringTextFragmentExtractor,
   ),
   jsonc: constructDefaultTextFragmentExtractor(
     "jsonc",
-    jsonStringTextFragmentExtractor
+    jsonStringTextFragmentExtractor,
   ),
   json: constructDefaultTextFragmentExtractor(
     "json",
-    jsonStringTextFragmentExtractor
+    jsonStringTextFragmentExtractor,
   ),
   latex: fullDocumentTextFragmentExtractor,
   markdown: fullDocumentTextFragmentExtractor,
   php: constructDefaultTextFragmentExtractor(
     "php",
-    phpStringTextFragmentExtractor
+    phpStringTextFragmentExtractor,
   ),
   python: constructDefaultTextFragmentExtractor("python"),
   ruby: constructDefaultTextFragmentExtractor(
     "ruby",
-    rubyStringTextFragmentExtractor
+    rubyStringTextFragmentExtractor,
   ),
   scala: constructDefaultTextFragmentExtractor(
     "scala",
-    constructHackedStringTextFragmentExtractor("scala")
+    constructHackedStringTextFragmentExtractor("scala"),
   ),
   scss: constructDefaultTextFragmentExtractor(
     "scss",
-    scssStringTextFragmentExtractor
+    scssStringTextFragmentExtractor,
   ),
   rust: constructDefaultTextFragmentExtractor("rust"),
   typescript: constructDefaultTextFragmentExtractor(
     "typescript",
-    typescriptStringTextFragmentExtractor
+    typescriptStringTextFragmentExtractor,
   ),
   typescriptreact: constructDefaultTextFragmentExtractor(
     "typescriptreact",
-    typescriptStringTextFragmentExtractor
+    typescriptStringTextFragmentExtractor,
   ),
   xml: constructDefaultTextFragmentExtractor(
     "xml",
-    htmlStringTextFragmentExtractor
+    htmlStringTextFragmentExtractor,
   ),
 };

--- a/src/languages/go.ts
+++ b/src/languages/go.ts
@@ -62,12 +62,12 @@ const nodeMatchers: Partial<
   argumentOrParameter: cascadingMatcher(
     argumentMatcher("argument_list", "parameter_list"),
     patternMatcher("parameter_declaration"),
-    patternMatcher("argument_declaration")
+    patternMatcher("argument_declaration"),
   ),
   collectionKey: "keyed_element[0]",
   value: cascadingMatcher(
     patternMatcher("keyed_element[1]"),
-    patternMatcher("return_statement.expression_list!")
+    patternMatcher("return_statement.expression_list!"),
   ),
 };
 

--- a/src/languages/html.ts
+++ b/src/languages/html.ts
@@ -26,7 +26,7 @@ const nodeMatchers: Partial<
 > = {
   xmlElement: matcher(
     typedNodeFinder("element", "script_element", "style_element"),
-    xmlElementExtractor
+    xmlElementExtractor,
   ),
   xmlBothTags: getTags,
   xmlStartTag: getStartTag,
@@ -37,7 +37,7 @@ const nodeMatchers: Partial<
   collectionKey: ["*?.attribute_name!"],
   value: leadingMatcher(
     ["*?.quoted_attribute_value!.attribute_value", "*?.attribute_value!"],
-    ["="]
+    ["="],
   ),
   string: "quoted_attribute_value",
   comment: "comment",
@@ -49,7 +49,7 @@ const textFragmentTypes = ["attribute_value", "raw_text", "text"];
 
 export function stringTextFragmentExtractor(
   node: SyntaxNode,
-  _selection: SelectionWithEditor
+  _selection: SelectionWithEditor,
 ) {
   if (textFragmentTypes.includes(node.type)) {
     return getNodeRange(node);

--- a/src/languages/index.ts
+++ b/src/languages/index.ts
@@ -1,7 +1,7 @@
 import { SupportedLanguageId, supportedLanguageIds } from "./constants";
 
 export function isLanguageSupported(
-  languageId: string
+  languageId: string,
 ): languageId is SupportedLanguageId {
   return languageId in supportedLanguageIds;
 }

--- a/src/languages/java.ts
+++ b/src/languages/java.ts
@@ -68,16 +68,16 @@ const nodeMatchers: Partial<
   functionCallee: cascadingMatcher(
     matcher(
       patternFinder("method_invocation"),
-      childRangeSelector(["argument_list"], [])
+      childRangeSelector(["argument_list"], []),
     ),
     matcher(
       patternFinder("object_creation_expression"),
-      childRangeSelector(["argument_list"], [])
+      childRangeSelector(["argument_list"], []),
     ),
     matcher(
       patternFinder("explicit_constructor_invocation"),
-      childRangeSelector(["argument_list", ";"], [])
-    )
+      childRangeSelector(["argument_list", ";"], []),
+    ),
   ),
   map: "block",
   name: [
@@ -107,7 +107,7 @@ const nodeMatchers: Partial<
       "return_statement[0]",
       "*[value]",
     ],
-    ["=", "+=", "-=", "*=", "/=", "%=", "&=", "|=", "^=", "<<=", ">>="]
+    ["=", "+=", "-=", "*=", "/=", "%=", "&=", "|=", "^=", "<<=", ">>="],
   ),
   condition: conditionMatcher("*[condition]"),
   argumentOrParameter: argumentMatcher("formal_parameters", "argument_list"),

--- a/src/languages/json.ts
+++ b/src/languages/json.ts
@@ -22,7 +22,7 @@ export const patternMatchers = createPatternMatchers(nodeMatchers);
 
 export function stringTextFragmentExtractor(
   node: SyntaxNode,
-  _selection: SelectionWithEditor
+  _selection: SelectionWithEditor,
 ) {
   if (node.type === "string_content") {
     return getNodeRange(node);

--- a/src/languages/latex.ts
+++ b/src/languages/latex.ts
@@ -88,17 +88,17 @@ const sectioningCommand = SECTIONING.map((s) => `${s}[command]`);
 
 function unwrapGroupParens(
   editor: TextEditor,
-  node: SyntaxNode
+  node: SyntaxNode,
 ): SelectionWithContext {
   return {
     selection: new Selection(
       editor.document.positionAt(node.startIndex + 1),
-      editor.document.positionAt(node.endIndex - 1)
+      editor.document.positionAt(node.endIndex - 1),
     ),
     context: {
       removalRange: new Selection(
         editor.document.positionAt(node.startIndex),
-        editor.document.positionAt(node.endIndex)
+        editor.document.positionAt(node.endIndex),
       ),
     },
   };
@@ -106,7 +106,7 @@ function unwrapGroupParens(
 
 function extendToNamedSiblingIfExists(
   editor: TextEditor,
-  node: SyntaxNode
+  node: SyntaxNode,
 ): SelectionWithContext {
   const startIndex = node.startIndex;
   let endIndex = node.endIndex;
@@ -119,7 +119,7 @@ function extendToNamedSiblingIfExists(
   return {
     selection: new Selection(
       editor.document.positionAt(startIndex),
-      editor.document.positionAt(endIndex)
+      editor.document.positionAt(endIndex),
     ),
     context: {},
   };
@@ -127,7 +127,7 @@ function extendToNamedSiblingIfExists(
 
 function extractItemContent(
   editor: TextEditor,
-  node: SyntaxNode
+  node: SyntaxNode,
 ): SelectionWithContext {
   let contentStartIndex = node.startIndex;
 
@@ -144,12 +144,12 @@ function extractItemContent(
   return {
     selection: new Selection(
       editor.document.positionAt(contentStartIndex),
-      editor.document.positionAt(node.endIndex)
+      editor.document.positionAt(node.endIndex),
     ),
     context: {
       leadingDelimiterRange: new Range(
         editor.document.positionAt(node.startIndex),
-        editor.document.positionAt(contentStartIndex - 1)
+        editor.document.positionAt(contentStartIndex - 1),
       ),
     },
   };
@@ -162,17 +162,17 @@ const nodeMatchers: Partial<
     ancestorChainNodeMatcher(
       [patternFinder(...COMMANDS), patternFinder(...GROUPS)],
       1,
-      unwrapGroupParens
+      unwrapGroupParens,
     ),
     matcher(
       patternFinder("begin[name]", "end[name]", ...sectioningText),
-      unwrapGroupParens
-    )
+      unwrapGroupParens,
+    ),
   ),
 
   functionCall: cascadingMatcher(
     matcher(patternFinder(...COMMANDS, "begin", "end")),
-    matcher(patternFinder(...sectioningCommand), extendToNamedSiblingIfExists)
+    matcher(patternFinder(...sectioningCommand), extendToNamedSiblingIfExists),
   ),
 
   name: matcher(patternFinder(...sectioningText), unwrapGroupParens),

--- a/src/languages/markdown.ts
+++ b/src/languages/markdown.ts
@@ -28,7 +28,7 @@ import {
  */
 function nameExtractor(
   editor: TextEditor,
-  node: SyntaxNode
+  node: SyntaxNode,
 ): SelectionWithContext {
   const range = getNodeRange(node);
   const contentRange = range.isEmpty
@@ -62,13 +62,13 @@ type HeadingMarkerType = typeof HEADING_MARKER_TYPES[number];
  * marker level or higher than the original type
  */
 function makeMinimumHeadingLevelFinder(
-  headingType: HeadingMarkerType
+  headingType: HeadingMarkerType,
 ): NodeFinder {
   const markerIndex = HEADING_MARKER_TYPES.indexOf(headingType);
   return (node: SyntaxNode) => {
     return node.type === "atx_heading" &&
       HEADING_MARKER_TYPES.indexOf(
-        node.firstNamedChild?.type as HeadingMarkerType
+        node.firstNamedChild?.type as HeadingMarkerType,
       ) <= markerIndex
       ? node
       : null;
@@ -77,7 +77,7 @@ function makeMinimumHeadingLevelFinder(
 
 function sectionExtractor(editor: TextEditor, node: SyntaxNode) {
   const finder = makeMinimumHeadingLevelFinder(
-    node.firstNamedChild?.type as HeadingMarkerType
+    node.firstNamedChild?.type as HeadingMarkerType,
   );
 
   return extendUntilNextMatchingSiblingOrLast(editor, node, finder);
@@ -96,7 +96,7 @@ const nodeMatchers: Partial<
   comment: "html_block",
   name: matcher(
     leadingSiblingNodeFinder(patternFinder("atx_heading.heading_content!")),
-    nameExtractor
+    nameExtractor,
   ),
   collectionItem: leadingMatcher(["list_item.paragraph!"], ["list_marker"]),
   section: sectionMatcher("atx_heading"),

--- a/src/languages/php.ts
+++ b/src/languages/php.ts
@@ -82,7 +82,7 @@ const assignmentOperators = [
  */
 function castTypeExtractor(
   editor: TextEditor,
-  node: SyntaxNode
+  node: SyntaxNode,
 ): SelectionWithContext {
   const range = getNodeRange(node);
   const contentRange = range;
@@ -115,7 +115,7 @@ const nodeMatchers: Partial<
   string: "string",
   type: cascadingMatcher(
     trailingMatcher(["~cast_expression[type]"]),
-    matcher(patternFinder("cast_expression[type]"), castTypeExtractor)
+    matcher(patternFinder("cast_expression[type]"), castTypeExtractor),
   ),
 
   namedFunction: trailingMatcher(
@@ -124,7 +124,7 @@ const nodeMatchers: Partial<
       "assignment_expression.anonymous_function_creation_expression",
       "assignment_expression.arrow_function",
     ],
-    [";"]
+    [";"],
   ),
   anonymousFunction: [
     "anonymous_function_creation_expression",
@@ -141,7 +141,7 @@ const nodeMatchers: Partial<
       "return_statement[0]",
       "yield_expression[0]",
     ],
-    assignmentOperators.concat(["=>"])
+    assignmentOperators.concat(["=>"]),
   ),
 
   collectionKey: trailingMatcher(["array_element_initializer[0]"], ["=>"]),
@@ -152,7 +152,7 @@ export default createPatternMatchers(nodeMatchers);
 
 export function stringTextFragmentExtractor(
   node: SyntaxNode,
-  _selection: SelectionWithEditor
+  _selection: SelectionWithEditor,
 ) {
   if (node.type === "string") {
     return getNodeRange(node);

--- a/src/languages/python.ts
+++ b/src/languages/python.ts
@@ -56,7 +56,7 @@ const listTypes = ["list", "list_comprehension", "set"];
 function itemNodeFinder(
   parentType: string,
   childType: string,
-  excludeFirstChild: boolean = false
+  excludeFirstChild: boolean = false,
 ): NodeFinder {
   const finder = argumentNodeFinder(parentType);
   return (node: SyntaxNode, selection?: Selection) => {
@@ -82,12 +82,12 @@ const nodeMatchers: Partial<
   collectionItem: cascadingMatcher(
     matcher(
       itemNodeFinder("import_from_statement", "dotted_name", true),
-      argumentSelectionExtractor()
+      argumentSelectionExtractor(),
     ),
     matcher(
       itemNodeFinder("global_statement", "identifier"),
-      argumentSelectionExtractor()
-    )
+      argumentSelectionExtractor(),
+    ),
   ),
   collectionKey: trailingMatcher(["pair[key]"], [":"]),
   ifStatement: "if_statement",
@@ -102,7 +102,7 @@ const nodeMatchers: Partial<
   condition: conditionMatcher("*[condition]"),
   type: leadingMatcher(
     ["function_definition[return_type]", "*[type]"],
-    [":", "->"]
+    [":", "->"],
   ),
   name: [
     "assignment[left]",
@@ -129,13 +129,13 @@ const nodeMatchers: Partial<
         "^=",
         "<<=",
         ">>=",
-      ]
+      ],
     ),
-    patternMatcher("return_statement.~return!")
+    patternMatcher("return_statement.~return!"),
   ),
   argumentOrParameter: cascadingMatcher(
     argumentMatcher("parameters", "argument_list"),
-    matcher(patternFinder("call.generator_expression!"), childRangeSelector())
+    matcher(patternFinder("call.generator_expression!"), childRangeSelector()),
   ),
 };
 

--- a/src/languages/ruby.ts
+++ b/src/languages/ruby.ts
@@ -160,8 +160,8 @@ const nodeMatchers: Partial<
         patternFinder(...EXPRESSION_STATEMENT_PARENT_TYPES),
         patternFinder(...EXPRESSION_TYPES),
       ],
-      1
-    )
+      1,
+    ),
   ),
   string: "string",
   ifStatement: "if",
@@ -171,7 +171,7 @@ const nodeMatchers: Partial<
   functionName: ["method[name]", "singleton_method[name]"],
   anonymousFunction: cascadingMatcher(
     patternMatcher("lambda", "do_block"),
-    matcher(blockFinder)
+    matcher(blockFinder),
   ),
   regularExpression: "regex",
   condition: conditionMatcher("*[condition]"),
@@ -179,7 +179,7 @@ const nodeMatchers: Partial<
     "lambda_parameters",
     "method_parameters",
     "block_parameters",
-    "argument_list"
+    "argument_list",
   ),
   class: "class",
   className: "class[name]",
@@ -198,7 +198,7 @@ const nodeMatchers: Partial<
       "operator_assignment[right]",
       "return.argument_list!",
     ],
-    assignmentOperators.concat(mapKeyValueSeparators)
+    assignmentOperators.concat(mapKeyValueSeparators),
   ),
   collectionItem: argumentMatcher(...mapTypes, ...listTypes),
 };
@@ -206,7 +206,7 @@ export const patternMatchers = createPatternMatchers(nodeMatchers);
 
 export function stringTextFragmentExtractor(
   node: SyntaxNode,
-  _selection: SelectionWithEditor
+  _selection: SelectionWithEditor,
 ) {
   if (node.type === "string_content" || node.type === "heredoc_content") {
     return getNodeRange(node);

--- a/src/languages/rust.ts
+++ b/src/languages/rust.ts
@@ -67,14 +67,14 @@ function implItemTypeFinder(node: SyntaxNode) {
 
 function traitBoundExtractor(
   editor: TextEditor,
-  node: SyntaxNode
+  node: SyntaxNode,
 ): SelectionWithContext {
   return {
     selection: makeNodePairSelection(node.children[1], node.lastNamedChild!),
     context: {
       leadingDelimiterRange: makeRangeFromPositions(
         node.children[0].startPosition,
-        node.children[1].startPosition
+        node.children[1].startPosition,
       ),
     },
   };
@@ -142,7 +142,7 @@ const nodeMatchers: Partial<
       patternFinder(...STATEMENT_PARENT_TYPES),
       patternFinder(...STATEMENT_TYPES),
     ],
-    1
+    1,
   ),
   string: ["raw_string_literal", "string_literal"],
   ifStatement: ["if_expression", "if_let_expression"],
@@ -160,14 +160,14 @@ const nodeMatchers: Partial<
         "field_declaration[type]",
         "const_item[type]",
       ],
-      [":"]
+      [":"],
     ),
     matcher(
       patternFinder(
         "constrained_type_parameter[bounds]",
-        "where_predicate[bounds]"
+        "where_predicate[bounds]",
       ),
-      traitBoundExtractor
+      traitBoundExtractor,
     ),
     leadingMatcher(["function_item[return_type]"], ["->"]),
     matcher(implItemTypeFinder),
@@ -175,8 +175,8 @@ const nodeMatchers: Partial<
       "struct_item",
       "trait_item",
       "impl_item",
-      "array_type[element]"
-    )
+      "array_type[element]",
+    ),
   ),
   functionName: ["function_item[name]"],
   anonymousFunction: "closure_expression",
@@ -184,10 +184,10 @@ const nodeMatchers: Partial<
     "arguments",
     "parameters",
     "meta_arguments",
-    "type_parameters"
+    "type_parameters",
   ),
   collectionKey: cascadingMatcher(
-    trailingMatcher(["field_initializer[name]", "field_pattern[name]"], [":"])
+    trailingMatcher(["field_initializer[name]", "field_pattern[name]"], [":"]),
   ),
   name: cascadingMatcher(
     patternMatcher(
@@ -202,9 +202,9 @@ const nodeMatchers: Partial<
       "let_declaration[pattern]",
       "constrained_type_parameter[left]",
       "where_predicate[left]",
-      "field_declaration[name]"
+      "field_declaration[name]",
     ),
-    trailingMatcher(["field_initializer[name]", "field_pattern[name]"], [":"])
+    trailingMatcher(["field_initializer[name]", "field_pattern[name]"], [":"]),
   ),
   class: ["struct_item", "struct_expression", "enum_item"],
   className: ["struct_item[name]", "enum_item[name]", "trait_item[name]"],
@@ -212,10 +212,10 @@ const nodeMatchers: Partial<
     leadingMatcher(["let_declaration[value]"], ["="]),
     leadingMatcher(
       ["field_initializer[value]", "field_pattern[pattern]"],
-      [":"]
+      [":"],
     ),
     patternMatcher("meta_item[value]", "const_item[value]"),
-    matcher(returnValueFinder)
+    matcher(returnValueFinder),
   ),
   attribute: trailingMatcher(["mutable_specifier", "attribute_item"]),
 };

--- a/src/languages/scala.ts
+++ b/src/languages/scala.ts
@@ -32,7 +32,7 @@ const nodeMatchers: Partial<
     "arguments",
     "parameters",
     "class_parameters",
-    "bindings"
+    "bindings",
   ),
 
   name: ["*[name]", "*[pattern]"],
@@ -59,11 +59,11 @@ const nodeMatchers: Partial<
       "typed_pattern[type]",
       "binding[type]",
     ],
-    [":"]
+    [":"],
   ),
   value: leadingMatcher(
     ["*[value]", "*[default_value]", "type_definition[type]"],
-    ["="]
+    ["="],
   ),
   condition: conditionMatcher("*[condition]"),
 

--- a/src/languages/scss.ts
+++ b/src/languages/scss.ts
@@ -73,7 +73,7 @@ function isAtDelimiter(node: SyntaxNode) {
  * @returns A non-delimiter node
  */
 function findAdjacentArgValues(
-  siblingFunc: (node: SyntaxNode) => SyntaxNode | null
+  siblingFunc: (node: SyntaxNode) => SyntaxNode | null,
 ) {
   return (node: SyntaxNode) => {
     // Handle the case where we are the cursor is placed before a delimiter, e.g. "|at"
@@ -94,7 +94,7 @@ function findAdjacentArgValues(
 
 function unitMatcher(
   selection: SelectionWithEditor,
-  node: SyntaxNode
+  node: SyntaxNode,
 ): NodeMatcherValue[] | null {
   if (node.type !== "declaration") {
     return null;
@@ -115,8 +115,8 @@ const nodeMatchers: Partial<
     patternMatcher(...STATEMENT_TYPES),
     matcher(
       patternFinder("attribute_selector"),
-      childRangeSelector([], ["attribute_name", "string_value"])
-    )
+      childRangeSelector([], ["attribute_name", "string_value"]),
+    ),
   ),
   string: "string_value",
   functionCall: "call_expression",
@@ -131,9 +131,9 @@ const nodeMatchers: Partial<
         (node) => isArgumentListDelimiter(node),
         ", ",
         findAdjacentArgValues((node) => node.previousSibling),
-        findAdjacentArgValues((node) => node.nextSibling)
-      )
-    )
+        findAdjacentArgValues((node) => node.nextSibling),
+      ),
+    ),
   ),
   name: [
     "function_statement.name!",
@@ -148,19 +148,19 @@ const nodeMatchers: Partial<
   value: cascadingMatcher(
     matcher(
       patternFinder("declaration"),
-      childRangeSelector(["property_name", "variable_name"])
+      childRangeSelector(["property_name", "variable_name"]),
     ),
     matcher(
       patternFinder("include_statement", "namespace_statement"),
-      childRangeSelector()
+      childRangeSelector(),
     ),
     patternMatcher(
       "return_statement.*!",
       "import_statement.*!",
       "attribute_selector.plain_value!",
       "attribute_selector.string_value!",
-      "parameter.default_value!"
-    )
+      "parameter.default_value!",
+    ),
   ),
   unit: cascadingMatcher(patternMatcher("integer_value.unit!"), unitMatcher),
   collectionItem: "declaration",
@@ -170,7 +170,7 @@ export const patternMatchers = createPatternMatchers(nodeMatchers);
 
 export function stringTextFragmentExtractor(
   node: SyntaxNode,
-  _selection: SelectionWithEditor
+  _selection: SelectionWithEditor,
 ) {
   if (node.type === "string_value") {
     return getNodeRange(node);

--- a/src/languages/typescript.ts
+++ b/src/languages/typescript.ts
@@ -84,10 +84,10 @@ function typeMatcher(): NodeMatcher {
       node.type !== "arguments"
     ) {
       const identifierNode = node.parent.children.find(
-        (n) => n.type === "identifier"
+        (n) => n.type === "identifier",
       );
       const argsNode = node.parent.children.find(
-        (n) => n.type === "type_arguments"
+        (n) => n.type === "type_arguments",
       );
       if (identifierNode && argsNode) {
         return [
@@ -96,7 +96,7 @@ function typeMatcher(): NodeMatcher {
             selection: pairSelectionExtractor(
               selection.editor,
               identifierNode,
-              argsNode
+              argsNode,
             ),
           },
         ];
@@ -106,7 +106,7 @@ function typeMatcher(): NodeMatcher {
             node: identifierNode,
             selection: simpleSelectionExtractor(
               selection.editor,
-              identifierNode
+              identifierNode,
             ),
           },
         ];
@@ -114,7 +114,7 @@ function typeMatcher(): NodeMatcher {
     }
 
     const typeAnnotationNode = node.children.find((child) =>
-      ["type_annotation", "opting_type_annotation"].includes(child.type)
+      ["type_annotation", "opting_type_annotation"].includes(child.type),
     );
     const targetNode = typeAnnotationNode?.lastChild;
 
@@ -135,7 +135,7 @@ function valueMatcher() {
     "assignment_expression[right]",
     "augmented_assignment_expression[right]",
     "*[value]",
-    "shorthand_property_identifier"
+    "shorthand_property_identifier",
   );
   return matcher(
     (node: SyntaxNode) =>
@@ -153,8 +153,8 @@ function valueMatcher() {
       "|=",
       "^=",
       "<<=",
-      ">>="
-    )
+      ">>=",
+    ),
   );
 }
 
@@ -173,12 +173,12 @@ const nodeMatchers: Partial<
       "jsx_attribute.property_identifier!",
       "shorthand_property_identifier",
     ],
-    [":"]
+    [":"],
   ),
   value: cascadingMatcher(
     valueMatcher(),
     patternMatcher("return_statement.~return!"),
-    patternMatcher("yield_expression.~yield!")
+    patternMatcher("yield_expression.~yield!"),
   ),
   ifStatement: "if_statement",
   anonymousFunction: ["arrow_function", "function"],
@@ -197,8 +197,8 @@ const nodeMatchers: Partial<
     patternMatcher("call_expression[function]"),
     matcher(
       patternFinder("new_expression"),
-      childRangeSelector(["arguments"], [])
-    )
+      childRangeSelector(["arguments"], []),
+    ),
   ),
   statement: STATEMENT_TYPES.map((type) => `export_statement?.${type}`),
   condition: cascadingMatcher(
@@ -207,8 +207,8 @@ const nodeMatchers: Partial<
       "if_statement[condition]",
       "for_statement[condition]",
       "while_statement[condition]",
-      "do_statement[condition]"
-    )
+      "do_statement[condition]",
+    ),
   ),
   class: [
     "export_statement?.class_declaration", // export class | class
@@ -260,13 +260,13 @@ const nodeMatchers: Partial<
       // foo = () => { }
       "assignment_expression.arrow_function",
       // foo = function*() { }
-      "generator_function_declaration"
+      "generator_function_declaration",
     ),
     // abstract class method
     matcher(
       patternFinder("abstract_method_signature"),
-      extendForwardPastOptional(";")
-    )
+      extendForwardPastOptional(";"),
+    ),
   ),
   type: cascadingMatcher(
     // Typed parameters, properties, and functions
@@ -275,15 +275,15 @@ const nodeMatchers: Partial<
     // Type alias/interface declarations
     patternMatcher(
       "export_statement?.type_alias_declaration",
-      "export_statement?.interface_declaration"
-    )
+      "export_statement?.interface_declaration",
+    ),
   ),
   argumentOrParameter: argumentMatcher("formal_parameters", "arguments"),
   // XML, JSX
   attribute: ["jsx_attribute"],
   xmlElement: matcher(
     typedNodeFinder("jsx_element", "jsx_self_closing_element"),
-    xmlElementExtractor
+    xmlElementExtractor,
   ),
   xmlBothTags: getTags,
   xmlStartTag: getStartTag,
@@ -294,7 +294,7 @@ export const patternMatchers = createPatternMatchers(nodeMatchers);
 
 export function stringTextFragmentExtractor(
   node: SyntaxNode,
-  _selection: SelectionWithEditor
+  _selection: SelectionWithEditor,
 ) {
   if (
     node.type === "string_fragment" ||

--- a/src/processTargets/getModifierStage.ts
+++ b/src/processTargets/getModifierStage.ts
@@ -58,7 +58,7 @@ export default (modifier: Modifier): ModifierStage => {
       return new RangeModifierStage(modifier);
     case "inferPreviousMark":
       throw Error(
-        `Unexpected modifier '${modifier.type}'; it should have been removed during inference`
+        `Unexpected modifier '${modifier.type}'; it should have been removed during inference`,
       );
   }
 };

--- a/src/processTargets/marks/CursorStage.ts
+++ b/src/processTargets/marks/CursorStage.ts
@@ -16,7 +16,7 @@ export default class CursorStage implements MarkStage {
           isReversed: isReversed(selection.selection),
           contentRange: selection.selection,
           hasExplicitRange: !selection.selection.isEmpty,
-        })
+        }),
     );
   }
 }

--- a/src/processTargets/marks/DecoratedSymbolStage.ts
+++ b/src/processTargets/marks/DecoratedSymbolStage.ts
@@ -10,12 +10,12 @@ export default class implements MarkStage {
   run(context: ProcessedTargetsContext): Target[] {
     const token = context.hatTokenMap.getToken(
       this.mark.symbolColor,
-      this.mark.character
+      this.mark.character,
     );
 
     if (token == null) {
       throw new Error(
-        `Couldn't find mark ${this.mark.symbolColor} '${this.mark.character}'`
+        `Couldn't find mark ${this.mark.symbolColor} '${this.mark.character}'`,
       );
     }
 

--- a/src/processTargets/marks/LineNumberStage.ts
+++ b/src/processTargets/marks/LineNumberStage.ts
@@ -19,7 +19,7 @@ export default class implements MarkStage {
     const lineNumber = getLineNumber(
       editor,
       this.mark.lineNumberType,
-      this.mark.lineNumber
+      this.mark.lineNumber,
     );
     const contentRange = editor.document.lineAt(lineNumber).range;
     return [createLineTarget(editor, false, contentRange)];
@@ -29,7 +29,7 @@ export default class implements MarkStage {
 const getLineNumber = (
   editor: TextEditor,
   lineNumberType: LineNumberType,
-  lineNumber: number
+  lineNumber: number,
 ) => {
   switch (lineNumberType) {
     case "absolute":
@@ -50,7 +50,7 @@ const getLineNumber = (
           const visible = editor.visibleRanges.find(
             (r) =>
               currentLineNumber >= r.start.line &&
-              currentLineNumber <= r.end.line
+              currentLineNumber <= r.end.line,
           );
           if (visible) {
             visibleLines.push(currentLineNumber);

--- a/src/processTargets/marks/RangeMarkStage.ts
+++ b/src/processTargets/marks/RangeMarkStage.ts
@@ -23,7 +23,7 @@ export default class RangeMarkStage implements MarkStage {
         anchorTargets[0],
         activeTargets[0],
         this.mark.excludeAnchor,
-        this.mark.excludeActive
+        this.mark.excludeActive,
       ),
     ];
   }

--- a/src/processTargets/modifiers/ContainingScopeStage.ts
+++ b/src/processTargets/modifiers/ContainingScopeStage.ts
@@ -43,7 +43,7 @@ export class ContainingScopeStage implements ModifierStage {
 
     const scopeHandler = getScopeHandler(
       scopeType,
-      target.editor.document.languageId
+      target.editor.document.languageId,
     );
 
     if (scopeHandler == null) {
@@ -53,7 +53,7 @@ export class ContainingScopeStage implements ModifierStage {
     const startScopes = scopeHandler.getScopesTouchingPosition(
       editor,
       start,
-      ancestorIndex
+      ancestorIndex,
     );
 
     if (startScopes.length === 0) {
@@ -82,7 +82,7 @@ export class ContainingScopeStage implements ModifierStage {
     const endScopes = scopeHandler.getScopesTouchingPosition(
       editor,
       end,
-      ancestorIndex
+      ancestorIndex,
     );
     const endScope = getLeftScope(endScopes);
 

--- a/src/processTargets/modifiers/EveryScopeStage.ts
+++ b/src/processTargets/modifiers/EveryScopeStage.ts
@@ -54,7 +54,7 @@ export class EveryScopeStage implements ModifierStage {
   getDefaultIterationRange(
     context: ProcessedTargetsContext,
     scopeHandler: ScopeHandler,
-    target: Target
+    target: Target,
   ): Range {
     const containingIterationScopeModifier = getModifierStage({
       type: "containingScope",

--- a/src/processTargets/modifiers/EveryScopeStage.ts
+++ b/src/processTargets/modifiers/EveryScopeStage.ts
@@ -48,7 +48,7 @@ export class EveryScopeStage implements ModifierStage {
     if (target.hasExplicitRange) {
       scopes = scopeHandler.getScopesOverlappingRange(
         editor,
-        target.contentRange
+        target.contentRange,
       );
 
       if (
@@ -67,7 +67,7 @@ export class EveryScopeStage implements ModifierStage {
       // instance, expand to iteration scope before overlapping
       scopes = scopeHandler.getScopesOverlappingRange(
         editor,
-        this.getDefaultIterationRange(context, scopeHandler, target)
+        this.getDefaultIterationRange(context, scopeHandler, target),
       );
     }
 

--- a/src/processTargets/modifiers/HeadTailStage.ts
+++ b/src/processTargets/modifiers/HeadTailStage.ts
@@ -31,7 +31,7 @@ abstract class HeadTailStage implements ModifierStage {
     return modifiedTargets.map((modifiedTarget) => {
       const contentRange = this.constructContentRange(
         target.contentRange,
-        modifiedTarget.contentRange
+        modifiedTarget.contentRange,
       );
 
       return new TokenTarget({
@@ -44,7 +44,7 @@ abstract class HeadTailStage implements ModifierStage {
 
   protected abstract constructContentRange(
     originalRange: Range,
-    modifiedRange: Range
+    modifiedRange: Range,
   ): Range;
 }
 

--- a/src/processTargets/modifiers/ItemStage/ItemStage.ts
+++ b/src/processTargets/modifiers/ItemStage/ItemStage.ts
@@ -24,7 +24,7 @@ export default class ItemStage implements ModifierStage {
     // First try the language specific implementation of item
     try {
       return new ContainingSyntaxScopeStage(
-        this.modifier as SimpleContainingScopeModifier
+        this.modifier as SimpleContainingScopeModifier,
       ).run(context, target);
     } catch (_error) {
       // do nothing
@@ -50,7 +50,7 @@ export default class ItemStage implements ModifierStage {
     }
 
     return filteredItemInfos.map((itemInfo) =>
-      this.itemInfoToTarget(target, itemInfo)
+      this.itemInfoToTarget(target, itemInfo),
     );
   }
 
@@ -89,13 +89,13 @@ export default class ItemStage implements ModifierStage {
   private itemInfoToTarget(
     target: Target,
     itemInfo: ItemInfo,
-    removalRange?: Range
+    removalRange?: Range,
   ) {
     const delimiter = getInsertionDelimiter(
       target.editor,
       itemInfo.leadingDelimiterRange,
       itemInfo.trailingDelimiterRange,
-      ", "
+      ", ",
     );
     return new ScopeTypeTarget({
       scopeTypeType: this.modifier.scopeType.type as SimpleScopeTypeType,
@@ -113,13 +113,13 @@ export default class ItemStage implements ModifierStage {
 /** Filter item infos by content range and domain intersection */
 function filterItemInfos(target: Target, itemInfos: ItemInfo[]): ItemInfo[] {
   return itemInfos.filter(
-    (itemInfo) => itemInfo.domain.intersection(target.contentRange) != null
+    (itemInfo) => itemInfo.domain.intersection(target.contentRange) != null,
   );
 }
 
 function getItemInfosForIterationScope(
   context: ProcessedTargetsContext,
-  target: Target
+  target: Target,
 ) {
   const { range, boundary } = getIterationScope(context, target);
   return getItemsInRange(target.editor, range, boundary);
@@ -128,7 +128,7 @@ function getItemInfosForIterationScope(
 function getItemsInRange(
   editor: TextEditor,
   interior: Range,
-  boundary?: [Range, Range]
+  boundary?: [Range, Range],
 ): ItemInfo[] {
   const tokens = tokenizeRange(editor, interior, boundary);
   const itemInfos: ItemInfo[] = [];

--- a/src/processTargets/modifiers/ItemStage/getIterationScope.ts
+++ b/src/processTargets/modifiers/ItemStage/getIterationScope.ts
@@ -14,12 +14,12 @@ import { SurroundingPairInfo } from "../surroundingPair/extractSelectionFromSurr
  */
 export function getIterationScope(
   context: ProcessedTargetsContext,
-  target: Target
+  target: Target,
 ): { range: Range; boundary?: [Range, Range] } {
   let pairInfo = getSurroundingPair(
     context,
     target.editor,
-    target.contentRange
+    target.contentRange,
   );
 
   // Iteration is necessary in case of nested strings
@@ -27,7 +27,7 @@ export function getIterationScope(
     const stringPairInfo = getStringSurroundingPair(
       context,
       target.editor,
-      pairInfo.contentRange
+      pairInfo.contentRange,
     );
 
     // We don't look for items inside strings.
@@ -55,7 +55,7 @@ export function getIterationScope(
 function getParentSurroundingPair(
   context: ProcessedTargetsContext,
   editor: TextEditor,
-  pairInfo: SurroundingPairInfo
+  pairInfo: SurroundingPairInfo,
 ) {
   const startOffset = editor.document.offsetAt(pairInfo.contentRange.start);
   // Can't have a parent; already at start of document
@@ -70,7 +70,7 @@ function getParentSurroundingPair(
 function getSurroundingPair(
   context: ProcessedTargetsContext,
   editor: TextEditor,
-  contentRange: Range
+  contentRange: Range,
 ) {
   return processSurroundingPair(context, editor, contentRange, {
     type: "surroundingPair",
@@ -82,7 +82,7 @@ function getSurroundingPair(
 function getStringSurroundingPair(
   context: ProcessedTargetsContext,
   editor: TextEditor,
-  contentRange: Range
+  contentRange: Range,
 ) {
   return processSurroundingPair(context, editor, contentRange, {
     type: "surroundingPair",

--- a/src/processTargets/modifiers/ItemStage/tokenizeRange.ts
+++ b/src/processTargets/modifiers/ItemStage/tokenizeRange.ts
@@ -29,7 +29,7 @@ import { Range, TextEditor } from "vscode";
 export function tokenizeRange(
   editor: TextEditor,
   interior: Range,
-  boundary?: [Range, Range]
+  boundary?: [Range, Range],
 ): Token[] {
   const { document } = editor;
   const text = document.getText(interior);
@@ -60,7 +60,7 @@ export function tokenizeRange(
         type: "separator",
         range: new Range(
           document.positionAt(offset),
-          document.positionAt(offset + lexeme.length)
+          document.positionAt(offset + lexeme.length),
         ),
       });
     }
@@ -72,7 +72,7 @@ export function tokenizeRange(
         type: "item",
         range: new Range(
           document.positionAt(offsetStart),
-          document.positionAt(offsetStart + lexeme.trim().length)
+          document.positionAt(offsetStart + lexeme.trim().length),
         ),
       });
     }

--- a/src/processTargets/modifiers/OrdinalScopeStage.ts
+++ b/src/processTargets/modifiers/OrdinalScopeStage.ts
@@ -14,7 +14,7 @@ export class OrdinalScopeStage implements ModifierStage {
     const targets = getEveryScopeTargets(
       context,
       target,
-      this.modifier.scopeType
+      this.modifier.scopeType,
     );
 
     const startIndex =
@@ -26,7 +26,7 @@ export class OrdinalScopeStage implements ModifierStage {
         target.isReversed,
         targets,
         startIndex,
-        endIndex
+        endIndex,
       ),
     ];
   }

--- a/src/processTargets/modifiers/RangeModifierStage.ts
+++ b/src/processTargets/modifiers/RangeModifierStage.ts
@@ -23,7 +23,7 @@ export default class RangeModifierStage implements ModifierStage {
         anchorTargets[0],
         activeTargets[0],
         this.modifier.excludeAnchor,
-        this.modifier.excludeActive
+        this.modifier.excludeActive,
       ),
     ];
   }

--- a/src/processTargets/modifiers/RelativeExclusiveScopeStage.ts
+++ b/src/processTargets/modifiers/RelativeExclusiveScopeStage.ts
@@ -34,7 +34,7 @@ export default class RelativeExclusiveScopeStage implements ModifierStage {
   run(context: ProcessedTargetsContext, target: Target): Target[] {
     const scopeHandler = getScopeHandler(
       this.modifier.scopeType,
-      target.editor.document.languageId
+      target.editor.document.languageId,
     );
 
     if (scopeHandler == null) {
@@ -49,7 +49,7 @@ export default class RelativeExclusiveScopeStage implements ModifierStage {
           scopeHandler,
           direction,
           editor,
-          inputRange.start
+          inputRange.start,
         )
       : direction === "forward"
       ? inputRange.end
@@ -59,7 +59,7 @@ export default class RelativeExclusiveScopeStage implements ModifierStage {
       editor,
       initialPosition,
       offset,
-      direction
+      direction,
     );
 
     if (desiredScopeCount === 1) {
@@ -72,7 +72,7 @@ export default class RelativeExclusiveScopeStage implements ModifierStage {
         ? proximalScope.domain.end
         : proximalScope.domain.start,
       desiredScopeCount - 1,
-      direction
+      direction,
     );
 
     return [constructScopeRangeTarget(isReversed, proximalScope, distalScope)];
@@ -95,11 +95,11 @@ function getInitialPositionForEmptyInputRange(
   scopeHandler: ScopeHandler,
   direction: string,
   editor: TextEditor,
-  inputPosition: Position
+  inputPosition: Position,
 ) {
   const scopesTouchingPosition = scopeHandler.getScopesTouchingPosition(
     editor,
-    inputPosition
+    inputPosition,
   );
 
   const skipScope =

--- a/src/processTargets/modifiers/RelativeInclusiveScopeStage.ts
+++ b/src/processTargets/modifiers/RelativeInclusiveScopeStage.ts
@@ -44,7 +44,7 @@ export class RelativeInclusiveScopeStage implements ModifierStage {
   run(context: ProcessedTargetsContext, target: Target): Target[] {
     const scopeHandler = getScopeHandler(
       this.modifier.scopeType,
-      target.editor.document.languageId
+      target.editor.document.languageId,
     );
 
     if (scopeHandler == null) {
@@ -58,7 +58,7 @@ export class RelativeInclusiveScopeStage implements ModifierStage {
       scopeHandler,
       direction,
       editor,
-      inputRange
+      inputRange,
     );
 
     const offset0ScopeCount = offset0Scopes.length;
@@ -71,7 +71,7 @@ export class RelativeInclusiveScopeStage implements ModifierStage {
       throw new TooFewScopesError(
         desiredScopeCount,
         offset0ScopeCount,
-        scopeType.type
+        scopeType.type,
       );
     }
 
@@ -89,7 +89,7 @@ export class RelativeInclusiveScopeStage implements ModifierStage {
             editor,
             initialPosition,
             desiredScopeCount - offset0ScopeCount,
-            direction
+            direction,
           )
         : direction === "forward"
         ? offset0Scopes.at(-1)!
@@ -115,14 +115,14 @@ function getOffset0Scopes(
   scopeHandler: ScopeHandler,
   direction: Direction,
   editor: TextEditor,
-  range: Range
+  range: Range,
 ): TargetScope[] {
   if (range.isEmpty) {
     const inputPosition = range.start;
 
     const scopesTouchingPosition = scopeHandler.getScopesTouchingPosition(
       editor,
-      inputPosition
+      inputPosition,
     );
 
     const preferredScope =

--- a/src/processTargets/modifiers/SurroundingPairStage.ts
+++ b/src/processTargets/modifiers/SurroundingPairStage.ts
@@ -26,7 +26,7 @@ export default class SurroundingPairStage implements ModifierStage {
 
   run(
     context: ProcessedTargetsContext,
-    target: Target
+    target: Target,
   ): SurroundingPairTarget[] {
     if (this.modifier.type === "everyScope") {
       throw Error(`Unsupported every scope ${this.modifier.scopeType.type}`);
@@ -39,13 +39,13 @@ export default class SurroundingPairStage implements ModifierStage {
 function processedSurroundingPairTarget(
   modifier: ContainingSurroundingPairModifier,
   context: ProcessedTargetsContext,
-  target: Target
+  target: Target,
 ): SurroundingPairTarget[] {
   const pairInfo = processSurroundingPair(
     context,
     target.editor,
     target.contentRange,
-    modifier.scopeType
+    modifier.scopeType,
   );
 
   if (pairInfo == null) {

--- a/src/processTargets/modifiers/TooFewScopesError.ts
+++ b/src/processTargets/modifiers/TooFewScopesError.ts
@@ -2,10 +2,10 @@ export class TooFewScopesError extends Error {
   constructor(
     requestedLength: number,
     currentLength: number,
-    scopeType: string
+    scopeType: string,
   ) {
     super(
-      `Requested ${requestedLength} ${scopeType}s, but ${currentLength} are already selected.`
+      `Requested ${requestedLength} ${scopeType}s, but ${currentLength} are already selected.`,
     );
     this.name = "TooFewScopesError";
   }

--- a/src/processTargets/modifiers/commonContainingScopeIfUntypedStages.ts
+++ b/src/processTargets/modifiers/commonContainingScopeIfUntypedStages.ts
@@ -19,7 +19,7 @@ export const containingSurroundingPairIfUntypedStage = new ModifyIfUntypedStage(
       type: "containingScope",
       scopeType: { type: "surroundingPair", delimiter: "any" },
     },
-  }
+  },
 );
 
 /**

--- a/src/processTargets/modifiers/constructScopeRangeTarget.ts
+++ b/src/processTargets/modifiers/constructScopeRangeTarget.ts
@@ -16,13 +16,13 @@ import { TargetScope } from "./scopeHandlers/scope.types";
 export function constructScopeRangeTarget(
   isReversed: boolean,
   scope1: TargetScope,
-  scope2: TargetScope
+  scope2: TargetScope,
 ): Target {
   const target1 = scope1.getTarget(isReversed);
   const target2 = scope2.getTarget(isReversed);
 
   const isScope2After = target2.contentRange.start.isAfterOrEqual(
-    target1.contentRange.start
+    target1.contentRange.start,
   );
 
   const [startTarget, endTarget] = isScope2After
@@ -33,6 +33,6 @@ export function constructScopeRangeTarget(
     isReversed,
     endTarget,
     true,
-    true
+    true,
   );
 }

--- a/src/processTargets/modifiers/getLegacyScopeStage.ts
+++ b/src/processTargets/modifiers/getLegacyScopeStage.ts
@@ -34,7 +34,7 @@ import SurroundingPairStage from "./SurroundingPairStage";
  * @returns A scope stage implementing the modifier for the given scope type
  */
 export default function getLegacyScopeStage(
-  modifier: ContainingScopeModifier | EveryScopeModifier
+  modifier: ContainingScopeModifier | EveryScopeModifier,
 ): ModifierStage {
   switch (modifier.scopeType.type) {
     case "notebookCell":
@@ -56,7 +56,7 @@ export default function getLegacyScopeStage(
     default:
       // Default to containing syntax scope using tree sitter
       return new ContainingSyntaxScopeStage(
-        modifier as SimpleContainingScopeModifier | SimpleEveryScopeModifier
+        modifier as SimpleContainingScopeModifier | SimpleEveryScopeModifier,
       );
   }
 }

--- a/src/processTargets/modifiers/getPreferredScope.ts
+++ b/src/processTargets/modifiers/getPreferredScope.ts
@@ -8,7 +8,7 @@ import { TargetScope } from "./scopeHandlers/scope.types";
  * @returns A single preferred scope, or `undefined` if {@link scopes} is empty
  */
 export function getPreferredScope(
-  scopes: TargetScope[]
+  scopes: TargetScope[],
 ): TargetScope | undefined {
   return getRightScope(scopes);
 }
@@ -21,7 +21,7 @@ export function getPreferredScope(
  */
 export function getLeftScope(scopes: TargetScope[]): TargetScope | undefined {
   return getScopeHelper(scopes, (scope1, scope2) =>
-    scope1.domain.start.isBefore(scope2.domain.start)
+    scope1.domain.start.isBefore(scope2.domain.start),
   );
 }
 
@@ -33,13 +33,13 @@ export function getLeftScope(scopes: TargetScope[]): TargetScope | undefined {
  */
 export function getRightScope(scopes: TargetScope[]): TargetScope | undefined {
   return getScopeHelper(scopes, (scope1, scope2) =>
-    scope1.domain.start.isAfter(scope2.domain.start)
+    scope1.domain.start.isAfter(scope2.domain.start),
   );
 }
 
 function getScopeHelper(
   scopes: TargetScope[],
-  isScope1Preferred: (scope1: TargetScope, scope2: TargetScope) => boolean
+  isScope1Preferred: (scope1: TargetScope, scope2: TargetScope) => boolean,
 ): TargetScope | undefined {
   if (scopes.length === 0) {
     return undefined;

--- a/src/processTargets/modifiers/relativeScopeLegacy.ts
+++ b/src/processTargets/modifiers/relativeScopeLegacy.ts
@@ -19,7 +19,7 @@ interface ContainingIndices {
 export function runLegacy(
   modifier: RelativeScopeModifier,
   context: ProcessedTargetsContext,
-  target: Target
+  target: Target,
 ): Target[] {
   /**
    * A list of targets in the iteration scope for the input {@link target}.
@@ -33,7 +33,7 @@ export function runLegacy(
   const targets = getEveryScopeTargets(
     context,
     createTargetWithoutExplicitRange(target),
-    modifier.scopeType
+    modifier.scopeType,
   );
 
   const containingIndices = getContainingIndices(target.contentRange, targets);
@@ -42,7 +42,7 @@ export function runLegacy(
     modifier,
     target,
     targets,
-    containingIndices
+    containingIndices,
   );
 }
 
@@ -50,7 +50,7 @@ function calculateIndicesAndCreateTarget(
   modifier: RelativeScopeModifier,
   target: Target,
   targets: Target[],
-  containingIndices: ContainingIndices | undefined
+  containingIndices: ContainingIndices | undefined,
 ): Target[] {
   const isForward = modifier.direction === "forward";
 
@@ -60,7 +60,7 @@ function calculateIndicesAndCreateTarget(
     target.contentRange,
     targets,
     isForward,
-    containingIndices
+    containingIndices,
   );
 
   /** Index of range farther from input target */
@@ -76,7 +76,7 @@ function calculateIndicesAndCreateTarget(
       target.isReversed,
       targets,
       startIndex,
-      endIndex
+      endIndex,
     ),
   ];
 }
@@ -95,17 +95,17 @@ function computeProximalIndex(
   inputTargetRange: Range,
   targets: Target[],
   isForward: boolean,
-  containingIndices: ContainingIndices | undefined
+  containingIndices: ContainingIndices | undefined,
 ) {
   const includeIntersectingScopes = modifier.offset === 0;
 
   if (containingIndices == null) {
     const adjacentTargetIndex = isForward
       ? targets.findIndex((t) =>
-          t.contentRange.start.isAfter(inputTargetRange.start)
+          t.contentRange.start.isAfter(inputTargetRange.start),
         )
       : findLastIndex(targets, (t) =>
-          t.contentRange.start.isBefore(inputTargetRange.start)
+          t.contentRange.start.isBefore(inputTargetRange.start),
         );
 
     if (adjacentTargetIndex === -1) {
@@ -141,7 +141,7 @@ function computeProximalIndex(
       throw new TooFewScopesError(
         modifier.length,
         intersectingLength,
-        modifier.scopeType.type
+        modifier.scopeType.type,
       );
     }
 
@@ -161,7 +161,7 @@ function computeProximalIndex(
  * {@link inputTargetRange} */
 function getContainingIndices(
   inputTargetRange: Range,
-  targets: Target[]
+  targets: Target[],
 ): ContainingIndices | undefined {
   const targetsWithIntersection = targets
     .map((t, i) => ({

--- a/src/processTargets/modifiers/scopeHandlers/CharacterScopeHandler.ts
+++ b/src/processTargets/modifiers/scopeHandlers/CharacterScopeHandler.ts
@@ -22,7 +22,7 @@ export default class CharacterScopeHandler extends NestedScopeHandler {
             contentRange: range,
             isReversed,
           }),
-      })
+      }),
     );
   }
 }

--- a/src/processTargets/modifiers/scopeHandlers/DocumentScopeHandler.ts
+++ b/src/processTargets/modifiers/scopeHandlers/DocumentScopeHandler.ts
@@ -18,7 +18,7 @@ export default class DocumentScopeHandler implements ScopeHandler {
   getScopesTouchingPosition(
     editor: TextEditor,
     _position: Position,
-    ancestorIndex: number = 0
+    ancestorIndex: number = 0,
   ): TargetScope[] {
     if (ancestorIndex !== 0) {
       throw new NotHierarchicalScopeError(this.scopeType);
@@ -35,7 +35,7 @@ export default class DocumentScopeHandler implements ScopeHandler {
     _editor: TextEditor,
     _position: Position,
     _offset: number,
-    _direction: Direction
+    _direction: Direction,
   ): TargetScope {
     // NB: offset will always be greater than or equal to 1, so this will be an
     // error

--- a/src/processTargets/modifiers/scopeHandlers/LineScopeHandler.ts
+++ b/src/processTargets/modifiers/scopeHandlers/LineScopeHandler.ts
@@ -18,7 +18,7 @@ export default class LineScopeHandler implements ScopeHandler {
   getScopesTouchingPosition(
     editor: TextEditor,
     position: Position,
-    ancestorIndex: number = 0
+    ancestorIndex: number = 0,
   ): TargetScope[] {
     if (ancestorIndex !== 0) {
       throw new NotHierarchicalScopeError(this.scopeType);
@@ -29,10 +29,10 @@ export default class LineScopeHandler implements ScopeHandler {
 
   getScopesOverlappingRange(
     editor: TextEditor,
-    { start, end }: Range
+    { start, end }: Range,
   ): TargetScope[] {
     return range(start.line, end.line + 1).map((lineNumber) =>
-      lineNumberToScope(editor, lineNumber)
+      lineNumberToScope(editor, lineNumber),
     );
   }
 
@@ -40,7 +40,7 @@ export default class LineScopeHandler implements ScopeHandler {
     editor: TextEditor,
     position: Position,
     offset: number,
-    direction: Direction
+    direction: Direction,
   ): TargetScope {
     const lineNumber =
       direction === "forward" ? position.line + offset : position.line - offset;
@@ -55,7 +55,7 @@ export default class LineScopeHandler implements ScopeHandler {
 
 function lineNumberToScope(
   editor: TextEditor,
-  lineNumber: number
+  lineNumber: number,
 ): TargetScope {
   const { range } = editor.document.lineAt(lineNumber);
 
@@ -69,7 +69,7 @@ function lineNumberToScope(
 export function createLineTarget(
   editor: TextEditor,
   isReversed: boolean,
-  range: Range
+  range: Range,
 ) {
   return new LineTarget({
     editor,
@@ -89,6 +89,6 @@ export function fitRangeToLineContent(editor: TextEditor, range: Range) {
     startLine.lineNumber,
     startLine.firstNonWhitespaceCharacterIndex,
     endLine.lineNumber,
-    endCharacterIndex
+    endCharacterIndex,
   );
 }

--- a/src/processTargets/modifiers/scopeHandlers/NestedScopeHandler.ts
+++ b/src/processTargets/modifiers/scopeHandlers/NestedScopeHandler.ts
@@ -41,21 +41,21 @@ export default abstract class NestedScopeHandler implements ScopeHandler {
    * @returns A list of all child scope types in the given parent scope type
    */
   protected abstract getScopesInSearchScope(
-    searchScope: TargetScope
+    searchScope: TargetScope,
   ): TargetScope[];
 
   private _searchScopeHandler: ScopeHandler | undefined;
 
   constructor(
     public readonly scopeType: ScopeType,
-    protected languageId: string
+    protected languageId: string,
   ) {}
 
   private get searchScopeHandler(): ScopeHandler {
     if (this._searchScopeHandler == null) {
       this._searchScopeHandler = getScopeHandler(
         this.searchScopeType,
-        this.languageId
+        this.languageId,
       )!;
     }
 
@@ -65,7 +65,7 @@ export default abstract class NestedScopeHandler implements ScopeHandler {
   getScopesTouchingPosition(
     editor: TextEditor,
     position: Position,
-    ancestorIndex: number = 0
+    ancestorIndex: number = 0,
   ): TargetScope[] {
     if (ancestorIndex !== 0) {
       throw new NotHierarchicalScopeError(this.scopeType);
@@ -91,7 +91,7 @@ export default abstract class NestedScopeHandler implements ScopeHandler {
     editor: TextEditor,
     position: Position,
     offset: number,
-    direction: Direction
+    direction: Direction,
   ): TargetScope {
     let remainingOffset = offset;
 
@@ -130,7 +130,7 @@ export default abstract class NestedScopeHandler implements ScopeHandler {
   private *iterateScopeGroups(
     editor: TextEditor,
     position: Position,
-    direction: Direction
+    direction: Direction,
   ): Generator<TargetScope[], void, unknown> {
     const containingSearchScopes =
       this.searchScopeHandler.getScopesTouchingPosition(editor, position);
@@ -147,7 +147,7 @@ export default abstract class NestedScopeHandler implements ScopeHandler {
         ({ domain }) =>
           direction === "forward"
             ? domain.start.isAfterOrEqual(position)
-            : domain.end.isBeforeOrEqual(position)
+            : domain.end.isBeforeOrEqual(position),
       );
 
       // Move current position past containing scope so that asking for next
@@ -168,7 +168,7 @@ export default abstract class NestedScopeHandler implements ScopeHandler {
         editor,
         currentPosition,
         1,
-        direction
+        direction,
       );
 
       yield this.getScopesInSearchScope(searchScope);

--- a/src/processTargets/modifiers/scopeHandlers/NotHierarchicalScopeError.ts
+++ b/src/processTargets/modifiers/scopeHandlers/NotHierarchicalScopeError.ts
@@ -12,7 +12,7 @@ export default class NotHierarchicalScopeError extends Error {
    */
   constructor(scopeType: ScopeType) {
     super(
-      `Cannot use hierarchical modifiers on ${scopeTypeToString(scopeType)}.`
+      `Cannot use hierarchical modifiers on ${scopeTypeToString(scopeType)}.`,
     );
     this.name = "NotHierarchicalScopeError";
   }

--- a/src/processTargets/modifiers/scopeHandlers/SurroundingPairScopeHandler.ts
+++ b/src/processTargets/modifiers/scopeHandlers/SurroundingPairScopeHandler.ts
@@ -11,7 +11,7 @@ export default class SurroundingPairScopeHandler implements ScopeHandler {
 
   constructor(
     public readonly scopeType: SurroundingPairScopeType,
-    _languageId: string
+    _languageId: string,
   ) {
     // FIXME: Figure out the actual iteration scope type
     this.iterationScopeType = this.scopeType;
@@ -20,7 +20,7 @@ export default class SurroundingPairScopeHandler implements ScopeHandler {
   getScopesTouchingPosition(
     _editor: TextEditor,
     _position: Position,
-    _ancestorIndex: number = 0
+    _ancestorIndex: number = 0,
   ): TargetScope[] {
     // TODO: Run existing surrounding pair code on empty range constructed from
     // position, returning both if position is adjacent to two
@@ -37,7 +37,7 @@ export default class SurroundingPairScopeHandler implements ScopeHandler {
     _editor: TextEditor,
     _position: Position,
     _offset: number,
-    _direction: Direction
+    _direction: Direction,
   ): TargetScope {
     // TODO: Walk forward until we hit either an opening or closing delimiter.
     // If we hit an opening delimiter then we walk over as many pairs as we need

--- a/src/processTargets/modifiers/scopeHandlers/WordScopeHandler.ts
+++ b/src/processTargets/modifiers/scopeHandlers/WordScopeHandler.ts
@@ -19,14 +19,14 @@ export default class WordScopeHandler extends NestedScopeHandler {
     // mock away vscode for the unit tests in subtoken.test.ts
     const offset = document.offsetAt(domain.start);
     const matches = this.wordTokenizer.splitIdentifier(
-      document.getText(domain)
+      document.getText(domain),
     );
     const contentRanges = matches.map(
       (match) =>
         new Range(
           document.positionAt(offset + match.index),
-          document.positionAt(offset + match.index + match.text.length)
-        )
+          document.positionAt(offset + match.index + match.text.length),
+        ),
     );
 
     return contentRanges.map((range, i) => ({
@@ -42,7 +42,7 @@ export default class WordScopeHandler extends NestedScopeHandler {
           editor,
           previousContentRange,
           range,
-          nextContentRange
+          nextContentRange,
         );
       },
     }));
@@ -54,7 +54,7 @@ function constructTarget(
   editor: TextEditor,
   previousContentRange: Range | null,
   contentRange: Range,
-  nextContentRange: Range | null
+  nextContentRange: Range | null,
 ) {
   const leadingDelimiterRange =
     previousContentRange != null &&
@@ -71,7 +71,7 @@ function constructTarget(
     leadingDelimiterRange != null || trailingDelimiterRange != null;
   const insertionDelimiter = isInDelimitedList
     ? editor.document.getText(
-        (leadingDelimiterRange ?? trailingDelimiterRange)!
+        (leadingDelimiterRange ?? trailingDelimiterRange)!,
       )
     : "";
 

--- a/src/processTargets/modifiers/scopeHandlers/getScopeHandler.ts
+++ b/src/processTargets/modifiers/scopeHandlers/getScopeHandler.ts
@@ -28,7 +28,7 @@ import type { ScopeHandler } from "./scopeHandler.types";
  */
 export default function getScopeHandler(
   scopeType: ScopeType,
-  languageId: string
+  languageId: string,
 ): ScopeHandler | undefined {
   switch (scopeType.type) {
     case "character":

--- a/src/processTargets/modifiers/scopeHandlers/scopeHandler.types.ts
+++ b/src/processTargets/modifiers/scopeHandlers/scopeHandler.types.ts
@@ -83,7 +83,7 @@ export interface ScopeHandler {
   getScopesTouchingPosition(
     editor: TextEditor,
     position: Position,
-    ancestorIndex?: number
+    ancestorIndex?: number,
   ): TargetScope[];
 
   /**
@@ -148,6 +148,6 @@ export interface ScopeHandler {
     editor: TextEditor,
     position: Position,
     offset: number,
-    direction: Direction
+    direction: Direction,
   ): TargetScope;
 }

--- a/src/processTargets/modifiers/scopeTypeStages/BoundedNonWhitespaceStage.ts
+++ b/src/processTargets/modifiers/scopeTypeStages/BoundedNonWhitespaceStage.ts
@@ -36,7 +36,7 @@ export default class BoundedNonWhitespaceSequenceStage
         type: "surroundingPair",
         delimiter: "any",
         requireStrongContainment: true,
-      }
+      },
     );
 
     if (pairInfo == null) {
@@ -45,7 +45,7 @@ export default class BoundedNonWhitespaceSequenceStage
 
     const targets = paintTargets.flatMap((paintTarget) => {
       const contentRange = paintTarget.contentRange.intersection(
-        pairInfo.interiorRange
+        pairInfo.interiorRange,
       );
 
       if (contentRange == null || contentRange.isEmpty) {

--- a/src/processTargets/modifiers/scopeTypeStages/ContainingSyntaxScopeStage.ts
+++ b/src/processTargets/modifiers/scopeTypeStages/ContainingSyntaxScopeStage.ts
@@ -28,25 +28,25 @@ export interface SimpleEveryScopeModifier extends EveryScopeModifier {
 
 export default class implements ModifierStage {
   constructor(
-    private modifier: SimpleContainingScopeModifier | SimpleEveryScopeModifier
+    private modifier: SimpleContainingScopeModifier | SimpleEveryScopeModifier,
   ) {}
 
   run(context: ProcessedTargetsContext, target: Target): ScopeTypeTarget[] {
     const nodeMatcher = getNodeMatcher(
       target.editor.document.languageId,
       this.modifier.scopeType.type,
-      this.modifier.type === "everyScope"
+      this.modifier.type === "everyScope",
     );
 
     const node: SyntaxNode | null = context.getNodeAtLocation(
-      new Location(target.editor.document.uri, target.contentRange)
+      new Location(target.editor.document.uri, target.contentRange),
     );
 
     const scopeNodes = findNearestContainingAncestorNode(node, nodeMatcher, {
       editor: target.editor,
       selection: new Selection(
         target.contentRange.start,
-        target.contentRange.end
+        target.contentRange.end,
       ),
     });
 
@@ -68,7 +68,7 @@ export default class implements ModifierStage {
         (leadingDelimiterRange != null || trailingDelimiterRange != null)
       ) {
         throw Error(
-          "Removal range is mutually exclusive with leading or trailing delimiter range"
+          "Removal range is mutually exclusive with leading or trailing delimiter range",
         );
       }
 
@@ -92,7 +92,7 @@ export default class implements ModifierStage {
 function findNearestContainingAncestorNode(
   startNode: SyntaxNode,
   nodeMatcher: NodeMatcher,
-  selection: SelectionWithEditor
+  selection: SelectionWithEditor,
 ): SelectionWithEditorWithContext[] | null {
   let node: SyntaxNode | null = startNode;
   while (node != null) {
@@ -103,7 +103,7 @@ function findNearestContainingAncestorNode(
         .map((matchedSelection) => ({
           selection: selectionWithEditorFromRange(
             selection,
-            matchedSelection.selection
+            matchedSelection.selection,
           ),
           context: matchedSelection.context,
         }));

--- a/src/processTargets/modifiers/scopeTypeStages/ParagraphStage.ts
+++ b/src/processTargets/modifiers/scopeTypeStages/ParagraphStage.ts
@@ -31,15 +31,15 @@ export default class implements ModifierStage {
 
     const possiblyAddParagraph = (
       paragraphStart: number,
-      paragraphEnd: number
+      paragraphEnd: number,
     ) => {
       // Paragraph and selection intersects
       if (paragraphEnd >= startLine && paragraphStart <= endLine) {
         targets.push(
           this.getTargetFromRange(
             target,
-            new Range(paragraphStart, 0, paragraphEnd, 0)
-          )
+            new Range(paragraphStart, 0, paragraphEnd, 0),
+          ),
         );
       }
     };
@@ -67,7 +67,7 @@ export default class implements ModifierStage {
 
     if (targets.length === 0) {
       throw new Error(
-        `Couldn't find containing ${this.modifier.scopeType.type}`
+        `Couldn't find containing ${this.modifier.scopeType.type}`,
       );
     }
 

--- a/src/processTargets/modifiers/scopeTypeStages/RegexStage.ts
+++ b/src/processTargets/modifiers/scopeTypeStages/RegexStage.ts
@@ -12,7 +12,7 @@ import { TokenTarget } from "../../targets";
 class RegexStageBase implements ModifierStage {
   constructor(
     private modifier: ContainingScopeModifier | EveryScopeModifier,
-    protected regex: RegExp
+    protected regex: RegExp,
   ) {}
 
   run(context: ProcessedTargetsContext, target: Target): Target[] {
@@ -27,7 +27,7 @@ class RegexStageBase implements ModifierStage {
 
     const searchRange = new Range(
       this.expandRangeForSearch(target.editor, contentRange.start).start,
-      this.expandRangeForSearch(target.editor, contentRange.end).end
+      this.expandRangeForSearch(target.editor, contentRange.end).end,
     );
 
     const matches = this.getMatchesInRange(editor, searchRange);
@@ -36,7 +36,7 @@ class RegexStageBase implements ModifierStage {
         ? matches.filter((match) => match.intersection(contentRange) != null)
         : matches
     ).map((contentRange) =>
-      this.rangeToTarget(target.isReversed, target.editor, contentRange)
+      this.rangeToTarget(target.isReversed, target.editor, contentRange),
     );
 
     if (targets.length === 0) {
@@ -53,18 +53,18 @@ class RegexStageBase implements ModifierStage {
       isReversed,
       editor,
       this.getMatchContainingPosition(editor, contentRange.start).union(
-        this.getMatchContainingPosition(editor, contentRange.end)
-      )
+        this.getMatchContainingPosition(editor, contentRange.end),
+      ),
     );
   }
 
   private getMatchContainingPosition(
     editor: TextEditor,
-    position: Position
+    position: Position,
   ): Range {
     const textRange = this.expandRangeForSearch(editor, position);
     const match = this.getMatchesInRange(editor, textRange).find(
-      (contentRange) => contentRange.contains(position)
+      (contentRange) => contentRange.contains(position),
     );
     if (match == null) {
       throw new NoContainingScopeError(this.modifier.scopeType.type);
@@ -83,7 +83,7 @@ class RegexStageBase implements ModifierStage {
    */
   protected expandRangeForSearch(
     editor: TextEditor,
-    position: Position
+    position: Position,
   ): Range {
     return editor.document.lineAt(position.line).range;
   }
@@ -95,8 +95,8 @@ class RegexStageBase implements ModifierStage {
       (match) =>
         new Range(
           editor.document.positionAt(offset + match.index!),
-          editor.document.positionAt(offset + match.index! + match[0].length)
-        )
+          editor.document.positionAt(offset + match.index! + match[0].length),
+        ),
     );
     if (result == null) {
       throw new NoContainingScopeError(this.modifier.scopeType.type);
@@ -107,7 +107,7 @@ class RegexStageBase implements ModifierStage {
   private rangeToTarget(
     isReversed: boolean,
     editor: TextEditor,
-    contentRange: Range
+    contentRange: Range,
   ): Target {
     return new TokenTarget({
       editor,

--- a/src/processTargets/modifiers/surroundingPair/delimiterMaps.ts
+++ b/src/processTargets/modifiers/surroundingPair/delimiterMaps.ts
@@ -26,7 +26,7 @@ export const delimiterToText: Record<
 };
 
 export const leftToRightMap: Record<string, string> = Object.fromEntries(
-  Object.values(delimiterToText)
+  Object.values(delimiterToText),
 );
 
 /**

--- a/src/processTargets/modifiers/surroundingPair/extractSelectionFromSurroundingPairOffsets.ts
+++ b/src/processTargets/modifiers/surroundingPair/extractSelectionFromSurroundingPairOffsets.ts
@@ -19,39 +19,41 @@ export interface SurroundingPairInfo {
 export function extractSelectionFromSurroundingPairOffsets(
   document: TextDocument,
   baseOffset: number,
-  surroundingPairOffsets: SurroundingPairOffsets
+  surroundingPairOffsets: SurroundingPairOffsets,
 ): SurroundingPairInfo {
   const interior = new Range(
     document.positionAt(baseOffset + surroundingPairOffsets.leftDelimiter.end),
     document.positionAt(
-      baseOffset + surroundingPairOffsets.rightDelimiter.start
-    )
+      baseOffset + surroundingPairOffsets.rightDelimiter.start,
+    ),
   );
   const boundary: [Range, Range] = [
     new Range(
       document.positionAt(
-        baseOffset + surroundingPairOffsets.leftDelimiter.start
+        baseOffset + surroundingPairOffsets.leftDelimiter.start,
       ),
-      document.positionAt(baseOffset + surroundingPairOffsets.leftDelimiter.end)
+      document.positionAt(
+        baseOffset + surroundingPairOffsets.leftDelimiter.end,
+      ),
     ),
     new Range(
       document.positionAt(
-        baseOffset + surroundingPairOffsets.rightDelimiter.start
+        baseOffset + surroundingPairOffsets.rightDelimiter.start,
       ),
       document.positionAt(
-        baseOffset + surroundingPairOffsets.rightDelimiter.end
-      )
+        baseOffset + surroundingPairOffsets.rightDelimiter.end,
+      ),
     ),
   ];
 
   return {
     contentRange: new Selection(
       document.positionAt(
-        baseOffset + surroundingPairOffsets.leftDelimiter.start
+        baseOffset + surroundingPairOffsets.leftDelimiter.start,
       ),
       document.positionAt(
-        baseOffset + surroundingPairOffsets.rightDelimiter.end
-      )
+        baseOffset + surroundingPairOffsets.rightDelimiter.end,
+      ),
     ),
     boundary,
     interiorRange: interior,

--- a/src/processTargets/modifiers/surroundingPair/findDelimiterPairAdjacentToSelection.ts
+++ b/src/processTargets/modifiers/surroundingPair/findDelimiterPairAdjacentToSelection.ts
@@ -31,7 +31,7 @@ export function findDelimiterPairAdjacentToSelection(
   delimiterOccurrences: PossibleDelimiterOccurrence[],
   selectionOffsets: Offsets,
   scopeType: SurroundingPairScopeType,
-  bailOnUnmatchedAdjacent: boolean = false
+  bailOnUnmatchedAdjacent: boolean = false,
 ): SurroundingPairOffsets | null {
   const indicesToTry = [initialIndex + 1, initialIndex];
 
@@ -49,13 +49,13 @@ export function findDelimiterPairAdjacentToSelection(
           delimiterOccurrences,
           index,
           delimiterInfo,
-          scopeType.forceDirection
+          scopeType.forceDirection,
         );
 
         if (possibleMatch != null) {
           const surroundingPairOffsets = getSurroundingPairOffsets(
             delimiterOccurrence as DelimiterOccurrence,
-            possibleMatch
+            possibleMatch,
           );
 
           if (

--- a/src/processTargets/modifiers/surroundingPair/findDelimiterPairContainingSelection.ts
+++ b/src/processTargets/modifiers/surroundingPair/findDelimiterPairContainingSelection.ts
@@ -39,7 +39,7 @@ export function findDelimiterPairContainingSelection(
   initialIndex: number,
   delimiterOccurrences: PossibleDelimiterOccurrence[],
   acceptableDelimiters: SimpleSurroundingPairName[],
-  selectionOffsets: Offsets
+  selectionOffsets: Offsets,
 ): SurroundingPairOffsets | null {
   // Accept any delimiter when scanning right
   const acceptableRightDelimiters = acceptableDelimiters;
@@ -52,7 +52,7 @@ export function findDelimiterPairContainingSelection(
     delimiterOccurrences,
     initialIndex,
     () => acceptableRightDelimiters,
-    true
+    true,
   );
 
   // Start just to the left of the delimiter we start from in our rightward
@@ -61,7 +61,7 @@ export function findDelimiterPairContainingSelection(
     delimiterOccurrences,
     initialIndex - 1,
     () => acceptableLeftDelimiters,
-    false
+    false,
   );
 
   while (true) {
@@ -88,7 +88,7 @@ export function findDelimiterPairContainingSelection(
     if (leftDelimiterOccurrence.offsets.start <= selectionOffsets.start) {
       return getSurroundingPairOffsets(
         leftDelimiterOccurrence,
-        rightDelimiterOccurrence
+        rightDelimiterOccurrence,
       );
     }
   }

--- a/src/processTargets/modifiers/surroundingPair/findOppositeDelimiter.ts
+++ b/src/processTargets/modifiers/surroundingPair/findOppositeDelimiter.ts
@@ -27,7 +27,7 @@ export function findOppositeDelimiter(
   delimiterOccurrences: PossibleDelimiterOccurrence[],
   index: number,
   delimiterInfo: IndividualDelimiter,
-  forceDirection: "left" | "right" | undefined
+  forceDirection: "left" | "right" | undefined,
 ): DelimiterOccurrence | null {
   const { side, delimiter } = delimiterInfo;
 
@@ -36,7 +36,7 @@ export function findOppositeDelimiter(
       delimiterOccurrences,
       direction === "right" ? index + 1 : index - 1,
       [delimiter],
-      direction === "right"
+      direction === "right",
     );
 
     if (unmatchedDelimiter != null) {
@@ -49,7 +49,7 @@ export function findOppositeDelimiter(
 
 function getDirections(
   side: DelimiterSide,
-  forceDirection: SurroundingPairDirection | undefined
+  forceDirection: SurroundingPairDirection | undefined,
 ): SurroundingPairDirection[] {
   if (forceDirection != null) {
     return [forceDirection];

--- a/src/processTargets/modifiers/surroundingPair/findSurroundingPairCore.ts
+++ b/src/processTargets/modifiers/surroundingPair/findSurroundingPairCore.ts
@@ -37,7 +37,7 @@ export function findSurroundingPairCore(
   delimiterOccurrences: PossibleDelimiterOccurrence[],
   acceptableDelimiters: SimpleSurroundingPairName[],
   selectionOffsets: Offsets,
-  bailOnUnmatchedAdjacent: boolean = false
+  bailOnUnmatchedAdjacent: boolean = false,
 ): SurroundingPairOffsets | null {
   /**
    * The initial index from which to start both of our searches.  We set this
@@ -51,7 +51,7 @@ export function findSurroundingPairCore(
     {
       offsets: selectionOffsets,
     },
-    "offsets.end"
+    "offsets.end",
   );
 
   // First look for delimiter pair where one delimiter contains the selection.
@@ -61,7 +61,7 @@ export function findSurroundingPairCore(
       delimiterOccurrences,
       selectionOffsets,
       scopeType,
-      bailOnUnmatchedAdjacent
+      bailOnUnmatchedAdjacent,
     );
 
   if (delimiterPairAdjacentToSelection != null) {
@@ -73,6 +73,6 @@ export function findSurroundingPairCore(
     initialIndex,
     delimiterOccurrences,
     acceptableDelimiters,
-    selectionOffsets
+    selectionOffsets,
   );
 }

--- a/src/processTargets/modifiers/surroundingPair/findSurroundingPairParseTreeBased.ts
+++ b/src/processTargets/modifiers/surroundingPair/findSurroundingPairParseTreeBased.ts
@@ -62,7 +62,7 @@ export function findSurroundingPairParseTreeBased(
   selection: Range,
   node: SyntaxNode,
   delimiters: SimpleSurroundingPairName[],
-  scopeType: SurroundingPairScopeType
+  scopeType: SurroundingPairScopeType,
 ) {
   const document: TextDocument = editor.document;
 
@@ -72,7 +72,7 @@ export function findSurroundingPairParseTreeBased(
     individualDelimiters.map((individualDelimiter) => [
       individualDelimiter.text,
       individualDelimiter,
-    ])
+    ]),
   );
 
   const selectionOffsets = {
@@ -107,7 +107,7 @@ export function findSurroundingPairParseTreeBased(
     // Here we apply the core algorithm
     const pairOffsets = findSurroundingPairContainedInNode(
       context,
-      currentNode
+      currentNode,
     );
 
     // And then perform postprocessing
@@ -115,7 +115,7 @@ export function findSurroundingPairParseTreeBased(
       return extractSelectionFromSurroundingPairOffsets(
         document,
         0,
-        pairOffsets
+        pairOffsets,
       );
     }
   }
@@ -163,7 +163,7 @@ interface Context {
  */
 function findSurroundingPairContainedInNode(
   context: Context,
-  node: SyntaxNode
+  node: SyntaxNode,
 ) {
   const {
     delimiterTextToDelimiterInfoMap,
@@ -238,7 +238,7 @@ function findSurroundingPairContainedInNode(
     // delimiter within our list. We do so because it's possible that the
     // adjacent delimiter's opposite might be found when we run again on a
     // parent node later.
-    node.parent != null
+    node.parent != null,
   );
 }
 

--- a/src/processTargets/modifiers/surroundingPair/findSurroundingPairTextBased.ts
+++ b/src/processTargets/modifiers/surroundingPair/findSurroundingPairTextBased.ts
@@ -70,7 +70,7 @@ export function findSurroundingPairTextBased(
   range: Range,
   allowableRange: Range | null,
   delimiters: SimpleSurroundingPairName[],
-  scopeType: SurroundingPairScopeType
+  scopeType: SurroundingPairScopeType,
 ) {
   const document: TextDocument = editor.document;
   const fullRange = allowableRange ?? getDocumentRange(document);
@@ -81,7 +81,7 @@ export function findSurroundingPairTextBased(
     individualDelimiters.map((individualDelimiter) => [
       individualDelimiter.text,
       individualDelimiter,
-    ])
+    ]),
   );
 
   /**
@@ -124,17 +124,17 @@ export function findSurroundingPairTextBased(
     const currentRangeOffsets = {
       start: Math.max(
         fullRangeOffsets.start,
-        selectionOffsets.end - scanLength / 2
+        selectionOffsets.end - scanLength / 2,
       ),
       end: Math.min(
         fullRangeOffsets.end,
-        selectionOffsets.end + scanLength / 2
+        selectionOffsets.end + scanLength / 2,
       ),
     };
 
     const currentRange = new Range(
       document.positionAt(currentRangeOffsets.start),
-      document.positionAt(currentRangeOffsets.end)
+      document.positionAt(currentRangeOffsets.end),
     );
 
     // Just bail early if the range doesn't completely contain our selection as
@@ -157,7 +157,7 @@ export function findSurroundingPairTextBased(
       document.getText(currentRange),
       adjustedSelectionOffsets,
       currentRangeOffsets.start === fullRangeOffsets.start,
-      currentRangeOffsets.end === fullRangeOffsets.end
+      currentRangeOffsets.end === fullRangeOffsets.end,
     );
 
     if (pairOffsets != null) {
@@ -165,7 +165,7 @@ export function findSurroundingPairTextBased(
       return extractSelectionFromSurroundingPairOffsets(
         document,
         currentRangeOffsets.start,
-        pairOffsets
+        pairOffsets,
       );
     }
 
@@ -183,7 +183,7 @@ function getDelimiterRegex(individualDelimiters: IndividualDelimiter[]) {
   // Create a regex which is a disjunction of all possible left / right
   // delimiter texts
   const individualDelimiterDisjunct = uniq(
-    individualDelimiters.map(({ text }) => text)
+    individualDelimiters.map(({ text }) => text),
   )
     .map(escapeRegExp)
     .join("|");
@@ -226,7 +226,7 @@ function getDelimiterPairOffsets(
   text: string,
   selectionOffsets: Offsets,
   isAtStartOfFullRange: boolean,
-  isAtEndOfFullRange: boolean
+  isAtEndOfFullRange: boolean,
 ): SurroundingPairOffsets | null {
   const {
     scopeType,
@@ -274,7 +274,7 @@ function getDelimiterPairOffsets(
                   delimiterOccurrences,
                   index,
                   rawDelimiterInfo?.delimiter,
-                  startOffset
+                  startOffset,
                 )
               : rawDelimiterInfo.side;
 
@@ -286,7 +286,7 @@ function getDelimiterPairOffsets(
           return delimiterInfo;
         },
       };
-    }
+    },
   );
 
   // Then just run core algorithm
@@ -295,7 +295,7 @@ function getDelimiterPairOffsets(
     delimiterOccurrences,
     delimiters,
     selectionOffsets,
-    !isAtStartOfFullRange || !isAtEndOfFullRange
+    !isAtStartOfFullRange || !isAtEndOfFullRange,
   );
 
   // If we're not at the start of the full range, or we're not at the end of the
@@ -346,7 +346,7 @@ function inferDelimiterSide(
   delimiterOccurrences: PossibleDelimiterOccurrence[],
   index: number,
   delimiter: SurroundingPairName,
-  occurrenceStartOffset: number
+  occurrenceStartOffset: number,
 ) {
   const previousOccurrence =
     index === 0
@@ -355,7 +355,7 @@ function inferDelimiterSide(
           delimiterOccurrences,
           (delimiterOccurrence) =>
             delimiterOccurrence.delimiterInfo?.delimiter === delimiter,
-          index - 1
+          index - 1,
         );
 
   if (

--- a/src/processTargets/modifiers/surroundingPair/generateUnmatchedDelimiters.ts
+++ b/src/processTargets/modifiers/surroundingPair/generateUnmatchedDelimiters.ts
@@ -23,13 +23,13 @@ export function findUnmatchedDelimiter(
   delimiterOccurrences: PossibleDelimiterOccurrence[],
   initialIndex: number,
   acceptableDelimiters: SimpleSurroundingPairName[],
-  lookForward: boolean
+  lookForward: boolean,
 ): DelimiterOccurrence | null {
   const generatorResult = generateUnmatchedDelimiters(
     delimiterOccurrences,
     initialIndex,
     () => acceptableDelimiters,
-    lookForward
+    lookForward,
   ).next();
 
   return generatorResult.done ? null : generatorResult.value;
@@ -62,7 +62,7 @@ export function* generateUnmatchedDelimiters(
   delimiterOccurrences: PossibleDelimiterOccurrence[],
   initialIndex: number,
   getCurrentAcceptableDelimiters: () => SimpleSurroundingPairName[],
-  lookForward: boolean
+  lookForward: boolean,
 ): Generator<DelimiterOccurrence, void, never> {
   /**
    * This map tells us whether to increment or decrement our delimiter count

--- a/src/processTargets/modifiers/surroundingPair/getIndividualDelimiters.ts
+++ b/src/processTargets/modifiers/surroundingPair/getIndividualDelimiters.ts
@@ -13,7 +13,7 @@ import { isString } from "../../../util/type";
  * @returns A list of information about all possible left / right delimiter instances
  */
 export function getIndividualDelimiters(
-  delimiters: SimpleSurroundingPairName[]
+  delimiters: SimpleSurroundingPairName[],
 ): IndividualDelimiter[] {
   return delimiters.flatMap((delimiter) => {
     const [leftDelimiter, rightDelimiter] = delimiterToText[delimiter];

--- a/src/processTargets/modifiers/surroundingPair/getSurroundingPairOffsets.ts
+++ b/src/processTargets/modifiers/surroundingPair/getSurroundingPairOffsets.ts
@@ -9,7 +9,7 @@ import { SurroundingPairOffsets, DelimiterOccurrence } from "./types";
  */
 export function getSurroundingPairOffsets(
   delimiter1: DelimiterOccurrence,
-  delimiter2: DelimiterOccurrence
+  delimiter2: DelimiterOccurrence,
 ): SurroundingPairOffsets {
   const isDelimiter1First = delimiter1.offsets.start < delimiter2.offsets.start;
   const leftDelimiter = isDelimiter1First ? delimiter1 : delimiter2;

--- a/src/processTargets/modifiers/surroundingPair/index.ts
+++ b/src/processTargets/modifiers/surroundingPair/index.ts
@@ -31,7 +31,7 @@ export function processSurroundingPair(
   context: ProcessedTargetsContext,
   editor: TextEditor,
   range: Range,
-  scopeType: SurroundingPairScopeType
+  scopeType: SurroundingPairScopeType,
 ): SurroundingPairInfo | null {
   const document = editor.document;
   const delimiters = complexDelimiterMap[
@@ -54,7 +54,7 @@ export function processSurroundingPair(
         range,
         null,
         delimiters,
-        scopeType
+        scopeType,
       );
     } else {
       throw err;
@@ -74,7 +74,7 @@ export function processSurroundingPair(
       range,
       textFragmentRange,
       delimiters,
-      scopeType
+      scopeType,
     );
 
     if (surroundingRange != null) {
@@ -90,6 +90,6 @@ export function processSurroundingPair(
     range,
     node,
     delimiters,
-    scopeType
+    scopeType,
   );
 }

--- a/src/processTargets/modifiers/targetSequenceUtils.ts
+++ b/src/processTargets/modifiers/targetSequenceUtils.ts
@@ -23,7 +23,7 @@ export function createRangeTargetFromIndices(
   isReversed: boolean,
   targets: Target[],
   startIndex: number,
-  endIndex: number
+  endIndex: number,
 ): Target {
   if (startIndex < 0 || endIndex >= targets.length) {
     throw new OutOfRangeError();
@@ -37,14 +37,14 @@ export function createRangeTargetFromIndices(
     isReversed,
     targets[endIndex],
     true,
-    true
+    true,
   );
 }
 
 export function getEveryScopeTargets(
   context: ProcessedTargetsContext,
   target: Target,
-  scopeType: ScopeType
+  scopeType: ScopeType,
 ): Target[] {
   const containingStage = getModifierStage({
     type: "everyScope",

--- a/src/processTargets/processTargets.ts
+++ b/src/processTargets/processTargets.ts
@@ -29,19 +29,19 @@ import { PlainTarget, PositionTarget } from "./targets";
  */
 export default function (
   context: ProcessedTargetsContext,
-  targets: TargetDescriptor[]
+  targets: TargetDescriptor[],
 ): Target[][] {
   return targets.map((target) => uniqTargets(processTarget(context, target)));
 }
 
 function processTarget(
   context: ProcessedTargetsContext,
-  target: TargetDescriptor
+  target: TargetDescriptor,
 ): Target[] {
   switch (target.type) {
     case "list":
       return target.elements.flatMap((element) =>
-        processTarget(context, element)
+        processTarget(context, element),
       );
     case "range":
       return processRangeTarget(context, target);
@@ -52,7 +52,7 @@ function processTarget(
 
 function processRangeTarget(
   context: ProcessedTargetsContext,
-  targetDesc: RangeTargetDescriptor
+  targetDesc: RangeTargetDescriptor,
 ): Target[] {
   const anchorTargets = processPrimitiveTarget(context, targetDesc.anchor);
   const activeTargets = processPrimitiveTarget(context, targetDesc.active);
@@ -70,7 +70,7 @@ function processRangeTarget(
               anchorTarget,
               activeTarget,
               targetDesc.excludeAnchor,
-              targetDesc.excludeActive
+              targetDesc.excludeActive,
             ),
           ];
         case "vertical":
@@ -78,10 +78,10 @@ function processRangeTarget(
             anchorTarget,
             activeTarget,
             targetDesc.excludeAnchor,
-            targetDesc.excludeActive
+            targetDesc.excludeActive,
           );
       }
-    }
+    },
   );
 }
 
@@ -89,7 +89,7 @@ export function targetsToContinuousTarget(
   anchorTarget: Target,
   activeTarget: Target,
   excludeAnchor: boolean = false,
-  excludeActive: boolean = false
+  excludeActive: boolean = false,
 ): Target {
   ensureSingleEditor(anchorTarget, activeTarget);
 
@@ -103,7 +103,7 @@ export function targetsToContinuousTarget(
     isReversed,
     endTarget,
     !excludeStart,
-    !excludeEnd
+    !excludeEnd,
   );
 }
 
@@ -111,7 +111,7 @@ function targetsToVerticalTarget(
   anchorTarget: Target,
   activeTarget: Target,
   excludeAnchor: boolean,
-  excludeActive: boolean
+  excludeActive: boolean,
 ): Target[] {
   ensureSingleEditor(anchorTarget, activeTarget);
 
@@ -133,7 +133,7 @@ function targetsToVerticalTarget(
       i,
       anchorTarget.contentRange.start.character,
       i,
-      anchorTarget.contentRange.end.character
+      anchorTarget.contentRange.end.character,
     );
 
     if (anchorTarget instanceof PositionTarget) {
@@ -144,7 +144,7 @@ function targetsToVerticalTarget(
           editor: anchorTarget.editor,
           isReversed: anchorTarget.isReversed,
           contentRange,
-        })
+        }),
       );
     }
 
@@ -177,7 +177,7 @@ function targetsToVerticalTarget(
  */
 function processPrimitiveTarget(
   context: ProcessedTargetsContext,
-  targetDescriptor: PrimitiveTargetDescriptor
+  targetDescriptor: PrimitiveTargetDescriptor,
 ): Target[] {
   // First, get the targets output by the mark
   const markStage = getMarkStage(targetDescriptor.mark);
@@ -204,7 +204,7 @@ function processPrimitiveTarget(
 
 /** Convert a list of target modifiers to modifier stages */
 export function getModifierStagesFromTargetModifiers(
-  targetModifiers: Modifier[]
+  targetModifiers: Modifier[],
 ) {
   // Reverse target modifiers because they are returned in reverse order from
   // the api, to match the order in which they are spoken.
@@ -215,7 +215,7 @@ export function getModifierStagesFromTargetModifiers(
 export function processModifierStages(
   context: ProcessedTargetsContext,
   modifierStages: ModifierStage[],
-  targets: Target[]
+  targets: Target[],
 ) {
   // First we apply each stage in sequence, letting each stage see the targets
   // one-by-one and concatenating the results before passing them on to the

--- a/src/processTargets/targetUtil/createContinuousRange.ts
+++ b/src/processTargets/targetUtil/createContinuousRange.ts
@@ -6,13 +6,13 @@ export function createContinuousRange(
   startTarget: Target,
   endTarget: Target,
   includeStart: boolean,
-  includeEnd: boolean
+  includeEnd: boolean,
 ) {
   return createContinuousRangeFromRanges(
     startTarget.contentRange,
     endTarget.contentRange,
     includeStart,
-    includeEnd
+    includeEnd,
   );
 }
 
@@ -20,11 +20,11 @@ export function createContinuousRangeFromRanges(
   startRange: Range,
   endRange: Range,
   includeStart: boolean,
-  includeEnd: boolean
+  includeEnd: boolean,
 ) {
   return new Range(
     includeStart ? startRange.start : startRange.end,
-    includeEnd ? endRange.end : endRange.start
+    includeEnd ? endRange.end : endRange.start,
   );
 }
 
@@ -32,7 +32,7 @@ export function createContinuousLineRange(
   startTarget: Target,
   endTarget: Target,
   includeStart: boolean,
-  includeEnd: boolean
+  includeEnd: boolean,
 ) {
   const start = includeStart
     ? startTarget.contentRange.start
@@ -51,10 +51,10 @@ export function createSimpleContinuousRangeTarget(
   target2: Target,
   isReversed: boolean,
   includeStart: boolean = true,
-  includeEnd: boolean = true
+  includeEnd: boolean = true,
 ) {
   const isForward = target1.contentRange.start.isBefore(
-    target2.contentRange.start
+    target2.contentRange.start,
   );
   const anchorTarget = isForward ? target1 : target2;
   const activeTarget = isForward ? target2 : target1;
@@ -63,7 +63,7 @@ export function createSimpleContinuousRangeTarget(
     isReversed,
     activeTarget,
     includeStart,
-    includeEnd
+    includeEnd,
   );
 }
 
@@ -72,7 +72,7 @@ export function createContinuousRangeUntypedTarget(
   startTarget: Target,
   endTarget: Target,
   includeStart: boolean,
-  includeEnd: boolean
+  includeEnd: boolean,
 ): UntypedTarget {
   return new UntypedTarget({
     editor: startTarget.editor,
@@ -82,7 +82,7 @@ export function createContinuousRangeUntypedTarget(
       startTarget,
       endTarget,
       includeStart,
-      includeEnd
+      includeEnd,
     ),
   });
 }

--- a/src/processTargets/targetUtil/insertionRemovalBehaviors/TokenInsertionRemovalBehavior.ts
+++ b/src/processTargets/targetUtil/insertionRemovalBehaviors/TokenInsertionRemovalBehavior.ts
@@ -5,7 +5,7 @@ import { expandToFullLine, makeEmptyRange } from "../../../util/rangeUtils";
 import { PlainTarget } from "../../targets";
 
 export function getTokenLeadingDelimiterTarget(
-  target: Target
+  target: Target,
 ): Target | undefined {
   const { editor } = target;
   const { start } = target.contentRange;
@@ -21,7 +21,7 @@ export function getTokenLeadingDelimiterTarget(
           start.line,
           start.character - leadingDelimiters[0].length,
           start.line,
-          start.character
+          start.character,
         ),
         editor,
         isReversed: target.isReversed,
@@ -29,7 +29,7 @@ export function getTokenLeadingDelimiterTarget(
 }
 
 export function getTokenTrailingDelimiterTarget(
-  target: Target
+  target: Target,
 ): Target | undefined {
   const { editor } = target;
   const { end } = target.contentRange;
@@ -45,7 +45,7 @@ export function getTokenTrailingDelimiterTarget(
           end.line,
           end.character,
           end.line,
-          end.character + trailingDelimiters[0].length
+          end.character + trailingDelimiters[0].length,
         ),
         editor,
         isReversed: target.isReversed,
@@ -111,7 +111,7 @@ export function getTokenRemovalRange(target: Target): Range {
 function mergesTokens(
   editor: TextEditor,
   contentRange: Range,
-  removalRange: Range
+  removalRange: Range,
 ) {
   const { document } = editor;
   const fullRange = expandToFullLine(editor, contentRange);
@@ -122,14 +122,14 @@ function mergesTokens(
     document,
     fullText,
     fullTextOffset,
-    contentRange
+    contentRange,
   );
 
   const numTokensRemovalRangeRemoved = calculateNumberOfTokensAfterRemoval(
     document,
     fullText,
     fullTextOffset,
-    removalRange
+    removalRange,
   );
 
   return numTokensContentRangeRemoved !== numTokensRemovalRangeRemoved;
@@ -139,7 +139,7 @@ function calculateNumberOfTokensAfterRemoval(
   document: TextDocument,
   fullText: string,
   fullTextOffset: number,
-  removalRange: Range
+  removalRange: Range,
 ): number {
   const startIndex = document.offsetAt(removalRange.start) - fullTextOffset;
   const endIndex = document.offsetAt(removalRange.end) - fullTextOffset;

--- a/src/processTargets/targets/BaseTarget.ts
+++ b/src/processTargets/targets/BaseTarget.ts
@@ -123,7 +123,7 @@ export default abstract class BaseTarget implements Target {
     isReversed: boolean,
     endTarget: Target,
     includeStart: boolean,
-    includeEnd: boolean
+    includeEnd: boolean,
   ): Target {
     if (isSameType(this, endTarget)) {
       const constructor = Object.getPrototypeOf(this).constructor;
@@ -135,7 +135,7 @@ export default abstract class BaseTarget implements Target {
           this,
           endTarget,
           includeStart,
-          includeEnd
+          includeEnd,
         ),
       });
     }
@@ -145,7 +145,7 @@ export default abstract class BaseTarget implements Target {
       this,
       endTarget,
       includeStart,
-      includeEnd
+      includeEnd,
     );
   }
 

--- a/src/processTargets/targets/InteriorTarget.ts
+++ b/src/processTargets/targets/InteriorTarget.ts
@@ -22,7 +22,7 @@ export default class InteriorTarget extends BaseTarget {
       ...parameters,
       contentRange: shrinkRangeToFitContent(
         parameters.editor,
-        parameters.fullInteriorRange
+        parameters.fullInteriorRange,
       ),
     });
     this.fullInteriorRange = parameters.fullInteriorRange;
@@ -43,7 +43,7 @@ export default class InteriorTarget extends BaseTarget {
     isReversed: boolean,
     endTarget: Target,
     includeStart: boolean,
-    includeEnd: boolean
+    includeEnd: boolean,
   ): Target {
     if (isSameType(this, endTarget)) {
       const constructor = Object.getPrototypeOf(this).constructor;
@@ -55,7 +55,7 @@ export default class InteriorTarget extends BaseTarget {
           this.fullInteriorRange,
           endTarget.fullInteriorRange,
           includeStart,
-          includeEnd
+          includeEnd,
         ),
       });
     }
@@ -65,7 +65,7 @@ export default class InteriorTarget extends BaseTarget {
       this,
       endTarget,
       includeStart,
-      includeEnd
+      includeEnd,
     );
   }
 }

--- a/src/processTargets/targets/LineTarget.ts
+++ b/src/processTargets/targets/LineTarget.ts
@@ -17,7 +17,7 @@ export default class LineTarget extends BaseTarget {
     return tryConstructPlainTarget(
       this.editor,
       getLeadingDelimiterRange(this.editor, this.fullLineContentRange),
-      this.isReversed
+      this.isReversed,
     );
   }
 
@@ -25,7 +25,7 @@ export default class LineTarget extends BaseTarget {
     return tryConstructPlainTarget(
       this.editor,
       getTrailingDelimiterRange(this.editor, this.fullLineContentRange),
-      this.isReversed
+      this.isReversed,
     );
   }
 
@@ -45,7 +45,7 @@ export default class LineTarget extends BaseTarget {
     isReversed: boolean,
     endTarget: Target,
     includeStart: boolean,
-    includeEnd: boolean
+    includeEnd: boolean,
   ): Target {
     if (endTarget.isLine) {
       return new LineTarget({
@@ -55,7 +55,7 @@ export default class LineTarget extends BaseTarget {
           this,
           endTarget,
           includeStart,
-          includeEnd
+          includeEnd,
         ),
       });
     }
@@ -64,7 +64,7 @@ export default class LineTarget extends BaseTarget {
       isReversed,
       endTarget,
       includeStart,
-      includeEnd
+      includeEnd,
     );
   }
 

--- a/src/processTargets/targets/ParagraphTarget.ts
+++ b/src/processTargets/targets/ParagraphTarget.ts
@@ -15,7 +15,7 @@ export default class ParagraphTarget extends BaseTarget {
     return constructLineTarget(
       this.editor,
       getLeadingDelimiterRange(this.editor, this.fullLineContentRange),
-      this.isReversed
+      this.isReversed,
     );
   }
 
@@ -23,7 +23,7 @@ export default class ParagraphTarget extends BaseTarget {
     return constructLineTarget(
       this.editor,
       getTrailingDelimiterRange(this.editor, this.fullLineContentRange),
-      this.isReversed
+      this.isReversed,
     );
   }
 
@@ -71,7 +71,7 @@ export default class ParagraphTarget extends BaseTarget {
     isReversed: boolean,
     endTarget: Target,
     includeStart: boolean,
-    includeEnd: boolean
+    includeEnd: boolean,
   ): Target {
     if (isSameType(this, endTarget)) {
       return new ParagraphTarget({
@@ -81,7 +81,7 @@ export default class ParagraphTarget extends BaseTarget {
           this,
           endTarget,
           includeStart,
-          includeEnd
+          includeEnd,
         ),
       });
     }
@@ -94,7 +94,7 @@ export default class ParagraphTarget extends BaseTarget {
           this,
           endTarget,
           includeStart,
-          includeEnd
+          includeEnd,
         ),
       });
     }
@@ -103,7 +103,7 @@ export default class ParagraphTarget extends BaseTarget {
       isReversed,
       endTarget,
       includeStart,
-      includeEnd
+      includeEnd,
     );
   }
 
@@ -124,14 +124,14 @@ function getLeadingDelimiterRange(editor: TextEditor, contentRange: Range) {
     }
     return new Range(
       new Position(leadingLine.lineNumber + 1, 0),
-      lineAt(startLine.lineNumber - 1).range.end
+      lineAt(startLine.lineNumber - 1).range.end,
     );
   }
   // Leading delimiter to start of file
   if (startLine.lineNumber > 0) {
     return new Range(
       new Position(0, 0),
-      lineAt(startLine.lineNumber - 1).range.end
+      lineAt(startLine.lineNumber - 1).range.end,
     );
   }
   return undefined;
@@ -148,14 +148,14 @@ function getTrailingDelimiterRange(editor: TextEditor, contentRange: Range) {
     }
     return new Range(
       new Position(endLine.lineNumber + 1, 0),
-      lineAt(trailingLine.lineNumber - 1).range.end
+      lineAt(trailingLine.lineNumber - 1).range.end,
     );
   }
   // Trailing delimiter to end of file
   if (endLine.lineNumber < document.lineCount - 1) {
     return new Range(
       new Position(endLine.lineNumber + 1, 0),
-      lineAt(document.lineCount - 1).range.end
+      lineAt(document.lineCount - 1).range.end,
     );
   }
   return undefined;

--- a/src/processTargets/targets/PositionTarget.ts
+++ b/src/processTargets/targets/PositionTarget.ts
@@ -31,7 +31,7 @@ export default class PositionTarget extends BaseTarget {
     this.indentationString = this.isLineDelimiter
       ? getIndentationString(
           parameters.editor,
-          parameters.thatTarget!.contentRange
+          parameters.thatTarget!.contentRange,
         )
       : "";
   }
@@ -94,7 +94,7 @@ export default class PositionTarget extends BaseTarget {
     const position = (() => {
       if (this.isLineDelimiter) {
         const line = this.editor.document.lineAt(
-          this.isBefore ? this.contentRange.start : this.contentRange.end
+          this.isBefore ? this.contentRange.start : this.contentRange.end,
         );
         return this.isBefore ? line.range.start : line.range.end;
       } else {
@@ -124,7 +124,7 @@ export default class PositionTarget extends BaseTarget {
 
     return new Range(
       this.editor.document.positionAt(startIndex),
-      this.editor.document.positionAt(endIndex)
+      this.editor.document.positionAt(endIndex),
     );
   }
 }
@@ -134,7 +134,7 @@ export function removalUnsupportedForPosition(position: string): Range {
     position === "after" || position === "end" ? "trailing" : "leading";
 
   throw new UnsupportedError(
-    `Please use "${preferredModifier}" modifier; removal is not supported for "${position}"`
+    `Please use "${preferredModifier}" modifier; removal is not supported for "${position}"`,
   );
 }
 

--- a/src/processTargets/targets/ScopeTypeTarget.ts
+++ b/src/processTargets/targets/ScopeTypeTarget.ts
@@ -100,7 +100,7 @@ export default class ScopeTypeTarget extends BaseTarget {
     isReversed: boolean,
     endTarget: Target,
     includeStart: boolean,
-    includeEnd: boolean
+    includeEnd: boolean,
   ): Target {
     if (isSameType(this, endTarget)) {
       const scopeTarget = endTarget;
@@ -111,7 +111,7 @@ export default class ScopeTypeTarget extends BaseTarget {
                 this.removalRange_ ?? this.contentRange,
                 scopeTarget.removalRange_ ?? scopeTarget.contentRange,
                 includeStart,
-                includeEnd
+                includeEnd,
               )
             : undefined;
 
@@ -125,7 +125,7 @@ export default class ScopeTypeTarget extends BaseTarget {
             this,
             endTarget,
             includeStart,
-            includeEnd
+            includeEnd,
           ),
         });
       }
@@ -135,7 +135,7 @@ export default class ScopeTypeTarget extends BaseTarget {
       isReversed,
       endTarget,
       includeStart,
-      includeEnd
+      includeEnd,
     );
   }
 

--- a/src/processTargets/targets/SubTokenWordTarget.ts
+++ b/src/processTargets/targets/SubTokenWordTarget.ts
@@ -25,7 +25,7 @@ export default class SubTokenWordTarget extends BaseTarget {
     return tryConstructPlainTarget(
       this.editor,
       this.leadingDelimiterRange_,
-      this.isReversed
+      this.isReversed,
     );
   }
 
@@ -33,7 +33,7 @@ export default class SubTokenWordTarget extends BaseTarget {
     return tryConstructPlainTarget(
       this.editor,
       this.trailingDelimiterRange_,
-      this.isReversed
+      this.isReversed,
     );
   }
 

--- a/src/processTargets/targets/SurroundingPairTarget.ts
+++ b/src/processTargets/targets/SurroundingPairTarget.ts
@@ -63,7 +63,7 @@ export default class SurroundingPairTarget extends BaseTarget {
           editor: this.editor,
           isReversed: this.isReversed,
           contentRange,
-        })
+        }),
     );
   }
 

--- a/src/processTargets/targets/UntypedTarget.ts
+++ b/src/processTargets/targets/UntypedTarget.ts
@@ -43,14 +43,14 @@ export default class UntypedTarget extends BaseTarget {
     isReversed: boolean,
     endTarget: Target,
     includeStart: boolean,
-    includeEnd: boolean
+    includeEnd: boolean,
   ): Target {
     return createContinuousRangeUntypedTarget(
       isReversed,
       this,
       endTarget,
       includeStart,
-      includeEnd
+      includeEnd,
     );
   }
 

--- a/src/scripts/hatAdjustments/add.ts
+++ b/src/scripts/hatAdjustments/add.ts
@@ -22,10 +22,10 @@ const adjustments: Partial<IndividualHatAdjustmentMap>[] = [
 
 function processProperty(
   hatAdjustmentsList: HatAdjustments[],
-  propertyName: keyof HatAdjustments
+  propertyName: keyof HatAdjustments,
 ) {
   const value = sum(
-    hatAdjustmentsList.map((adjustment) => adjustment[propertyName] ?? 0)
+    hatAdjustmentsList.map((adjustment) => adjustment[propertyName] ?? 0),
   );
 
   return postProcessValue(value);
@@ -35,7 +35,7 @@ function main() {
   const finalMap = Object.fromEntries(
     HAT_SHAPES.map((shape) => {
       const adjustmentsList = adjustments.map(
-        (adjustment) => adjustment[shape] ?? {}
+        (adjustment) => adjustment[shape] ?? {},
       );
 
       return [
@@ -45,7 +45,7 @@ function main() {
           verticalOffset: processProperty(adjustmentsList, "verticalOffset"),
         },
       ];
-    })
+    }),
   ) as IndividualHatAdjustmentMap;
 
   console.log(JSON.stringify(finalMap, null, 2));

--- a/src/scripts/hatAdjustments/average.ts
+++ b/src/scripts/hatAdjustments/average.ts
@@ -17,7 +17,7 @@ const newAdjustments: Partial<IndividualHatAdjustmentMap> = {};
 function processProperty(
   originalAdjustment: HatAdjustments,
   newAdjustment: HatAdjustments,
-  propertyName: keyof HatAdjustments
+  propertyName: keyof HatAdjustments,
 ) {
   const originalValue = originalAdjustment[propertyName] ?? 0;
   const newAdjustmentValue = newAdjustment[propertyName] ?? 0;
@@ -43,16 +43,16 @@ function main() {
           sizeAdjustment: processProperty(
             originalAdjustment,
             newAdjustment,
-            "sizeAdjustment"
+            "sizeAdjustment",
           ),
           verticalOffset: processProperty(
             originalAdjustment,
             newAdjustment,
-            "verticalOffset"
+            "verticalOffset",
           ),
         },
       ];
-    })
+    }),
   );
 
   (["value", "originalAdjustment", "newAdjustment"] as const).forEach((key) => {
@@ -65,7 +65,7 @@ function main() {
             verticalOffset: fullMap[shape].verticalOffset[key],
           },
         ];
-      })
+      }),
     ) as IndividualHatAdjustmentMap;
     console.log(`${key}: `);
     console.log(JSON.stringify(map, null, 2));

--- a/src/scripts/prepareForExtensionPublish.ts
+++ b/src/scripts/prepareForExtensionPublish.ts
@@ -44,7 +44,7 @@ async function main() {
     JSON.stringify({
       gitSha: (await runCommand("git rev-parse HEAD")).trim(),
       buildUrl: `${githubBaseUrl}/${repository}/actions/runs/${runId}`,
-    })
+    }),
   );
 }
 

--- a/src/scripts/transformRecordedTests/transformFile.ts
+++ b/src/scripts/transformRecordedTests/transformFile.ts
@@ -6,7 +6,7 @@ import { FixtureTransformation } from "./types";
 
 export async function transformFile(
   transformation: FixtureTransformation,
-  file: string
+  file: string,
 ) {
   const buffer = await fsp.readFile(file);
   const inputFixture = yaml.load(buffer.toString()) as TestCaseFixture;

--- a/src/scripts/transformRecordedTests/transformations/upgrade.ts
+++ b/src/scripts/transformRecordedTests/transformations/upgrade.ts
@@ -9,7 +9,7 @@ export const upgrade = flow(upgradeCommand, reorderFields);
 function upgradeCommand(fixture: TestCaseFixture) {
   fixture.command = flow(
     canonicalizeAndValidateCommand,
-    cleanUpTestCaseCommand
+    cleanUpTestCaseCommand,
   )(fixture.command);
 
   return fixture;

--- a/src/scripts/transformRecordedTests/transformations/upgradeFromVersion0.ts
+++ b/src/scripts/transformRecordedTests/transformations/upgradeFromVersion0.ts
@@ -21,7 +21,7 @@ export function upgradeFromVersion0(fixture: TestCaseFixture) {
         (target.mark as any).usePrePhraseSnapshot = undefined;
       }
       return target;
-    }
+    },
   );
 
   return {

--- a/src/scripts/transformRecordedTests/types.ts
+++ b/src/scripts/transformRecordedTests/types.ts
@@ -1,5 +1,5 @@
 import { TestCaseFixture } from "../../testUtil/TestCase";
 
 export type FixtureTransformation = (
-  originalFixture: TestCaseFixture
+  originalFixture: TestCaseFixture,
 ) => TestCaseFixture;

--- a/src/scripts/transformRecordedTests/upgradeThatMarks.ts
+++ b/src/scripts/transformRecordedTests/upgradeThatMarks.ts
@@ -7,13 +7,13 @@ import { FixtureTransformation } from "./types";
 
 // FIXME: Remove this before merging the PR
 export const upgradeThatMarks: FixtureTransformation = (
-  fixture: TestCaseFixture
+  fixture: TestCaseFixture,
 ) => {
   fixture.initialState.thatMark = fixture.initialState.thatMark?.map(
-    (rangePlainObject) => fixRange(rangePlainObject as any)
+    (rangePlainObject) => fixRange(rangePlainObject as any),
   );
   fixture.initialState.sourceMark = fixture.initialState.sourceMark?.map(
-    (rangePlainObject) => fixRange(rangePlainObject as any)
+    (rangePlainObject) => fixRange(rangePlainObject as any),
   );
 
   if (fixture.finalState == null) {
@@ -21,10 +21,10 @@ export const upgradeThatMarks: FixtureTransformation = (
   }
 
   fixture.finalState.thatMark = fixture.finalState.thatMark?.map(
-    (rangePlainObject) => fixRange(rangePlainObject as any)
+    (rangePlainObject) => fixRange(rangePlainObject as any),
   );
   fixture.finalState.sourceMark = fixture.finalState.sourceMark?.map(
-    (rangePlainObject) => fixRange(rangePlainObject as any)
+    (rangePlainObject) => fixRange(rangePlainObject as any),
   );
 
   return fixture;

--- a/src/test/initLaunchSandbox.ts
+++ b/src/test/initLaunchSandbox.ts
@@ -16,7 +16,7 @@ async function main() {
     const extensionSandboxDir = path.join(
       extensionDevelopmentPath,
       ".vscode-sandbox",
-      "extensions"
+      "extensions",
     );
     await mkdir(extensionSandboxDir, { recursive: true });
 
@@ -24,7 +24,7 @@ async function main() {
       "--extensions-dir",
       extensionSandboxDir,
       ...[...extensionDependencies, ...extraExtensions].flatMap(
-        (dependency) => ["--install-extension", dependency]
+        (dependency) => ["--install-extension", dependency],
       ),
     ];
 

--- a/src/test/mockPrePhraseGetVersion.ts
+++ b/src/test/mockPrePhraseGetVersion.ts
@@ -3,7 +3,7 @@ import { Graph } from "../typings/Types";
 
 export function mockPrePhraseGetVersion(
   graph: Graph,
-  getVersion: () => Promise<string>
+  getVersion: () => Promise<string>,
 ) {
   sinon.replaceGetter(graph, "commandServerApi", () => ({
     signals: {

--- a/src/test/openNewEditor.ts
+++ b/src/test/openNewEditor.ts
@@ -3,7 +3,7 @@ import { getParseTreeApi } from "../util/getExtensionApi";
 
 export async function openNewEditor(
   content: string,
-  language: string = "plaintext"
+  language: string = "plaintext",
 ) {
   await vscode.commands.executeCommand("workbench.action.closeAllEditors");
 
@@ -29,7 +29,7 @@ export async function openNewEditor(
 export async function reuseEditor(
   editor: vscode.TextEditor,
   content: string,
-  language: string = "plaintext"
+  language: string = "plaintext",
 ) {
   if (editor.document.languageId !== language) {
     await vscode.languages.setTextDocumentLanguage(editor.document, language);
@@ -40,9 +40,9 @@ export async function reuseEditor(
     editBuilder.replace(
       new vscode.Range(
         editor.document.lineAt(0).range.start,
-        editor.document.lineAt(editor.document.lineCount - 1).range.end
+        editor.document.lineAt(editor.document.lineCount - 1).range.end,
       ),
-      content
+      content,
     );
 
     const eol = content.includes("\r\n")
@@ -63,7 +63,7 @@ export async function reuseEditor(
  */
 export async function openNewNotebookEditor(
   cellContents: string[],
-  language: string = "plaintext"
+  language: string = "plaintext",
 ) {
   await vscode.commands.executeCommand("workbench.action.closeAllEditors");
 
@@ -75,10 +75,10 @@ export async function openNewNotebookEditor(
           new vscode.NotebookCellData(
             vscode.NotebookCellKind.Code,
             contents,
-            language
-          )
-      )
-    )
+            language,
+          ),
+      ),
+    ),
   );
 
   await (await getParseTreeApi()).loadLanguage(language);

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -40,7 +40,7 @@ async function main() {
       {
         encoding: "utf-8",
         stdio: "inherit",
-      }
+      },
     );
 
     // Run the integration test

--- a/src/test/suite/backwardCompatibility.test.ts
+++ b/src/test/suite/backwardCompatibility.test.ts
@@ -25,7 +25,7 @@ async function runTest() {
     "wrapWithPairedDelimiter",
     [{ type: "primitive", selectionType: "line", mark: { type: "cursor" } }],
     "(",
-    ")"
+    ")",
   );
 
   assert.deepStrictEqual(editor.document.getText(), "()");

--- a/src/test/suite/breakpoints.test.ts
+++ b/src/test/suite/breakpoints.test.ts
@@ -39,7 +39,7 @@ async function breakpointHarpAdd() {
           character: "h",
         },
       },
-    ]
+    ],
   );
 
   const breakpoints = vscode.debug.breakpoints;
@@ -68,7 +68,7 @@ async function breakpointTokenHarpAdd() {
           character: "h",
         },
       },
-    ]
+    ],
   );
 
   const breakpoints = vscode.debug.breakpoints;
@@ -85,7 +85,7 @@ async function breakpointHarpRemove() {
 
   vscode.debug.addBreakpoints([
     new vscode.SourceBreakpoint(
-      new vscode.Location(editor.document.uri, new vscode.Range(0, 0, 0, 0))
+      new vscode.Location(editor.document.uri, new vscode.Range(0, 0, 0, 0)),
     ),
   ]);
 
@@ -104,7 +104,7 @@ async function breakpointHarpRemove() {
           character: "h",
         },
       },
-    ]
+    ],
   );
 
   assert.deepStrictEqual(vscode.debug.breakpoints.length, 0);
@@ -117,10 +117,10 @@ async function breakpointTokenHarpRemove() {
 
   vscode.debug.addBreakpoints([
     new vscode.SourceBreakpoint(
-      new vscode.Location(editor.document.uri, new vscode.Range(0, 0, 0, 0))
+      new vscode.Location(editor.document.uri, new vscode.Range(0, 0, 0, 0)),
     ),
     new vscode.SourceBreakpoint(
-      new vscode.Location(editor.document.uri, new vscode.Range(0, 2, 0, 7))
+      new vscode.Location(editor.document.uri, new vscode.Range(0, 2, 0, 7)),
     ),
   ]);
 
@@ -140,7 +140,7 @@ async function breakpointTokenHarpRemove() {
           character: "h",
         },
       },
-    ]
+    ],
   );
 
   const breakpoints = vscode.debug.breakpoints;

--- a/src/test/suite/crossCellsSetSelection.test.ts
+++ b/src/test/suite/crossCellsSetSelection.test.ts
@@ -35,7 +35,7 @@ async function runTest() {
           character: "w",
         },
       },
-    ]
+    ],
   );
 
   const editor = vscode.window.activeTextEditor;

--- a/src/test/suite/editNewCell.test.ts
+++ b/src/test/suite/editNewCell.test.ts
@@ -20,7 +20,7 @@ async function runTest(
   spokenForm: string,
   command: string,
   expectedActiveCellIndex: number,
-  expectedNotebookContents: string[]
+  expectedNotebookContents: string[],
 ) {
   const graph = (await getCursorlessApi()).graph!;
   const notebook = await openNewNotebookEditor(["hello"]);
@@ -45,20 +45,20 @@ async function runTest(
           type: "cursor",
         },
       },
-    ]
+    ],
   );
 
   assert.equal(notebook.cellCount, 2);
 
   const activeCelIndex = getCellIndex(
     notebook,
-    vscode.window.activeTextEditor!.document
+    vscode.window.activeTextEditor!.document,
   );
 
   assert.equal(activeCelIndex, expectedActiveCellIndex);
 
   assert.deepStrictEqual(
     getPlainNotebookContents(notebook),
-    expectedNotebookContents
+    expectedNotebookContents,
   );
 }

--- a/src/test/suite/fakes/ide/FakeConfiguration.ts
+++ b/src/test/suite/fakes/ide/FakeConfiguration.ts
@@ -15,7 +15,7 @@ export default class FakeConfiguration implements Configuration {
   }
 
   getOwnConfiguration<T extends CursorlessConfigKey>(
-    key: T
+    key: T,
   ): CursorlessConfiguration[T] | undefined {
     return this.mocks[key];
   }
@@ -24,7 +24,7 @@ export default class FakeConfiguration implements Configuration {
 
   mockConfiguration<T extends CursorlessConfigKey>(
     key: T,
-    value: CursorlessConfiguration[T]
+    value: CursorlessConfiguration[T],
   ): void {
     this.mocks[key] = value;
     this.notifier.notifyListeners();

--- a/src/test/suite/fold.test.ts
+++ b/src/test/suite/fold.test.ts
@@ -24,7 +24,7 @@ async function foldMade() {
           type: "cursor",
         },
       },
-    ]
+    ],
   );
 
   assert.equal(editor.visibleRanges.length, 2);
@@ -53,7 +53,7 @@ async function unfoldMade() {
           type: "cursor",
         },
       },
-    ]
+    ],
   );
 
   assert.equal(editor.visibleRanges.length, 1);

--- a/src/test/suite/followLink.test.ts
+++ b/src/test/suite/followLink.test.ts
@@ -15,7 +15,7 @@ suite("followLink", async function () {
 async function followDefinition() {
   const editor = await openNewEditor(
     "const foo = 'hello';\nconst bar = foo;",
-    "typescript"
+    "typescript",
   );
   await vscode.commands.executeCommand("revealLine", {
     lineNumber: 1,
@@ -36,7 +36,7 @@ async function followDefinition() {
           type: "cursor",
         },
       },
-    ]
+    ],
   );
 
   assert.equal(editor.visibleRanges[0].start.line, 0);
@@ -59,7 +59,7 @@ async function followLink() {
           type: "cursor",
         },
       },
-    ]
+    ],
   );
 
   const editor = vscode.window.activeTextEditor;

--- a/src/test/suite/groupByDocument.test.ts
+++ b/src/test/suite/groupByDocument.test.ts
@@ -23,7 +23,7 @@ async function runTest() {
   const editor1 = await vscode.window.showTextDocument(document);
   const editor2 = await vscode.window.showTextDocument(
     document,
-    vscode.ViewColumn.Beside
+    vscode.ViewColumn.Beside,
   );
 
   await graph.hatTokenMap.addDecorations();
@@ -37,10 +37,10 @@ async function runTest() {
     .find(([, token]) => token.editor === editor2 && token.text === "world");
 
   const { hatStyle: hatStyle1, character: char1 } = HatTokenMap.splitKey(
-    hat1![0]
+    hat1![0],
   );
   const { hatStyle: hatStyle2, character: char2 } = HatTokenMap.splitKey(
-    hat2![0]
+    hat2![0],
   );
 
   await vscode.commands.executeCommand(
@@ -64,7 +64,7 @@ async function runTest() {
           character: char2,
         },
       },
-    ]
+    ],
   );
 
   assert.deepStrictEqual(document.getText(), "world hello");

--- a/src/test/suite/intraCellSetSelection.test.ts
+++ b/src/test/suite/intraCellSetSelection.test.ts
@@ -35,7 +35,7 @@ async function runTest() {
           character: "w",
         },
       },
-    ]
+    ],
   );
 
   const editor = vscode.window.activeTextEditor;

--- a/src/test/suite/prePhraseSnapshot.test.ts
+++ b/src/test/suite/prePhraseSnapshot.test.ts
@@ -33,7 +33,7 @@ suite("Pre-phrase snapshots", async function () {
 async function runTest(
   usePrePhraseSnapshot: boolean,
   multiplePhrases: boolean,
-  expectedSelections: vscode.Selection[]
+  expectedSelections: vscode.Selection[],
 ) {
   const graph = (await getCursorlessApi()).graph!;
 
@@ -87,6 +87,6 @@ async function runTest(
 
   assert.deepStrictEqual(
     editor.selections.map(selectionToPlainObject),
-    expectedSelections.map(selectionToPlainObject)
+    expectedSelections.map(selectionToPlainObject),
   );
 }

--- a/src/test/suite/recorded.test.ts
+++ b/src/test/suite/recorded.test.ts
@@ -51,8 +51,8 @@ suite("recorded test cases", async function () {
   getRecordedTestPaths().forEach((path) =>
     test(
       path.split(".")[0],
-      asyncSafety(() => runTest(path))
-    )
+      asyncSafety(() => runTest(path)),
+    ),
   );
 });
 
@@ -71,7 +71,7 @@ async function runTest(file: string) {
 
   const editor = await openNewEditor(
     fixture.initialState.documentContents,
-    fixture.languageId
+    fixture.languageId,
   );
 
   if (fixture.postEditorOpenSleepTimeMs != null) {
@@ -82,14 +82,14 @@ async function runTest(file: string) {
 
   if (fixture.initialState.thatMark) {
     const initialThatTargets = fixture.initialState.thatMark.map((mark) =>
-      plainObjectToTarget(editor, mark)
+      plainObjectToTarget(editor, mark),
     );
     cursorlessApi.thatMark.set(initialThatTargets);
   }
 
   if (fixture.initialState.sourceMark) {
     const initialSourceTargets = fixture.initialState.sourceMark.map((mark) =>
-      plainObjectToTarget(editor, mark)
+      plainObjectToTarget(editor, mark),
     );
     cursorlessApi.sourceMark.set(initialSourceTargets);
   }
@@ -107,7 +107,7 @@ async function runTest(file: string) {
   await graph.hatTokenMap.addDecorations();
 
   const readableHatMap = await graph.hatTokenMap.getReadableMap(
-    usePrePhraseSnapshot
+    usePrePhraseSnapshot,
   );
 
   // Assert that recorded decorations are present
@@ -157,8 +157,8 @@ async function runTest(file: string) {
       : marksToPlainObject(
           extractTargetedMarks(
             Object.keys(fixture.finalState.marks) as string[],
-            readableHatMap
-          )
+            readableHatMap,
+          ),
         );
 
   if (fixture.finalState?.clipboard == null) {
@@ -180,7 +180,7 @@ async function runTest(file: string) {
     cursorlessApi.sourceMark,
     excludeFields,
     [],
-    marks
+    marks,
   );
 
   const actualDecorations =
@@ -204,39 +204,39 @@ async function runTest(file: string) {
   } else {
     if (fixture.thrownError != null) {
       throw Error(
-        `Expected error ${fixture.thrownError.name} but none was thrown`
+        `Expected error ${fixture.thrownError.name} but none was thrown`,
       );
     }
 
     assert.deepStrictEqual(
       resultState,
       fixture.finalState,
-      "Unexpected final state"
+      "Unexpected final state",
     );
 
     assert.deepStrictEqual(
       actualDecorations,
       fixture.decorations,
-      "Unexpected decorations"
+      "Unexpected decorations",
     );
 
     assert.deepStrictEqual(
       returnValue,
       fixture.returnValue,
-      "Unexpected return value"
+      "Unexpected return value",
     );
 
     assert.deepStrictEqual(
       actualSpyIdeValues,
       fixture.ide,
-      "Unexpected ide captured values"
+      "Unexpected ide captured values",
     );
   }
 }
 
 function checkMarks(
   marks: SerializedMarks | undefined,
-  hatTokenMap: ReadOnlyHatMap
+  hatTokenMap: ReadOnlyHatMap,
 ) {
   if (marks == null) {
     return;

--- a/src/test/suite/scroll.test.ts
+++ b/src/test/suite/scroll.test.ts
@@ -25,7 +25,7 @@ async function topWhale() {
           type: "cursor",
         },
       },
-    ]
+    ],
   );
 
   assert.equal(editor.visibleRanges.length, 1);
@@ -53,7 +53,7 @@ async function bottomWhale() {
           type: "cursor",
         },
       },
-    ]
+    ],
   );
 
   assert.equal(editor.visibleRanges.length, 1);

--- a/src/test/suite/subtoken.test.ts
+++ b/src/test/suite/subtoken.test.ts
@@ -8,7 +8,7 @@ suite("subtoken regex matcher", () => {
     test(input, () => {
       assert.deepStrictEqual(
         wordTokenizer.splitIdentifier(input).map(({ text }) => text),
-        expectedOutput
+        expectedOutput,
       );
     });
   });

--- a/src/test/suite/tokenGraphemeSplitter.test.ts
+++ b/src/test/suite/tokenGraphemeSplitter.test.ts
@@ -292,7 +292,7 @@ const ide = graph.ide as FakeIDE;
 
 ide.configuration.mockConfiguration(
   "tokenHatSplittingMode",
-  tokenHatSplittingDefaults
+  tokenHatSplittingDefaults,
 );
 
 const tokenGraphemeSplitter = graph.tokenGraphemeSplitter;
@@ -312,7 +312,7 @@ tests.forEach(({ tokenHatSplittingMode, extraTestCases }) => {
           text,
           tokenStartOffset,
           tokenEndOffset,
-        })
+        }),
       );
 
       const actualOutput = tokenGraphemeSplitter.getTokenGraphemes(input);

--- a/src/test/suite/tokenizer.test.ts
+++ b/src/test/suite/tokenizer.test.ts
@@ -127,7 +127,7 @@ suite("tokenizer", () => {
       const tests = [
         ...languageSpecificTests,
         ...globalTests.filter(
-          ([input, _expectedOutput]) => !exclusionPredicate(input)
+          ([input, _expectedOutput]) => !exclusionPredicate(input),
         ),
       ];
 
@@ -137,7 +137,7 @@ suite("tokenizer", () => {
           assert.deepStrictEqual(output, expectedOutput);
         });
       });
-    }
+    },
   );
 });
 
@@ -154,8 +154,8 @@ function getAsciiSymbols() {
   return flatten(
     rangesToTest.map(([start, end]) =>
       range(start.charCodeAt(0), end.charCodeAt(0) + 1).map((charCode) =>
-        String.fromCharCode(charCode)
-      )
-    )
+        String.fromCharCode(charCode),
+      ),
+    ),
   );
 }

--- a/src/test/util/getFixturePaths.ts
+++ b/src/test/util/getFixturePaths.ts
@@ -13,6 +13,6 @@ export function getRecordedTestPaths() {
   const directory = path.join(getFixturesPath(), "recorded");
 
   return walkFilesSync(directory).filter(
-    (path) => path.endsWith(".yml") || path.endsWith(".yaml")
+    (path) => path.endsWith(".yml") || path.endsWith(".yaml"),
   );
 }

--- a/src/testUtil/TestCase.ts
+++ b/src/testUtil/TestCase.ts
@@ -101,7 +101,7 @@ export class TestCase {
     private isDecorationsTest: boolean = false,
     private startTimestamp: bigint,
     private captureFinalThatMark: boolean,
-    private extraSnapshotFields?: ExtraSnapshotField[]
+    private extraSnapshotFields?: ExtraSnapshotField[],
   ) {
     const activeEditor = vscode.window.activeTextEditor!;
     this.command = cleanUpTestCaseCommand(command);
@@ -144,11 +144,11 @@ export class TestCase {
       return true;
     } else if (target.type === "list") {
       return target.elements.some((target) =>
-        this.includesThatMark(target, type)
+        this.includesThatMark(target, type),
       );
     } else if (target.type === "range") {
       return [target.anchor, target.active].some((target) =>
-        this.includesThatMark(target, type)
+        this.includesThatMark(target, type),
       );
     }
     return false;
@@ -173,19 +173,19 @@ export class TestCase {
         (!isInitialSnapshot && !this.captureFinalThatMark) ||
         (isInitialSnapshot &&
           !this.fullTargets.some((target) =>
-            this.includesThatMark(target, "that")
+            this.includesThatMark(target, "that"),
           )),
       sourceMark:
         (!isInitialSnapshot && !this.captureFinalThatMark) ||
         (isInitialSnapshot &&
           !this.fullTargets.some((target) =>
-            this.includesThatMark(target, "source")
+            this.includesThatMark(target, "source"),
           )),
       visibleRanges: !visibleRangeActions.includes(this.command.action.name),
     };
 
     return Object.keys(excludableFields).filter(
-      (field) => excludableFields[field]
+      (field) => excludableFields[field],
     );
   }
 
@@ -219,7 +219,7 @@ export class TestCase {
       excludeFields,
       this.extraSnapshotFields,
       this.getMarks(),
-      { startTimestamp: this.startTimestamp }
+      { startTimestamp: this.startTimestamp },
     );
   }
 
@@ -232,7 +232,7 @@ export class TestCase {
       excludeFields,
       this.extraSnapshotFields,
       this.isHatTokenMapTest ? this.getMarks() : undefined,
-      { startTimestamp: this.startTimestamp }
+      { startTimestamp: this.startTimestamp },
     );
     this.recordDecorations();
     this.recordSpyIdeValues();
@@ -248,12 +248,12 @@ export class TestCase {
 
     this.initialState!.marks = pick(
       this.initialState!.marks,
-      keys
+      keys,
     ) as SerializedMarks;
 
     this.finalState!.marks = pick(
       this.finalState!.marks,
-      keys
+      keys,
     ) as SerializedMarks;
 
     this.marksToCheck = marksToCheck;

--- a/src/testUtil/TestCaseRecorder.ts
+++ b/src/testUtil/TestCaseRecorder.ts
@@ -112,13 +112,13 @@ export class TestCaseRecorder {
         async (arg?: RecordTestCaseCommandArg) => {
           if (this.active) {
             vscode.window.showInformationMessage(
-              "Stopped recording test cases"
+              "Stopped recording test cases",
             );
             this.stop();
           } else {
             return await this.start(arg);
           }
-        }
+        },
       ),
 
       vscode.commands.registerCommand("cursorless.pauseRecording", async () => {
@@ -137,7 +137,7 @@ export class TestCaseRecorder {
           }
 
           this.paused = false;
-        }
+        },
       ),
 
       vscode.commands.registerCommand(
@@ -146,18 +146,18 @@ export class TestCaseRecorder {
           outPath: string,
           metadata: unknown,
           targetedMarks: DecoratedSymbolMark[],
-          usePrePhraseSnapshot: boolean
+          usePrePhraseSnapshot: boolean,
         ) => {
           let marks: SerializedMarks | undefined;
           if (targetedMarks.length !== 0) {
             const keys = targetedMarks.map(({ character, symbolColor }) =>
-              HatTokenMap.getKey(symbolColor, character)
+              HatTokenMap.getKey(symbolColor, character),
             );
             const readableHatMap = await this.graph.hatTokenMap.getReadableMap(
-              usePrePhraseSnapshot
+              usePrePhraseSnapshot,
             );
             marks = marksToPlainObject(
-              extractTargetedMarks(keys, readableHatMap)
+              extractTargetedMarks(keys, readableHatMap),
             );
           } else {
             marks = undefined;
@@ -170,12 +170,12 @@ export class TestCaseRecorder {
             this.active ? this.extraSnapshotFields : undefined,
             marks,
             this.active ? { startTimestamp: this.startTimestamp } : undefined,
-            metadata
+            metadata,
           );
 
           await this.writeToFile(outPath, serialize(snapshot));
-        }
-      )
+        },
+      ),
     );
   }
 
@@ -220,10 +220,10 @@ export class TestCaseRecorder {
       {},
       ...(await Promise.all(
         parentDirectories.map((parent) =>
-          readJsonIfExists(path.join(parent, "config.json"))
-        )
+          readJsonIfExists(path.join(parent, "config.json")),
+        ),
       )),
-      explicitConfig
+      explicitConfig,
     );
 
     const {
@@ -239,7 +239,7 @@ export class TestCaseRecorder {
     this.active = true;
 
     const startTimestampISO = await this.recordStartTime(
-      showCalibrationDisplay
+      showCalibrationDisplay,
     );
     this.isHatTokenMapTest = isHatTokenMapTest;
     this.captureFinalThatMark = captureFinalThatMark;
@@ -250,7 +250,7 @@ export class TestCaseRecorder {
     this.paused = false;
 
     vscode.window.showInformationMessage(
-      `Recording test cases for following commands in:\n${this.targetDirectory}`
+      `Recording test cases for following commands in:\n${this.targetDirectory}`,
     );
 
     return { startTimestampISO };
@@ -293,7 +293,7 @@ export class TestCaseRecorder {
       // cared about from the last command
       invariant(
         this.testCase.awaitingFinalMarkInfo,
-        () => "expected to be awaiting final mark info"
+        () => "expected to be awaiting final mark info",
       );
       this.testCase.filterMarks(command, context);
       await this.finishTestCase();
@@ -309,7 +309,7 @@ export class TestCaseRecorder {
         this.isDecorationsTest,
         this.startTimestamp!,
         this.captureFinalThatMark,
-        this.extraSnapshotFields
+        this.extraSnapshotFields,
       );
 
       await this.testCase.recordInitialState();
@@ -365,7 +365,7 @@ export class TestCaseRecorder {
       !["cursorless-vscode", "cursorless"].includes(this.workspaceName)
     ) {
       throw new Error(
-        '"Cursorless record" must be run from within cursorless directory'
+        '"Cursorless record" must be run from within cursorless directory',
       );
     }
 
@@ -459,7 +459,7 @@ function capitalize(str: string) {
 }
 
 async function readJsonIfExists(
-  path: string
+  path: string,
 ): Promise<RecordTestCaseCommandArg> {
   let rawText: string;
 

--- a/src/testUtil/cleanUpTestCaseCommand.ts
+++ b/src/testUtil/cleanUpTestCaseCommand.ts
@@ -1,7 +1,7 @@
 import { TestCaseCommand } from "./TestCase";
 
 export function cleanUpTestCaseCommand(
-  command: TestCaseCommand
+  command: TestCaseCommand,
 ): TestCaseCommand {
   const { action, ...rest } = command;
   const { args } = action;

--- a/src/testUtil/extractTargetedMarks.ts
+++ b/src/testUtil/extractTargetedMarks.ts
@@ -35,7 +35,7 @@ export function extractTargetKeys(target: TargetDescriptor): string[] {
 
 export function extractTargetedMarks(
   targetKeys: string[],
-  hatTokenMap: ReadOnlyHatMap
+  hatTokenMap: ReadOnlyHatMap,
 ) {
   const targetedMarks: { [decoratedCharacter: string]: Token } = {};
 

--- a/src/testUtil/fromPlainObject.ts
+++ b/src/testUtil/fromPlainObject.ts
@@ -23,7 +23,7 @@ import {
  */
 export function plainObjectToTarget(
   editor: TextEditor,
-  plainObject: TargetPlainObject
+  plainObject: TargetPlainObject,
 ): Target {
   switch (plainObject.type) {
     case "UntypedTarget":
@@ -55,6 +55,6 @@ export function plainObjectToSelection({
 }: SelectionPlainObject): Selection {
   return new Selection(
     plainObjectToPosition(anchor),
-    plainObjectToPosition(active)
+    plainObjectToPosition(active),
   );
 }

--- a/src/testUtil/serialize.ts
+++ b/src/testUtil/serialize.ts
@@ -7,13 +7,13 @@ import * as yaml from "js-yaml";
 class CustomDump {
   constructor(
     private readonly data: unknown,
-    private readonly opts: yaml.DumpOptions
+    private readonly opts: yaml.DumpOptions,
   ) {}
 
   represent() {
     let result = yaml.dump(
       this.data,
-      Object.assign({ replacer, schema }, this.opts)
+      Object.assign({ replacer, schema }, this.opts),
     );
     result = result.trim();
     if (result.includes("\n")) {
@@ -38,7 +38,7 @@ const isObject = (value: unknown): value is object =>
 function hasSimpleChildren(value: unknown) {
   if (isObject(value)) {
     return Object.values(value).every(
-      (value) => !isObject(value) && !Array.isArray(value)
+      (value) => !isObject(value) && !Array.isArray(value),
     );
   }
   if (Array.isArray(value)) {

--- a/src/testUtil/takeSnapshot.ts
+++ b/src/testUtil/takeSnapshot.ts
@@ -44,7 +44,7 @@ export async function takeSnapshot(
   extraFields: ExtraSnapshotField[] = [],
   marks?: SerializedMarks,
   extraContext?: ExtraContext,
-  metadata?: unknown
+  metadata?: unknown,
 ) {
   const activeEditor = vscode.window.activeTextEditor!;
 
@@ -90,7 +90,7 @@ export async function takeSnapshot(
 
     if (startTimestamp == null) {
       throw new Error(
-        "No start timestamp provided but time offset was requested"
+        "No start timestamp provided but time offset was requested",
       );
     }
 

--- a/src/testUtil/toPlainObject.ts
+++ b/src/testUtil/toPlainObject.ts
@@ -61,7 +61,7 @@ export function rangeToPlainObject(range: Range): RangePlainObject {
 }
 
 export function selectionToPlainObject(
-  selection: Selection
+  selection: Selection,
 ): SelectionPlainObject {
   return {
     anchor: positionToPlainObject(selection.anchor),
@@ -101,7 +101,7 @@ export function marksToPlainObject(marks: {
   const serializedMarks: SerializedMarks = {};
   Object.entries(marks).forEach(
     ([key, value]: [string, Token]) =>
-      (serializedMarks[key] = rangeToPlainObject(value.range))
+      (serializedMarks[key] = rangeToPlainObject(value.range)),
   );
   return serializedMarks;
 }

--- a/src/testUtil/walkAsync.ts
+++ b/src/testUtil/walkAsync.ts
@@ -17,7 +17,7 @@ export const walkFiles = async (dir: string): Promise<string[]> => {
       dirEntries.map(async (dirent) => {
         const filePath = path.join(dir, dirent.name);
         return dirent.isDirectory() ? await walkFiles(filePath) : [filePath];
-      })
-    )
+      }),
+    ),
   );
 };

--- a/src/typings/Types.ts
+++ b/src/typings/Types.ts
@@ -186,7 +186,7 @@ export type NodeMatcherAlternative = NodeMatcher | string[] | string;
 
 export type NodeMatcher = (
   selection: SelectionWithEditor,
-  node: SyntaxNode
+  node: SyntaxNode,
 ) => NodeMatcherValue[] | null;
 
 /**
@@ -195,13 +195,13 @@ export type NodeMatcher = (
  **/
 export type NodeFinder = (
   node: SyntaxNode,
-  selection?: vscode.Selection
+  selection?: vscode.Selection,
 ) => SyntaxNode | null;
 
 /** Returns one or more selections for a given SyntaxNode */
 export type SelectionExtractor = (
   editor: vscode.TextEditor,
-  nodes: SyntaxNode
+  nodes: SyntaxNode,
 ) => SelectionWithContext;
 
 /** Represent a single edit/change in the document */

--- a/src/typings/target.types.ts
+++ b/src/typings/target.types.ts
@@ -130,7 +130,7 @@ export interface Target {
     isReversed: boolean,
     endTarget: Target,
     includeStart: boolean,
-    includeEnd: boolean
+    includeEnd: boolean,
   ): Target;
   /** Constructs change/insertion edit. Adds delimiter before/after if needed */
   constructChangeEdit(text: string): EditWithRangeUpdater;

--- a/src/typings/treeSitter.ts
+++ b/src/typings/treeSitter.ts
@@ -7,7 +7,7 @@ declare module "web-tree-sitter" {
     parse(
       input: string | Parser.Input,
       previousTree?: Parser.Tree,
-      options?: Parser.Options
+      options?: Parser.Options,
     ): Parser.Tree;
     getLanguage(): any;
     setLanguage(language: any): void;
@@ -45,13 +45,13 @@ declare module "web-tree-sitter" {
     export type Logger = (
       message: string,
       params: { [param: string]: string },
-      type: "parse" | "lex"
+      type: "parse" | "lex",
     ) => void;
 
     export type Input = (
       startIndex: number,
       startPoint?: Point,
-      endIndex?: number
+      endIndex?: number,
     ) => string | null;
 
     export interface SyntaxNode {
@@ -93,19 +93,19 @@ declare module "web-tree-sitter" {
       descendantsOfType(
         type: string | Array<string>,
         startPosition?: Point,
-        endPosition?: Point
+        endPosition?: Point,
       ): Array<SyntaxNode>;
       namedDescendantForIndex(index: number): SyntaxNode;
       namedDescendantForIndex(startIndex: number, endIndex: number): SyntaxNode;
       descendantForPosition(position: Point): SyntaxNode;
       descendantForPosition(
         startPosition: Point,
-        endPosition: Point
+        endPosition: Point,
       ): SyntaxNode;
       namedDescendantForPosition(position: Point): SyntaxNode;
       namedDescendantForPosition(
         startPosition: Point,
-        endPosition: Point
+        endPosition: Point,
       ): SyntaxNode;
 
       walk(): TreeCursor;
@@ -181,12 +181,12 @@ declare module "web-tree-sitter" {
       matches(
         node: SyntaxNode,
         startPosition?: Point,
-        endPosition?: Point
+        endPosition?: Point,
       ): QueryMatch[];
       captures(
         node: SyntaxNode,
         startPosition?: Point,
-        endPosition?: Point
+        endPosition?: Point,
       ): QueryCapture[];
       predicatesForPattern(patternIndex: number): PredicateResult[];
     }

--- a/src/util/addDecorationsToEditor.ts
+++ b/src/util/addDecorationsToEditor.ts
@@ -13,7 +13,7 @@ import { getTokensInRange } from "./getTokensInRange";
 export function addDecorationsToEditors(
   hatTokenMap: IndividualHatMap,
   decorations: Decorations,
-  tokenGraphemeSplitter: TokenGraphemeSplitter
+  tokenGraphemeSplitter: TokenGraphemeSplitter,
 ) {
   hatTokenMap.clear();
 
@@ -25,7 +25,7 @@ export function addDecorationsToEditors(
     editors = [
       vscode.window.activeTextEditor,
       ...vscode.window.visibleTextEditors.filter(
-        (editor) => editor !== vscode.window.activeTextEditor
+        (editor) => editor !== vscode.window.activeTextEditor,
       ),
     ];
   }
@@ -51,19 +51,19 @@ export function addDecorationsToEditors(
                 regex: getMatcher(languageId).tokenMatcher,
               },
             },
-          }))
-        )
+          })),
+        ),
       );
 
       tokens.sort(
         getTokenComparator(
           displayLineMap.get(editor.selection.active.line)!,
-          editor.selection.active.character
-        )
+          editor.selection.active.character,
+        ),
       );
 
       return tokens;
-    })
+    }),
   );
 
   /**
@@ -102,9 +102,9 @@ export function addDecorationsToEditors(
     editors.map((editor) => [
       editor,
       Object.fromEntries(
-        decorations.decorations.map((decoration) => [decoration.name, []])
+        decorations.decorations.map((decoration) => [decoration.name, []]),
       ),
-    ])
+    ]),
   );
 
   // Picks the character with minimum color such that the next token that contains
@@ -129,7 +129,7 @@ export function addDecorationsToEditors(
       }));
 
     const minDecorationIndex = min(
-      tokenGraphemes.map(({ decorationIndex }) => decorationIndex)
+      tokenGraphemes.map(({ decorationIndex }) => decorationIndex),
     )!;
 
     if (minDecorationIndex >= decorations.decorations.length) {
@@ -138,14 +138,14 @@ export function addDecorationsToEditors(
 
     const bestGrapheme = maxBy(
       tokenGraphemes.filter(
-        ({ decorationIndex }) => decorationIndex === minDecorationIndex
+        ({ decorationIndex }) => decorationIndex === minDecorationIndex,
       ),
       ({ text }) =>
         min(
           graphemeTokenIndices[text].filter(
-            (laterTokenIdx) => laterTokenIdx > tokenIdx
-          )
-        ) ?? Infinity
+            (laterTokenIdx) => laterTokenIdx > tokenIdx,
+          ),
+        ) ?? Infinity,
     )!;
 
     const currentDecorationIndex = bestGrapheme.decorationIndex;
@@ -157,8 +157,8 @@ export function addDecorationsToEditors(
       [hatStyleName]!.push(
         new vscode.Range(
           token.range.start.translate(undefined, bestGrapheme.tokenStartOffset),
-          token.range.start.translate(undefined, bestGrapheme.tokenEndOffset)
-        )
+          token.range.start.translate(undefined, bestGrapheme.tokenEndOffset),
+        ),
       );
 
     hatTokenMap.addToken(hatStyleName, bestGrapheme.text, token);
@@ -170,7 +170,7 @@ export function addDecorationsToEditors(
     decorations.hatStyleNames.forEach((hatStyleName) => {
       editor.setDecorations(
         decorations.decorationMap[hatStyleName]!,
-        ranges[hatStyleName]!
+        ranges[hatStyleName]!,
       );
     });
   });

--- a/src/util/getDisplayLineMap.ts
+++ b/src/util/getDisplayLineMap.ts
@@ -13,16 +13,16 @@ export function getDisplayLineMap(editor: vscode.TextEditor) {
   return new Map(
     flow(
       flatten,
-      uniq
+      uniq,
     )(
       concat(
         [[editor.selection.start.line]],
         editor.visibleRanges.map((visibleRange) =>
-          range(visibleRange.start.line, visibleRange.end.line + 1)
-        )
-      )
+          range(visibleRange.start.line, visibleRange.end.line + 1),
+        ),
+      ),
     )
       .sort((a, b) => a - b)
-      .map((value, index) => [value, index])
+      .map((value, index) => [value, index]),
   );
 }

--- a/src/util/getLinks.ts
+++ b/src/util/getLinks.ts
@@ -3,11 +3,11 @@ import { Target } from "../typings/target.types";
 
 export async function getLinksForSelections(
   editor: vscode.TextEditor,
-  selections: vscode.Selection[]
+  selections: vscode.Selection[],
 ) {
   const links = await getLinksForEditor(editor);
   return links.filter((link) =>
-    selections.find((selection) => link.range.contains(selection))
+    selections.find((selection) => link.range.contains(selection)),
   );
 }
 
@@ -19,6 +19,6 @@ export async function getLinkForTarget(target: Target) {
 function getLinksForEditor(editor: vscode.TextEditor) {
   return vscode.commands.executeCommand(
     "vscode.executeLinkProvider",
-    editor.document.uri
+    editor.document.uri,
   ) as Thenable<vscode.DocumentLink[]>;
 }

--- a/src/util/getPrimitiveTargets.ts
+++ b/src/util/getPrimitiveTargets.ts
@@ -18,7 +18,7 @@ export function getPartialPrimitiveTargets(targets: PartialTargetDescriptor[]) {
 }
 
 function getPartialPrimitiveTargetsHelper(
-  target: PartialTargetDescriptor
+  target: PartialTargetDescriptor,
 ): PartialPrimitiveTargetDescriptor[] {
   switch (target.type) {
     case "primitive":
@@ -41,7 +41,7 @@ export function getPrimitiveTargets(targets: TargetDescriptor[]) {
 }
 
 function getPrimitiveTargetsHelper(
-  target: TargetDescriptor
+  target: TargetDescriptor,
 ): PrimitiveTargetDescriptor[] {
   switch (target.type) {
     case "primitive":
@@ -63,19 +63,19 @@ function getPrimitiveTargetsHelper(
 export function transformPartialPrimitiveTargets(
   targets: PartialTargetDescriptor[],
   func: (
-    target: PartialPrimitiveTargetDescriptor
-  ) => PartialPrimitiveTargetDescriptor
+    target: PartialPrimitiveTargetDescriptor,
+  ) => PartialPrimitiveTargetDescriptor,
 ) {
   return targets.map((target) =>
-    transformPartialPrimitiveTargetsHelper(target, func)
+    transformPartialPrimitiveTargetsHelper(target, func),
   );
 }
 
 function transformPartialPrimitiveTargetsHelper(
   target: PartialTargetDescriptor,
   func: (
-    target: PartialPrimitiveTargetDescriptor
-  ) => PartialPrimitiveTargetDescriptor
+    target: PartialPrimitiveTargetDescriptor,
+  ) => PartialPrimitiveTargetDescriptor,
 ): PartialTargetDescriptor {
   switch (target.type) {
     case "primitive":
@@ -87,7 +87,7 @@ function transformPartialPrimitiveTargetsHelper(
           (element) =>
             transformPartialPrimitiveTargetsHelper(element, func) as
               | PartialPrimitiveTargetDescriptor
-              | PartialRangeTargetDescriptor
+              | PartialRangeTargetDescriptor,
         ),
       };
     case "range":

--- a/src/util/getTokenComparator.ts
+++ b/src/util/getTokenComparator.ts
@@ -8,7 +8,7 @@ import { Token } from "../typings/Types";
  */
 export function getTokenComparator(
   selectionDisplayLine: number,
-  selectionCharacterIndex: number
+  selectionCharacterIndex: number,
 ): (a: Token, b: Token) => number {
   return (token1, token2) => {
     const token1LineDiff = Math.abs(token1.displayLine - selectionDisplayLine);
@@ -23,11 +23,11 @@ export function getTokenComparator(
     }
 
     const token1CharacterDiff = Math.abs(
-      token1.range.start.character - selectionCharacterIndex
+      token1.range.start.character - selectionCharacterIndex,
     );
 
     const token2CharacterDiff = Math.abs(
-      token2.range.start.character - selectionCharacterIndex
+      token2.range.start.character - selectionCharacterIndex,
     );
 
     return token1CharacterDiff - token2CharacterDiff;

--- a/src/util/getTokensInRange.ts
+++ b/src/util/getTokensInRange.ts
@@ -10,7 +10,7 @@ export interface PartialToken {
 
 export function getTokensInRange(
   editor: vscode.TextEditor,
-  range: vscode.Range
+  range: vscode.Range,
 ): PartialToken[] {
   const languageId = editor.document.languageId;
   const text = editor.document.getText(range);
@@ -21,7 +21,7 @@ export function getTokensInRange(
     const endOffset = rangeOffset + match.index! + match[0].length;
     const range = new vscode.Range(
       editor.document.positionAt(startOffset),
-      editor.document.positionAt(endOffset)
+      editor.document.positionAt(endOffset),
     );
 
     return {

--- a/src/util/graphFactories.ts
+++ b/src/util/graphFactories.ts
@@ -38,7 +38,7 @@ const graphFactories: Partial<FactoryMap<Graph>> = Object.fromEntries(
   Object.entries(graphConstructors).map(([key, constructor]) => [
     key,
     (graph: Graph) => new constructor(graph),
-  ])
+  ]),
 );
 
 export default graphFactories;

--- a/src/util/makeGraph.ts
+++ b/src/util/makeGraph.ts
@@ -10,7 +10,7 @@ function makeGetter<GraphType, K extends keyof GraphType>(
   components: Partial<GraphType>,
   factoryMap: FactoryMap<GraphType>,
   lockedKeys: K[],
-  key: K
+  key: K,
 ): () => GraphType[K] {
   return () => {
     let returnValue: GraphType[K];
@@ -18,7 +18,7 @@ function makeGetter<GraphType, K extends keyof GraphType>(
     if (components[key] == null) {
       if (lockedKeys.includes(key)) {
         const cycle = [...lockedKeys.slice(lockedKeys.indexOf(key)), key].join(
-          " -> "
+          " -> ",
         );
         throw new Error(`Dependency injection graph cycle detected: ${cycle}`);
       }
@@ -39,7 +39,7 @@ function makeGetter<GraphType, K extends keyof GraphType>(
 
 export default function makeGraph<GraphType extends object>(
   factoryMap: FactoryMap<GraphType>,
-  writableKeys: ExtractMutable<GraphType>[] = []
+  writableKeys: ExtractMutable<GraphType>[] = [],
 ) {
   const components: Partial<GraphType> = {};
   const graph: Partial<GraphType> = {};
@@ -55,7 +55,7 @@ export default function makeGraph<GraphType extends object>(
         components,
         factoryMap,
         lockedKeys,
-        key as keyof GraphType
+        key as keyof GraphType,
       ),
 
       set: isMutable

--- a/src/util/nodeFinders.ts
+++ b/src/util/nodeFinders.ts
@@ -3,7 +3,7 @@ import { Point, SyntaxNode } from "web-tree-sitter";
 import { NodeFinder } from "../typings/Types";
 
 export const nodeFinder = (
-  isTargetNode: (node: SyntaxNode) => boolean
+  isTargetNode: (node: SyntaxNode) => boolean,
 ): NodeFinder => {
   return (node: SyntaxNode) => {
     return isTargetNode(node) ? node : null;
@@ -137,7 +137,7 @@ export const argumentNodeFinder = (...parentTypes: string[]): NodeFinder => {
       const children = [...node.children];
       const childRight =
         children.find(({ startPosition }) =>
-          toPosition(startPosition).isAfterOrEqual(end)
+          toPosition(startPosition).isAfterOrEqual(end),
         ) ?? null;
       if (isOk(childRight)) {
         return childRight;
@@ -145,7 +145,7 @@ export const argumentNodeFinder = (...parentTypes: string[]): NodeFinder => {
       children.reverse();
       const childLeft =
         children.find(({ endPosition }) =>
-          toPosition(endPosition).isBeforeOrEqual(start)
+          toPosition(endPosition).isBeforeOrEqual(start),
         ) ?? null;
       if (isOk(childLeft)) {
         return childLeft;
@@ -170,7 +170,7 @@ export const argumentNodeFinder = (...parentTypes: string[]): NodeFinder => {
 export function findPossiblyWrappedNode(
   isWrapperNode: NodeFinder,
   isTargetNode: NodeFinder,
-  getWrappedNodes: (node: SyntaxNode) => (SyntaxNode | null)[]
+  getWrappedNodes: (node: SyntaxNode) => (SyntaxNode | null)[],
 ): NodeFinder {
   return (node: SyntaxNode) => {
     if (node.parent != null && isWrapperNode(node.parent)) {
@@ -182,7 +182,7 @@ export function findPossiblyWrappedNode(
 
     if (isWrapperNode(node)) {
       const isWrappingTargetNode = getWrappedNodes(node).some(
-        (node) => node != null && isTargetNode(node)
+        (node) => node != null && isTargetNode(node),
       );
 
       if (isWrappingTargetNode) {
@@ -209,13 +209,13 @@ export function patternFinder(...patterns: string[]): NodeFinder {
 
 function parsePatternStrings(patternStrings: string[]) {
   return patternStrings.map((patternString) =>
-    patternString.split(".").map((pattern) => new Pattern(pattern))
+    patternString.split(".").map((pattern) => new Pattern(pattern)),
   );
 }
 
 function tryPatternMatch(
   node: SyntaxNode,
-  patterns: Pattern[]
+  patterns: Pattern[],
 ): SyntaxNode | null {
   let result = searchNodeAscending(node, patterns);
 
@@ -251,7 +251,7 @@ type NodePattern = [SyntaxNode, Pattern] | null;
 
 function searchNodeAscending(
   node: SyntaxNode,
-  patterns: Pattern[]
+  patterns: Pattern[],
 ): NodePattern {
   let result: NodePattern = null;
   let currentNode: SyntaxNode | null = node;
@@ -279,7 +279,7 @@ function searchNodeAscending(
 
 function searchNodeDescending(
   node: SyntaxNode,
-  patterns: Pattern[]
+  patterns: Pattern[],
 ): NodePattern {
   let result: NodePattern = null;
   let currentNode: SyntaxNode | null = node;
@@ -301,7 +301,7 @@ function searchNodeDescending(
 
     if (i + 1 < patterns.length) {
       const children: SyntaxNode[] = currentNode.namedChildren.filter((node) =>
-        patterns[i + 1].typeEquals(node)
+        patterns[i + 1].typeEquals(node),
       );
       currentNode = children.length === 1 ? children[0] : null;
     }

--- a/src/util/nodeMatchers.ts
+++ b/src/util/nodeMatchers.ts
@@ -24,7 +24,7 @@ import {
 
 export function matcher(
   finder: NodeFinder,
-  selector: SelectionExtractor = simpleSelectionExtractor
+  selector: SelectionExtractor = simpleSelectionExtractor,
 ): NodeMatcher {
   return function (selection: SelectionWithEditor, node: SyntaxNode) {
     const targetNode = finder(node, selection.selection);
@@ -49,7 +49,7 @@ export function matcher(
  */
 export function chainedMatcher(
   finders: NodeFinder[],
-  selector: SelectionExtractor = simpleSelectionExtractor
+  selector: SelectionExtractor = simpleSelectionExtractor,
 ): NodeMatcher {
   const nodeFinder = chainedNodeFinder(...finders);
 
@@ -89,11 +89,11 @@ export function chainedMatcher(
 export function ancestorChainNodeMatcher(
   nodeFinders: NodeFinder[],
   nodeToReturn: number = 0,
-  selector: SelectionExtractor = simpleSelectionExtractor
+  selector: SelectionExtractor = simpleSelectionExtractor,
 ) {
   return matcher(
     ancestorChainNodeFinder(nodeToReturn, ...nodeFinders),
-    selector
+    selector,
   );
 }
 
@@ -108,7 +108,7 @@ export function patternMatcher(...patterns: string[]): NodeMatcher {
 export function argumentMatcher(...parentTypes: string[]): NodeMatcher {
   return matcher(
     argumentNodeFinder(...parentTypes),
-    argumentSelectionExtractor()
+    argumentSelectionExtractor(),
   );
 }
 
@@ -124,11 +124,11 @@ export function conditionMatcher(...patterns: string[]): NodeMatcher {
  */
 export function leadingMatcher(
   patterns: string[],
-  delimiters: string[] = []
+  delimiters: string[] = [],
 ): NodeMatcher {
   return matcher(
     patternFinder(...patterns),
-    selectWithLeadingDelimiter(...delimiters)
+    selectWithLeadingDelimiter(...delimiters),
   );
 }
 
@@ -140,11 +140,11 @@ export function leadingMatcher(
  */
 export function trailingMatcher(
   patterns: string[],
-  delimiters: string[] = []
+  delimiters: string[] = [],
 ): NodeMatcher {
   return matcher(
     patternFinder(...patterns),
-    selectWithTrailingDelimiter(...delimiters)
+    selectWithTrailingDelimiter(...delimiters),
   );
 }
 
@@ -170,13 +170,13 @@ export function cascadingMatcher(...matchers: NodeMatcher[]): NodeMatcher {
 
 export const notSupported: NodeMatcher = (
   _selection: SelectionWithEditor,
-  _node: SyntaxNode
+  _node: SyntaxNode,
 ) => {
   throw new Error("Node type not supported");
 };
 
 export function createPatternMatchers(
-  nodeMatchers: Partial<Record<SimpleScopeTypeType, NodeMatcherAlternative>>
+  nodeMatchers: Partial<Record<SimpleScopeTypeType, NodeMatcherAlternative>>,
 ): Record<SimpleScopeTypeType, NodeMatcher> {
   Object.keys(nodeMatchers).forEach((scopeType: SimpleScopeTypeType) => {
     const matcher = nodeMatchers[scopeType];

--- a/src/util/nodeSelectors.ts
+++ b/src/util/nodeSelectors.ts
@@ -9,13 +9,13 @@ import {
 
 export function makeRangeFromPositions(
   startPosition: Point,
-  endPosition: Point
+  endPosition: Point,
 ) {
   return new Range(
     startPosition.row,
     startPosition.column,
     endPosition.row,
-    endPosition.column
+    endPosition.column,
   );
 }
 
@@ -28,7 +28,7 @@ export function getNodeRange(node: SyntaxNode) {
     node.startPosition.row,
     node.startPosition.column,
     node.endPosition.row,
-    node.endPosition.column
+    node.endPosition.column,
   );
 }
 
@@ -37,7 +37,7 @@ export function makeNodePairSelection(anchor: SyntaxNode, active: SyntaxNode) {
     anchor.startPosition.row,
     anchor.startPosition.column,
     active.endPosition.row,
-    active.endPosition.column
+    active.endPosition.column,
   );
 }
 
@@ -51,18 +51,18 @@ export function getNodeInternalRange(node: SyntaxNode) {
 
   return makeRangeFromPositions(
     children[0].endPosition,
-    children[children.length - 1].startPosition
+    children[children.length - 1].startPosition,
   );
 }
 
 export function simpleSelectionExtractor(
   editor: TextEditor,
-  node: SyntaxNode
+  node: SyntaxNode,
 ): SelectionWithContext {
   return {
     selection: new Selection(
       new Position(node.startPosition.row, node.startPosition.column),
-      new Position(node.endPosition.row, node.endPosition.column)
+      new Position(node.endPosition.row, node.endPosition.column),
     ),
     context: {},
   };
@@ -81,7 +81,7 @@ export function simpleSelectionExtractor(
 export function extendUntilNextMatchingSiblingOrLast(
   editor: TextEditor,
   node: SyntaxNode,
-  nodeFinder: NodeFinder
+  nodeFinder: NodeFinder,
 ) {
   const endNode = getNextMatchingSiblingNodeOrLast(node, nodeFinder);
   return pairSelectionExtractor(editor, node, endNode);
@@ -89,7 +89,7 @@ export function extendUntilNextMatchingSiblingOrLast(
 
 function getNextMatchingSiblingNodeOrLast(
   node: SyntaxNode,
-  nodeFinder: NodeFinder
+  nodeFinder: NodeFinder,
 ): SyntaxNode {
   let currentNode: SyntaxNode = node;
   let nextNode: SyntaxNode | null = node.nextSibling;
@@ -126,7 +126,7 @@ export function extendForwardPastOptional(...delimiters: string[]) {
 export function pairSelectionExtractor(
   editor: TextEditor,
   node1: SyntaxNode,
-  node2: SyntaxNode
+  node2: SyntaxNode,
 ): SelectionWithContext {
   const isForward = node1.startIndex < node2.startIndex;
   const start = isForward ? node1 : node2;
@@ -134,7 +134,7 @@ export function pairSelectionExtractor(
   return {
     selection: new Selection(
       new Position(start.startPosition.row, start.startPosition.column),
-      new Position(end.endPosition.row, end.endPosition.column)
+      new Position(end.endPosition.row, end.endPosition.column),
     ),
     context: {},
   };
@@ -152,13 +152,13 @@ export function argumentSelectionExtractor(): SelectionExtractor {
       node.type === "<" ||
       node.type === "}" ||
       node.type === "{",
-    ", "
+    ", ",
   );
 }
 
 export function unwrapSelectionExtractor(
   editor: TextEditor,
-  node: SyntaxNode
+  node: SyntaxNode,
 ): SelectionWithContext {
   let startIndex = node.startIndex;
   let endIndex = node.endIndex;
@@ -171,7 +171,7 @@ export function unwrapSelectionExtractor(
   return {
     selection: new Selection(
       editor.document.positionAt(startIndex),
-      editor.document.positionAt(endIndex)
+      editor.document.positionAt(endIndex),
     ),
     context: {},
   };
@@ -188,14 +188,14 @@ export function selectWithLeadingDelimiter(...delimiters: string[]) {
         if (secondSibling) {
           leadingDelimiterRange = makeRangeFromPositions(
             secondSibling.endPosition,
-            node.startPosition
+            node.startPosition,
           );
         }
         // First delimiter sibling exists. Terminate after it.
         else {
           leadingDelimiterRange = makeRangeFromPositions(
             firstSibling.startPosition,
-            node.startPosition
+            node.startPosition,
           );
         }
       }
@@ -203,7 +203,7 @@ export function selectWithLeadingDelimiter(...delimiters: string[]) {
       else {
         leadingDelimiterRange = makeRangeFromPositions(
           firstSibling.endPosition,
-          node.startPosition
+          node.startPosition,
         );
       }
     }
@@ -226,7 +226,7 @@ export function selectWithLeadingDelimiter(...delimiters: string[]) {
  */
 export function childRangeSelector(
   typesToExclude: string[] = [],
-  typesToInclude: string[] = []
+  typesToInclude: string[] = [],
 ) {
   return function (editor: TextEditor, node: SyntaxNode): SelectionWithContext {
     if (typesToExclude.length > 0 && typesToInclude.length > 0) {
@@ -261,18 +261,18 @@ export function selectWithTrailingDelimiter(...delimiters: string[]) {
         if (secondSibling) {
           trailingDelimiterRange = makeRangeFromPositions(
             node.endPosition,
-            secondSibling.startPosition
+            secondSibling.startPosition,
           );
         } else {
           trailingDelimiterRange = makeRangeFromPositions(
             node.endPosition,
-            firstSibling.endPosition
+            firstSibling.endPosition,
           );
         }
       } else {
         trailingDelimiterRange = makeRangeFromPositions(
           node.endPosition,
-          firstSibling.startPosition
+          firstSibling.startPosition,
         );
       }
     }
@@ -287,7 +287,7 @@ export function selectWithTrailingDelimiter(...delimiters: string[]) {
 
 function getNextNonDelimiterNode(
   startNode: SyntaxNode,
-  isDelimiterNode: (node: SyntaxNode) => boolean
+  isDelimiterNode: (node: SyntaxNode) => boolean,
 ): SyntaxNode | null {
   let node = startNode.nextSibling;
 
@@ -304,7 +304,7 @@ function getNextNonDelimiterNode(
 
 function getPreviousNonDelimiterNode(
   startNode: SyntaxNode,
-  isDelimiterNode: (node: SyntaxNode) => boolean
+  isDelimiterNode: (node: SyntaxNode) => boolean,
 ): SyntaxNode | null {
   let node = startNode.previousSibling;
 
@@ -340,7 +340,7 @@ export function delimitedSelector(
   isDelimiterNode: (node: SyntaxNode) => boolean,
   defaultDelimiter: string,
   getStartNode: (node: SyntaxNode) => SyntaxNode = identity,
-  getEndNode: (node: SyntaxNode) => SyntaxNode = identity
+  getEndNode: (node: SyntaxNode) => SyntaxNode = identity,
 ): SelectionExtractor {
   return (editor: TextEditor, node: SyntaxNode) => {
     let leadingDelimiterRange: Range | undefined;
@@ -350,24 +350,24 @@ export function delimitedSelector(
 
     const previousNonDelimiterNode = getPreviousNonDelimiterNode(
       startNode,
-      isDelimiterNode
+      isDelimiterNode,
     );
     const nextNonDelimiterNode = getNextNonDelimiterNode(
       endNode,
-      isDelimiterNode
+      isDelimiterNode,
     );
 
     if (previousNonDelimiterNode != null) {
       leadingDelimiterRange = makeRangeFromPositions(
         previousNonDelimiterNode.endPosition,
-        startNode.startPosition
+        startNode.startPosition,
       );
     }
 
     if (nextNonDelimiterNode != null) {
       trailingDelimiterRange = makeRangeFromPositions(
         endNode.endPosition,
-        nextNonDelimiterNode.startPosition
+        nextNonDelimiterNode.startPosition,
       );
     }
 
@@ -375,16 +375,16 @@ export function delimitedSelector(
       editor,
       leadingDelimiterRange,
       trailingDelimiterRange,
-      defaultDelimiter
+      defaultDelimiter,
     );
 
     return {
       selection: new Selection(
         new Position(
           startNode.startPosition.row,
-          startNode.startPosition.column
+          startNode.startPosition.column,
         ),
-        new Position(endNode.endPosition.row, endNode.endPosition.column)
+        new Position(endNode.endPosition.row, endNode.endPosition.column),
       ),
       context: {
         containingListDelimiter,
@@ -397,7 +397,7 @@ export function delimitedSelector(
 
 export function xmlElementExtractor(
   editor: TextEditor,
-  node: SyntaxNode
+  node: SyntaxNode,
 ): SelectionWithContext {
   const selection = simpleSelectionExtractor(editor, node);
 
@@ -410,7 +410,7 @@ export function xmlElementExtractor(
         firstNamedChild.endPosition.row,
         firstNamedChild.endPosition.column,
         lastNamedChild.startPosition.row,
-        lastNamedChild.startPosition.column
+        lastNamedChild.startPosition.column,
       );
     }
   }
@@ -422,7 +422,7 @@ export function getInsertionDelimiter(
   editor: TextEditor,
   leadingDelimiterRange: Range | undefined,
   trailingDelimiterRange: Range | undefined,
-  defaultDelimiterInsertion: string
+  defaultDelimiterInsertion: string,
 ) {
   const { getText } = editor.document;
   const delimiters = [

--- a/src/util/notebook.ts
+++ b/src/util/notebook.ts
@@ -24,10 +24,10 @@ export function getNotebookFromCellDocument(document: TextDocument) {
         (notebookEditor.document.getCells() as NotebookCell[]).map((cell) => ({
           notebookEditor,
           cell,
-        }))
+        })),
       )
       .find(
-        ({ cell }) => cell.document.uri.toString() === document.uri.toString()
+        ({ cell }) => cell.document.uri.toString() === document.uri.toString(),
       ) ?? {};
 
   return notebookEditor;
@@ -42,11 +42,11 @@ export function getNotebookFromCellDocument(document: TextDocument) {
  */
 export function getCellIndex(
   notebookDocument: NotebookDocument,
-  document: TextDocument
+  document: TextDocument,
 ) {
   return notebookDocument
     .getCells()
     .findIndex(
-      (cell) => cell.document.uri.toString() === document.uri.toString()
+      (cell) => cell.document.uri.toString() === document.uri.toString(),
     );
 }

--- a/src/util/notebookLegacy.ts
+++ b/src/util/notebookLegacy.ts
@@ -23,7 +23,7 @@ export async function focusNotebookCellLegacy(editor: TextEditor) {
 
   const editorNotebook = getNotebookFromCellDocument(editor.document);
   const activeEditorNotebook = getNotebookFromCellDocument(
-    activeTextEditor.document
+    activeTextEditor.document,
   );
 
   if (
@@ -37,12 +37,12 @@ export async function focusNotebookCellLegacy(editor: TextEditor) {
   const editorIndex = getCellIndex(editorNotebook, editor.document);
   const activeEditorIndex = getCellIndex(
     editorNotebook,
-    activeTextEditor.document
+    activeTextEditor.document,
   );
 
   if (editorIndex === -1 || activeEditorIndex === -1) {
     throw new Error(
-      "Couldn't find editor corresponding to given cell in the expected notebook"
+      "Couldn't find editor corresponding to given cell in the expected notebook",
     );
   }
 

--- a/src/util/performDocumentEdits.ts
+++ b/src/util/performDocumentEdits.ts
@@ -5,11 +5,11 @@ import { RangeUpdater } from "../core/updateSelections/RangeUpdater";
 export async function performDocumentEdits(
   rangeUpdater: RangeUpdater,
   editor: TextEditor,
-  edits: Edit[]
+  edits: Edit[],
 ) {
   const deregister = rangeUpdater.registerReplaceEditList(
     editor.document,
-    edits.filter((edit) => edit.isReplace)
+    edits.filter((edit) => edit.isReplace),
   );
 
   const wereEditsApplied = await editor.edit((editBuilder) => {

--- a/src/util/rangeUtils.ts
+++ b/src/util/rangeUtils.ts
@@ -21,7 +21,7 @@ export function isAtStartOfLine(position: Position) {
 export function expandToFullLine(editor: TextEditor, range: Range) {
   return new Range(
     new Position(range.start.line, 0),
-    editor.document.lineAt(range.end).range.end
+    editor.document.lineAt(range.end).range.end,
   );
 }
 
@@ -60,6 +60,6 @@ export function strictlyContains(range1: Range, range2: Range): boolean {
 export function getDocumentRange(document: TextDocument) {
   return new Range(
     new Position(0, 0),
-    document.lineAt(document.lineCount - 1).range.end
+    document.lineAt(document.lineCount - 1).range.end,
   );
 }

--- a/src/util/regex.ts
+++ b/src/util/regex.ts
@@ -35,7 +35,7 @@ export const leftAnchored = makeCache(_leftAnchored);
 export function matchAll<T>(
   text: string,
   regex: RegExp,
-  mapfn: (v: RegExpMatchArray, k: number) => T
+  mapfn: (v: RegExpMatchArray, k: number) => T,
 ) {
   // Reset the regex to start at the beginning of string, in case the regex has
   // been used before.
@@ -59,7 +59,7 @@ export function matchText(text: string, regex: RegExp): MatchedText[] {
 export function getMatchesInRange(
   regex: RegExp,
   editor: TextEditor,
-  range: Range
+  range: Range,
 ): Range[] {
   const offset = editor.document.offsetAt(range.start);
   const text = editor.document.getText(range);
@@ -70,7 +70,7 @@ export function getMatchesInRange(
     (match) =>
       new Range(
         editor.document.positionAt(offset + match.index!),
-        editor.document.positionAt(offset + match.index! + match[0].length)
-      )
+        editor.document.positionAt(offset + match.index! + match[0].length),
+      ),
   );
 }

--- a/src/util/selectionUtils.ts
+++ b/src/util/selectionUtils.ts
@@ -11,7 +11,7 @@ export function isReversed(selection: Selection) {
 
 export function selectionWithEditorFromRange(
   selection: SelectionWithEditor,
-  range: Range
+  range: Range,
 ): SelectionWithEditor {
   return selectionWithEditorFromPositions(selection, range.start, range.end);
 }
@@ -19,7 +19,7 @@ export function selectionWithEditorFromRange(
 function selectionWithEditorFromPositions(
   selection: SelectionWithEditor,
   start: Position,
-  end: Position
+  end: Position,
 ): SelectionWithEditor {
   return {
     editor: selection.editor,
@@ -30,7 +30,7 @@ function selectionWithEditorFromPositions(
 function selectionFromPositions(
   selection: Selection,
   start: Position,
-  end: Position
+  end: Position,
 ): Selection {
   // The built in isReversed is bugged on empty selection. don't use
   return isForward(selection)

--- a/src/util/setSelectionsAndFocusEditor.ts
+++ b/src/util/setSelectionsAndFocusEditor.ts
@@ -32,7 +32,7 @@ const columnFocusCommands = {
 export async function setSelectionsAndFocusEditor(
   editor: TextEditor,
   selections: Selection[],
-  revealRange: boolean = true
+  revealRange: boolean = true,
 ) {
   setSelectionsWithoutFocusingEditor(editor, selections);
 
@@ -47,7 +47,7 @@ export async function setSelectionsAndFocusEditor(
 
 export function setSelectionsWithoutFocusingEditor(
   editor: TextEditor,
-  selections: Selection[]
+  selections: Selection[],
 ) {
   editor.selections = uniqDeep(selections);
 }
@@ -79,7 +79,7 @@ function getViewColumn(editor: TextEditor): ViewColumn | undefined {
   }
   const uri = editor.document.uri.toString();
   const tabGroup = (window as any)?.tabGroups?.all?.find((tabGroup: any) =>
-    tabGroup?.tabs.find((tab: any) => tab?.input?.modified?.toString() === uri)
+    tabGroup?.tabs.find((tab: any) => tab?.input?.modified?.toString() === uri),
   );
   return tabGroup?.viewColumn;
 }
@@ -96,12 +96,12 @@ async function focusNotebookCell(editor: TextEditor) {
   await commands.executeCommand(
     columnFocusCommands[
       desiredNotebookEditor.viewColumn as keyof typeof columnFocusCommands
-    ]
+    ],
   );
 
   const desiredEditorIndex = getCellIndex(
     desiredNotebookDocument,
-    editor.document
+    editor.document,
   );
 
   const desiredSelections = [

--- a/src/util/snippet.ts
+++ b/src/util/snippet.ts
@@ -24,7 +24,7 @@ import { KnownSnippetVariableNames } from "../vendor/snippet/snippetVariables";
 export function transformSnippetVariables(
   parsedSnippet: TextmateSnippet,
   placeholderName?: string | null,
-  substitutions?: Record<string, string>
+  substitutions?: Record<string, string>,
 ): void {
   let nextPlaceholderIndex = getMaxPlaceholderIndex(parsedSnippet) + 1;
   const placeholderIndexMap: Record<string, number> = {};
@@ -85,10 +85,10 @@ function getMaxPlaceholderIndex(parsedSnippet: TextmateSnippet): number {
  */
 export function findMatchingSnippetDefinitionStrict(
   targets: Target[],
-  definitions: SnippetDefinition[]
+  definitions: SnippetDefinition[],
 ): SnippetDefinition {
   const definitionIndices = targets.map((target) =>
-    findMatchingSnippetDefinitionForSingleTarget(target, definitions)
+    findMatchingSnippetDefinitionForSingleTarget(target, definitions),
   );
 
   const definitionIndex = definitionIndices[0];
@@ -106,7 +106,7 @@ export function findMatchingSnippetDefinitionStrict(
 
 function findMatchingSnippetDefinitionForSingleTarget(
   target: Target,
-  definitions: SnippetDefinition[]
+  definitions: SnippetDefinition[],
 ): number {
   const languageId = target.editor.document.languageId;
 

--- a/src/util/targetUtils.ts
+++ b/src/util/targetUtils.ts
@@ -29,18 +29,18 @@ export function ensureSingleTarget(targets: Target[]) {
 export async function runForEachEditor<T, U>(
   targets: T[],
   getEditor: (target: T) => TextEditor,
-  func: (editor: TextEditor, editorTargets: T[]) => Promise<U>
+  func: (editor: TextEditor, editorTargets: T[]) => Promise<U>,
 ): Promise<U[]> {
   return Promise.all(
     groupForEachEditor(targets, getEditor).map(([editor, editorTargets]) =>
-      func(editor, editorTargets)
-    )
+      func(editor, editorTargets),
+    ),
   );
 }
 
 export async function runOnTargetsForEachEditor<T>(
   targets: Target[],
-  func: (editor: TextEditor, targets: Target[]) => Promise<T>
+  func: (editor: TextEditor, targets: Target[]) => Promise<T>,
 ): Promise<T[]> {
   return runForEachEditor(targets, (target) => target.editor, func);
 }
@@ -51,7 +51,7 @@ export function groupTargetsForEachEditor(targets: Target[]) {
 
 export function groupForEachEditor<T>(
   targets: T[],
-  getEditor: (target: T) => TextEditor
+  getEditor: (target: T) => TextEditor,
 ): [TextEditor, T[]][] {
   // Actually group by document and not editor. If the same document is open in multiple editors we want to perform all actions in one editor or an concurrency error will occur.
   const getDocument = (target: T) => getEditor(target).document;
@@ -67,7 +67,7 @@ export function groupForEachEditor<T>(
 export function getOutsideOverflow(
   editor: TextEditor,
   insideRange: Range,
-  outsideRange: Range
+  outsideRange: Range,
 ): Range[] {
   const { start: insideStart, end: insideEnd } = insideRange;
   const { start: outsideStart, end: outsideEnd } = outsideRange;
@@ -87,7 +87,7 @@ export function getContentRange(target: Target) {
 
 export function createThatMark(
   targets: Target[],
-  ranges?: Range[]
+  ranges?: Range[],
 ): SelectionWithEditor[] {
   const thatMark =
     ranges != null

--- a/src/util/timeUtils.ts
+++ b/src/util/timeUtils.ts
@@ -2,7 +2,7 @@ const nanosecondsPerSecond = BigInt(1000000000);
 
 export function hrtimeBigintToSeconds(
   nanoseconds: bigint,
-  precision: bigint = BigInt(1000000)
+  precision: bigint = BigInt(1000000),
 ) {
   return (
     Number((nanoseconds * precision) / nanosecondsPerSecond) / Number(precision)

--- a/src/util/treeSitterUtils.ts
+++ b/src/util/treeSitterUtils.ts
@@ -17,7 +17,7 @@ export const getDeclarationNode = (node: SyntaxNode) =>
 
 export function getChildNodesForFieldName(
   node: SyntaxNode,
-  fieldName: string
+  fieldName: string,
 ): SyntaxNode[] {
   const treeCursor = node.walk();
   treeCursor.gotoFirstChild();

--- a/src/util/tryConstructTarget.ts
+++ b/src/util/tryConstructTarget.ts
@@ -7,7 +7,7 @@ import {
 import { Target } from "../typings/target.types";
 
 type TargetConstructor<T extends Target> = new (
-  parameters: CommonTargetParameters
+  parameters: CommonTargetParameters,
 ) => T;
 
 /**
@@ -24,7 +24,7 @@ export function tryConstructTarget<T extends Target>(
   constructor: TargetConstructor<T>,
   editor: TextEditor,
   range: Range | undefined,
-  isReversed: boolean
+  isReversed: boolean,
 ): T | undefined {
   return range == null
     ? undefined
@@ -47,7 +47,7 @@ export function tryConstructTarget<T extends Target>(
 export function tryConstructPlainTarget(
   editor: TextEditor,
   range: Range | undefined,
-  isReversed: boolean
+  isReversed: boolean,
 ): PlainTarget | undefined {
   return tryConstructTarget(PlainTarget, editor, range, isReversed);
 }
@@ -64,7 +64,7 @@ export function tryConstructPlainTarget(
 export function constructLineTarget(
   editor: TextEditor,
   range: Range | undefined,
-  isReversed: boolean
+  isReversed: boolean,
 ): LineTarget | undefined {
   return tryConstructTarget(LineTarget, editor, range, isReversed);
 }

--- a/src/util/unifyRanges.ts
+++ b/src/util/unifyRanges.ts
@@ -47,7 +47,7 @@ export function unifyRemovalTargets(targets: Target[]): Target[] {
     }
     let results = [...targets];
     results.sort((a, b) =>
-      a.contentRange.start.compareTo(b.contentRange.start)
+      a.contentRange.start.compareTo(b.contentRange.start),
     );
     let run = true;
     // Merge targets untill there are no overlaps/intersections


### PR DESCRIPTION
See discussion in https://github.com/cursorless-dev/cursorless/pull/1041#issuecomment-1281902910.  In prettier v3, this [will be the new default](https://github.com/prettier/prettier/pull/11479)

We should add this commit to the git blame ignore once it merges

## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
