### PR TITLE
Added shell:true to init launch sandbox

### DIFF
--- a/src/test/initLaunchSandbox.ts
+++ b/src/test/initLaunchSandbox.ts
@@ -29,7 +29,7 @@ async function main() {
     ];
 
     // Install extension dependencies
-    const process = cp.spawn("code", args, { stdio: "inherit" });
+    const process = cp.spawn("code", args, { stdio: "inherit", shell: true });
 
     await new Promise<void>((resolve, reject) => {
       process.on("error", reject);


### PR DESCRIPTION
Doesn't work on windows otherwise
If this has any problem on mac or Linux we could make this boolean only be true on windows


## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet
