### PR TITLE
Support `"value"` for switch statements

### DIFF
--- a/src/languages/java.ts
+++ b/src/languages/java.ts
@@ -103,14 +103,24 @@ const nodeMatchers: Partial<
     "method_declaration.identifier!",
     "constructor_declaration.identifier!",
   ],
-  value: leadingMatcher(
-    [
-      "*[declarator][value]",
-      "assignment_expression[right]",
-      "return_statement[0]",
-      "*[value]",
-    ],
-    ["=", "+=", "-=", "*=", "/=", "%=", "&=", "|=", "^=", "<<=", ">>="],
+  value: cascadingMatcher(
+    leadingMatcher(
+      [
+        "*[declarator][value]",
+        "assignment_expression[right]",
+        "return_statement[0]",
+        "*[value]",
+      ],
+      ["=", "+=", "-=", "*=", "/=", "%=", "&=", "|=", "^=", "<<=", ">>="],
+    ),
+    matcher(
+      patternFinder("switch_block_statement_group"),
+      childRangeSelector(["switch_label"], []),
+    ),
+    matcher(
+      patternFinder("switch_rule"),
+      childRangeSelector(["switch_label"], []),
+    ),
   ),
   condition: conditionMatcher("*[condition]"),
   argumentOrParameter: argumentMatcher("formal_parameters", "argument_list"),

--- a/src/languages/python.ts
+++ b/src/languages/python.ts
@@ -140,6 +140,7 @@ const nodeMatchers: Partial<
       ],
     ),
     patternMatcher("return_statement.~return!"),
+    patternMatcher("case_clause[consequence]"),
   ),
   argumentOrParameter: cascadingMatcher(
     argumentMatcher("parameters", "argument_list"),

--- a/src/languages/scala.ts
+++ b/src/languages/scala.ts
@@ -62,9 +62,12 @@ const nodeMatchers: Partial<
     ],
     [":"],
   ),
-  value: leadingMatcher(
-    ["*[value]", "*[default_value]", "type_definition[type]"],
-    ["="],
+  value: cascadingMatcher(
+    patternMatcher("case_clause[body]"),
+    leadingMatcher(
+      ["*[value]", "*[default_value]", "type_definition[type]"],
+      ["="],
+    ),
   ),
   condition: conditionMatcher("*[condition]"),
 

--- a/src/test/suite/fixtures/recorded/languages/java/clearValue4.yml
+++ b/src/test/suite/fixtures/recorded/languages/java/clearValue4.yml
@@ -1,0 +1,43 @@
+languageId: java
+command:
+  spokenForm: clear value
+  version: 3
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: value}
+  usePrePhraseSnapshot: true
+  action: {name: clearAndSetSelection}
+initialState:
+  documentContents: |-
+    class Aaa {
+      static void bbb() {
+        switch ("0") {
+          case ("0"):
+            break;
+          case ("1"):
+            break;
+        }
+      }
+    }
+  selections:
+    - anchor: {line: 3, character: 9}
+      active: {line: 3, character: 9}
+  marks: {}
+finalState:
+  documentContents: |-
+    class Aaa {
+      static void bbb() {
+        switch ("0") {
+          case ("0"):
+            
+          case ("1"):
+            break;
+        }
+      }
+    }
+  selections:
+    - anchor: {line: 4, character: 8}
+      active: {line: 4, character: 8}
+fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: [{type: containingScope, scopeType: {type: value}}]}]

--- a/src/test/suite/fixtures/recorded/languages/java/clearValue5.yml
+++ b/src/test/suite/fixtures/recorded/languages/java/clearValue5.yml
@@ -1,0 +1,43 @@
+languageId: java
+command:
+  spokenForm: clear value
+  version: 3
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: value}
+  usePrePhraseSnapshot: true
+  action: {name: clearAndSetSelection}
+initialState:
+  documentContents: |-
+    class Aaa {
+      static void bbb() {
+        switch ("0") {
+          case ("0"):
+            break;
+          case ("1"):
+            break;
+        }
+      }
+    }
+  selections:
+    - anchor: {line: 4, character: 11}
+      active: {line: 4, character: 11}
+  marks: {}
+finalState:
+  documentContents: |-
+    class Aaa {
+      static void bbb() {
+        switch ("0") {
+          case ("0"):
+            
+          case ("1"):
+            break;
+        }
+      }
+    }
+  selections:
+    - anchor: {line: 4, character: 8}
+      active: {line: 4, character: 8}
+fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: [{type: containingScope, scopeType: {type: value}}]}]

--- a/src/test/suite/fixtures/recorded/languages/java/clearValue6.yml
+++ b/src/test/suite/fixtures/recorded/languages/java/clearValue6.yml
@@ -1,0 +1,41 @@
+languageId: java
+command:
+  spokenForm: clear value
+  version: 3
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: value}
+  usePrePhraseSnapshot: true
+  action: {name: clearAndSetSelection}
+initialState:
+  documentContents: |-
+    class Aaa {
+      static void bbb() {
+        var s =
+          switch ("0") {
+            case "0" -> "zero";
+            case "1" -> "one";
+          };
+      }
+    }
+  selections:
+    - anchor: {line: 4, character: 14}
+      active: {line: 4, character: 14}
+  marks: {}
+finalState:
+  documentContents: |-
+    class Aaa {
+      static void bbb() {
+        var s =
+          switch ("0") {
+            case "0" -> 
+            case "1" -> "one";
+          };
+      }
+    }
+  selections:
+    - anchor: {line: 4, character: 20}
+      active: {line: 4, character: 20}
+fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: [{type: containingScope, scopeType: {type: value}}]}]

--- a/src/test/suite/fixtures/recorded/languages/java/clearValue7.yml
+++ b/src/test/suite/fixtures/recorded/languages/java/clearValue7.yml
@@ -1,0 +1,41 @@
+languageId: java
+command:
+  spokenForm: clear value
+  version: 3
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: value}
+  usePrePhraseSnapshot: true
+  action: {name: clearAndSetSelection}
+initialState:
+  documentContents: |-
+    class Aaa {
+      static void bbb() {
+        var s =
+          switch ("0") {
+            case "0" -> "zero";
+            case "1" -> "one";
+          };
+      }
+    }
+  selections:
+    - anchor: {line: 4, character: 23}
+      active: {line: 4, character: 23}
+  marks: {}
+finalState:
+  documentContents: |-
+    class Aaa {
+      static void bbb() {
+        var s =
+          switch ("0") {
+            case "0" -> 
+            case "1" -> "one";
+          };
+      }
+    }
+  selections:
+    - anchor: {line: 4, character: 20}
+      active: {line: 4, character: 20}
+fullTargets: [{type: primitive, mark: {type: cursor}, modifiers: [{type: containingScope, scopeType: {type: value}}]}]

--- a/src/test/suite/fixtures/recorded/languages/python/changeValueBlueEach.yml
+++ b/src/test/suite/fixtures/recorded/languages/python/changeValueBlueEach.yml
@@ -1,0 +1,48 @@
+languageId: python
+command:
+  spokenForm: change value blue each
+  version: 2
+  targets:
+    - type: primitive
+      mark: {type: decoratedSymbol, symbolColor: blue, character: e}
+      modifiers:
+        - type: containingScope
+          scopeType: {type: value}
+  usePrePhraseSnapshot: true
+  action: {name: clearAndSetSelection}
+initialState:
+  documentContents: |
+    match command.split():
+        case ["quit"]:
+            print("quit")
+        case ["go", direction] | []:
+            print("going", direction)
+        case ["drop", *objects]:
+            print("drop", objects)
+        case _:
+            print(f"Sorry, I couldn't understand {command!r}")
+  selections:
+    - anchor: {line: 9, character: 0}
+      active: {line: 9, character: 0}
+  marks:
+    blue.e:
+      start: {line: 1, character: 4}
+      end: {line: 1, character: 8}
+finalState:
+  documentContents: |
+    match command.split():
+        case ["quit"]:
+            
+        case ["go", direction] | []:
+            print("going", direction)
+        case ["drop", *objects]:
+            print("drop", objects)
+        case _:
+            print(f"Sorry, I couldn't understand {command!r}")
+  selections:
+    - anchor: {line: 2, character: 8}
+      active: {line: 2, character: 8}
+  thatMark:
+    - anchor: {line: 2, character: 8}
+      active: {line: 2, character: 8}
+fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: blue, character: e}, modifiers: [{type: containingScope, scopeType: {type: value}}]}]

--- a/src/test/suite/fixtures/recorded/languages/python/changeValueCap2.yml
+++ b/src/test/suite/fixtures/recorded/languages/python/changeValueCap2.yml
@@ -1,0 +1,48 @@
+languageId: python
+command:
+  spokenForm: change value cap
+  version: 2
+  targets:
+    - type: primitive
+      mark: {type: decoratedSymbol, symbolColor: default, character: c}
+      modifiers:
+        - type: containingScope
+          scopeType: {type: value}
+  usePrePhraseSnapshot: true
+  action: {name: clearAndSetSelection}
+initialState:
+  documentContents: |
+    match command.split():
+        case ["quit"]:
+            print("quit")
+        case ["go", direction] | []:
+            print("going", direction)
+        case ["drop", *objects]:
+            print("drop", objects)
+        case _:
+            print(f"Sorry, I couldn't understand {command!r}")
+  selections:
+    - anchor: {line: 9, character: 0}
+      active: {line: 9, character: 0}
+  marks:
+    default.c:
+      start: {line: 5, character: 4}
+      end: {line: 5, character: 8}
+finalState:
+  documentContents: |
+    match command.split():
+        case ["quit"]:
+            print("quit")
+        case ["go", direction] | []:
+            print("going", direction)
+        case ["drop", *objects]:
+            
+        case _:
+            print(f"Sorry, I couldn't understand {command!r}")
+  selections:
+    - anchor: {line: 6, character: 8}
+      active: {line: 6, character: 8}
+  thatMark:
+    - anchor: {line: 6, character: 8}
+      active: {line: 6, character: 8}
+fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: c}, modifiers: [{type: containingScope, scopeType: {type: value}}]}]

--- a/src/test/suite/fixtures/recorded/languages/rust/changeValueSun.yml
+++ b/src/test/suite/fixtures/recorded/languages/rust/changeValueSun.yml
@@ -1,0 +1,38 @@
+languageId: rust
+command:
+  spokenForm: change value sun
+  version: 2
+  targets:
+    - type: primitive
+      mark: {type: decoratedSymbol, symbolColor: default, character: s}
+      modifiers:
+        - type: containingScope
+          scopeType: {type: value}
+  usePrePhraseSnapshot: true
+  action: {name: clearAndSetSelection}
+initialState:
+  documentContents: |
+    match user {
+        User { first_name: "John" } => {},
+        User { first_name } if first_name.starts_with("P") => {}
+    }
+  selections:
+    - anchor: {line: 2, character: 27}
+      active: {line: 2, character: 54}
+  marks:
+    default.s:
+      start: {line: 1, character: 4}
+      end: {line: 1, character: 8}
+finalState:
+  documentContents: |
+    match user {
+        User { first_name: "John" } => ,
+        User { first_name } if first_name.starts_with("P") => {}
+    }
+  selections:
+    - anchor: {line: 1, character: 35}
+      active: {line: 1, character: 35}
+  thatMark:
+    - anchor: {line: 1, character: 35}
+      active: {line: 1, character: 35}
+fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: s}, modifiers: [{type: containingScope, scopeType: {type: value}}]}]

--- a/src/test/suite/fixtures/recorded/languages/scala/changeValueZero.yml
+++ b/src/test/suite/fixtures/recorded/languages/scala/changeValueZero.yml
@@ -1,0 +1,42 @@
+languageId: scala
+command:
+  spokenForm: change value zero
+  version: 2
+  targets:
+    - type: primitive
+      mark: {type: decoratedSymbol, symbolColor: default, character: '0'}
+      modifiers:
+        - type: containingScope
+          scopeType: {type: value}
+  usePrePhraseSnapshot: true
+  action: {name: clearAndSetSelection}
+initialState:
+  documentContents: |
+    def matchTest(x: Int): String = x match {
+      case 0 => "zero"
+      case 1 => "one"
+      case 2 => "two"
+      case _ => "other"
+    }
+  selections:
+    - anchor: {line: 6, character: 0}
+      active: {line: 6, character: 0}
+  marks:
+    default.0:
+      start: {line: 1, character: 7}
+      end: {line: 1, character: 8}
+finalState:
+  documentContents: |
+    def matchTest(x: Int): String = x match {
+      case 0 => 
+      case 1 => "one"
+      case 2 => "two"
+      case _ => "other"
+    }
+  selections:
+    - anchor: {line: 1, character: 12}
+      active: {line: 1, character: 12}
+  thatMark:
+    - anchor: {line: 1, character: 12}
+      active: {line: 1, character: 12}
+fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: '0'}, modifiers: [{type: containingScope, scopeType: {type: value}}]}]

--- a/src/test/suite/fixtures/recorded/languages/scala/changeValueZero2.yml
+++ b/src/test/suite/fixtures/recorded/languages/scala/changeValueZero2.yml
@@ -1,0 +1,42 @@
+languageId: scala
+command:
+  spokenForm: change value zero
+  version: 2
+  targets:
+    - type: primitive
+      mark: {type: decoratedSymbol, symbolColor: default, character: '0'}
+      modifiers:
+        - type: containingScope
+          scopeType: {type: value}
+  usePrePhraseSnapshot: true
+  action: {name: clearAndSetSelection}
+initialState:
+  documentContents: |
+    def matchTest(x: Int): String = x match {
+      case 0 => "zero"
+      case 1 => "one"
+      case 2 => "two"
+      case _ => "other"
+    }
+  selections:
+    - anchor: {line: 3, character: 2}
+      active: {line: 4, character: 2}
+  marks:
+    default.0:
+      start: {line: 1, character: 7}
+      end: {line: 1, character: 8}
+finalState:
+  documentContents: |
+    def matchTest(x: Int): String = x match {
+      case 0 => 
+      case 1 => "one"
+      case 2 => "two"
+      case _ => "other"
+    }
+  selections:
+    - anchor: {line: 1, character: 12}
+      active: {line: 1, character: 12}
+  thatMark:
+    - anchor: {line: 1, character: 12}
+      active: {line: 1, character: 12}
+fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: '0'}, modifiers: [{type: containingScope, scopeType: {type: value}}]}]


### PR DESCRIPTION
- Closes https://github.com/cursorless-dev/cursorless/issues/1175
- Split from https://github.com/cursorless-dev/cursorless/pull/831

## Checklist

- [ ] Typescript
- [ ] C++
- [ ] C#
- [x] Java
- [x] Python
- [ ] Rust
- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet

Co-authored-by: Michael Doronin <warrior2031@mail.ru>