### PR TITLE
Tweak cheatsheet variable coloring

### DIFF
--- a/cursorless-nx/libs/cheatsheet/src/lib/components/formatCaptures.tsx
+++ b/cursorless-nx/libs/cheatsheet/src/lib/components/formatCaptures.tsx
@@ -13,7 +13,7 @@ export function formatCaptures(input: string) {
       );
 
     return (
-      <span className="inline-block px-[2px] rounded-md text-cyan-900 dark:text-inherit bg-cyan-400 dark:bg-cyan-600">
+      <span className="inline-block p-[2px] rounded-md text-[#000000E3] dark:text-[#FFFFFFE3] bg-[#8686864C] dark:bg-[#FFFFFF33]">
         <SmartLink key={i} to="#legend" noFormatting={true}>
           {'['}
           {innerElement}


### PR DESCRIPTION

<img width="751" alt="image" src="https://user-images.githubusercontent.com/755842/202714227-c51da4c7-354b-49d8-b267-0f034602cbcf.png">
<img width="751" alt="image" src="https://user-images.githubusercontent.com/755842/202714231-40558f37-6afa-46b8-a5aa-0ccba9e12410.png">

## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [x] I have not broken the cheatsheet
