### PR TITLE
Switch tree-sitter-markdown dependency

### DIFF
--- a/src/languages/markdown.ts
+++ b/src/languages/markdown.ts
@@ -7,11 +7,7 @@ import {
   SelectionWithContext,
 } from "../typings/Types";
 import { leadingSiblingNodeFinder, patternFinder } from "../util/nodeFinders";
-import {
-  createPatternMatchers,
-  leadingMatcher,
-  matcher,
-} from "../util/nodeMatchers";
+import { createPatternMatchers, matcher } from "../util/nodeMatchers";
 import {
   extendUntilNextMatchingSiblingOrLast,
   getNodeRange,

--- a/src/test/suite/fixtures/recorded/languages/markdown/chuckName.yml
+++ b/src/test/suite/fixtures/recorded/languages/markdown/chuckName.yml
@@ -18,9 +18,8 @@ initialState:
 finalState:
   documentContents: |-
 
-
     Testing testing
   selections:
-    - anchor: {line: 2, character: 14}
-      active: {line: 2, character: 14}
+    - anchor: {line: 1, character: 14}
+      active: {line: 1, character: 14}
 fullTargets: [{type: primitive, mark: {type: cursor}, selectionType: token, position: contents, insideOutsideType: outside, modifier: {type: containingScope, scopeType: name, includeSiblings: false}, isImplicit: false}]

--- a/src/test/suite/runTestSubset.ts
+++ b/src/test/suite/runTestSubset.ts
@@ -4,7 +4,7 @@
  * configuration.
  * See https://mochajs.org/#-grep-regexp-g-regexp for supported syntax
  */
-export const TEST_SUBSET_GREP_STRING = "tokenizer";
+export const TEST_SUBSET_GREP_STRING = "markdown";
 
 /**
  * Determine whether we should run just the subset of the tests specified by


### PR DESCRIPTION
For better performance.  Must be merged at the same time as https://github.com/cursorless-dev/vscode-parse-tree/pull/56

## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet
