### PR TITLE
Added new notebook editor field

### DIFF
--- a/src/util/notebook.ts
+++ b/src/util/notebook.ts
@@ -21,7 +21,11 @@ export function getNotebookFromCellDocument(document: TextDocument) {
   const { notebookEditor } =
     ((window as any).visibleNotebookEditors as any[])
       .flatMap((notebookEditor: any) =>
-        (notebookEditor.document.getCells() as NotebookCell[]).map((cell) => ({
+        (
+          (
+            notebookEditor.document ?? notebookEditor.notebook
+          ).getCells() as NotebookCell[]
+        ).map((cell) => ({
           notebookEditor,
           cell,
         })),


### PR DESCRIPTION
Looks like the experimental notebook api has been deprecated. Solved it for now by adding an additional field name. 

We should really think about updating to vscode version 1.68 and get these as proper types.

https://github.com/DefinitelyTyped/DefinitelyTyped/blob/1a72ad27159fcb85c0d951e6ff2fd19f47017ab0/types/vscode/index.d.ts#L12793

## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet
