### PR TITLE
Fixed bug with reusing regex in token preference

### DIFF
--- a/src/processTargets/modifiers/scopeHandlers/TokenScopeHandler.ts
+++ b/src/processTargets/modifiers/scopeHandlers/TokenScopeHandler.ts
@@ -43,6 +43,8 @@ export default class TokenScopeHandler extends NestedScopeHandler {
     } = scopeA;
     const { identifierMatcher } = getMatcher(document.languageId);
 
+    // NB: Don't directly use `test` here because global regexes are stateful
+    // See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec#finding_successive_matches
     return testRegex(identifierMatcher, document.getText(scopeA.domain))
       ? true
       : testRegex(identifierMatcher, document.getText(scopeB.domain))

--- a/src/processTargets/modifiers/scopeHandlers/TokenScopeHandler.ts
+++ b/src/processTargets/modifiers/scopeHandlers/TokenScopeHandler.ts
@@ -5,7 +5,7 @@ import type {
   Direction,
   ScopeType,
 } from "../../../typings/targetDescriptor.types";
-import { generateMatchesInRange } from "../../../util/regex";
+import { generateMatchesInRange, testRegex } from "../../../util/regex";
 import { TokenTarget } from "../../targets";
 import type { TargetScope } from "./scope.types";
 
@@ -43,9 +43,9 @@ export default class TokenScopeHandler extends NestedScopeHandler {
     } = scopeA;
     const { identifierMatcher } = getMatcher(document.languageId);
 
-    return identifierMatcher.test(document.getText(scopeA.domain))
+    return testRegex(document.getText(scopeA.domain), identifierMatcher)
       ? true
-      : identifierMatcher.test(document.getText(scopeB.domain))
+      : testRegex(document.getText(scopeB.domain), identifierMatcher)
       ? false
       : undefined;
   }

--- a/src/processTargets/modifiers/scopeHandlers/TokenScopeHandler.ts
+++ b/src/processTargets/modifiers/scopeHandlers/TokenScopeHandler.ts
@@ -43,9 +43,9 @@ export default class TokenScopeHandler extends NestedScopeHandler {
     } = scopeA;
     const { identifierMatcher } = getMatcher(document.languageId);
 
-    return testRegex(document.getText(scopeA.domain), identifierMatcher)
+    return testRegex(identifierMatcher, document.getText(scopeA.domain))
       ? true
-      : testRegex(document.getText(scopeB.domain), identifierMatcher)
+      : testRegex(identifierMatcher, document.getText(scopeB.domain))
       ? false
       : undefined;
   }

--- a/src/test/suite/containingTokenTwice.test.ts
+++ b/src/test/suite/containingTokenTwice.test.ts
@@ -5,6 +5,9 @@ import { getCursorlessApi } from "../../util/getExtensionApi";
 import { openNewEditor } from "../openNewEditor";
 import { standardSuiteSetup } from "./standardSuiteSetup";
 
+// Check that we don't run afoul of stateful regex craziness
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec#finding_successive_matches
+// When this fails, the regex that checks if something is an identifier will start at the wrong place the second time it is called
 suite("Take token twice", async function () {
   standardSuiteSetup(this);
 

--- a/src/test/suite/containingTokenTwice.test.ts
+++ b/src/test/suite/containingTokenTwice.test.ts
@@ -1,0 +1,41 @@
+import { assert } from "chai";
+import * as vscode from "vscode";
+import { CommandV3 } from "../../core/commandRunner/command.types";
+import { getCursorlessApi } from "../../util/getExtensionApi";
+import { openNewEditor } from "../openNewEditor";
+import { standardSuiteSetup } from "./standardSuiteSetup";
+
+suite("Take token twice", async function () {
+  standardSuiteSetup(this);
+
+  test("Take token twice", runTest);
+});
+
+async function runTest() {
+  const graph = (await getCursorlessApi()).graph!;
+  const editor = await openNewEditor("a)");
+  await graph.hatTokenMap.addDecorations();
+
+  for (let i = 0; i < 2; ++i) {
+    editor.selection = new vscode.Selection(0, 1, 0, 1);
+
+    const command: CommandV3 = {
+      version: 3,
+      action: { name: "setSelection" },
+      usePrePhraseSnapshot: false,
+      targets: [
+        {
+          type: "primitive",
+          modifiers: [
+            { type: "containingScope", scopeType: { type: "token" } },
+          ],
+          mark: { type: "cursor" },
+        },
+      ],
+    };
+
+    await vscode.commands.executeCommand("cursorless.command", command);
+
+    assert.isTrue(editor.selection.isEqual(new vscode.Selection(0, 0, 0, 1)));
+  }
+}

--- a/src/test/suite/fixtures/recorded/subtoken/takeFirstChar2.yml
+++ b/src/test/suite/fixtures/recorded/subtoken/takeFirstChar2.yml
@@ -16,6 +16,6 @@ initialState:
 finalState:
   documentContents: aa//
   selections:
-    - anchor: {line: 0, character: 2}
-      active: {line: 0, character: 3}
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 1}
 fullTargets: [{type: primitive, mark: {type: cursorToken}, selectionType: token, position: contents, modifier: {type: subpiece, pieceType: character, anchor: 0, active: 0}, insideOutsideType: inside}]

--- a/src/util/regex.ts
+++ b/src/util/regex.ts
@@ -46,6 +46,14 @@ export function matchAll<T>(
   return Array.from(text.matchAll(regex), mapfn);
 }
 
+export function testRegex(text: string, regex: RegExp) {
+  // Reset the regex to start at the beginning of string, in case the regex has
+  // been used before.
+  // See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec#finding_successive_matches
+  regex.lastIndex = 0;
+  return regex.test(text);
+}
+
 export interface MatchedText {
   index: number;
   text: string;

--- a/src/util/regex.ts
+++ b/src/util/regex.ts
@@ -46,7 +46,7 @@ export function matchAll<T>(
   return Array.from(text.matchAll(regex), mapfn);
 }
 
-export function testRegex(text: string, regex: RegExp) {
+export function testRegex(regex: RegExp, text: string): boolean {
   // Reset the regex to start at the beginning of string, in case the regex has
   // been used before.
   // See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec#finding_successive_matches


### PR DESCRIPTION
Fixes #1108

## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet
