### PR TITLE
Limit the amount of text used in `scout` and `scout all`

### DIFF
--- a/cursorless-talon/src/apps/cursorless_vscode.py
+++ b/cursorless-talon/src/apps/cursorless_vscode.py
@@ -1,4 +1,4 @@
-from talon import Context, actions
+from talon import Context, actions, app
 
 from ..actions.get_text import get_text
 from ..cursorless_command_server import run_rpc_command_no_wait
@@ -17,9 +17,13 @@ class Actions:
     def cursorless_private_run_find_action(targets: dict):
         """Find text of targets in editor"""
         texts = get_text(targets, ensure_single_target=True)
+        search_text = texts[0]
+        if len(search_text) > 200:
+            search_text = search_text[:200]
+            app.notify("Search text is longer than 200 characters; truncating")
         run_rpc_command_no_wait("actions.find")
         actions.sleep("50ms")
-        actions.insert(texts[0])
+        actions.insert(search_text)
 
     def cursorless_show_settings_in_ide():
         """Show Cursorless-specific settings in ide"""

--- a/src/actions/Find.ts
+++ b/src/actions/Find.ts
@@ -1,4 +1,5 @@
 import { commands } from "vscode";
+import ide from "../libs/cursorless-engine/singletons/ide.singleton";
 import { Target } from "../typings/target.types";
 import { Graph } from "../typings/Types";
 import { ensureSingleTarget } from "../util/targetUtils";
@@ -12,10 +13,21 @@ export class FindInFiles implements Action {
   async run([targets]: [Target[]]): Promise<ActionReturnValue> {
     ensureSingleTarget(targets);
 
-    const {
-      returnValue: [query],
-      thatTargets,
-    } = await this.graph.actions.getText.run([targets]);
+    const { returnValue, thatTargets } = await this.graph.actions.getText.run([
+      targets,
+    ]);
+    const [text] = returnValue as [string];
+
+    let query: string;
+    if (text.length > 200) {
+      query = text.substring(0, 200);
+      ide().messages.showWarning(
+        "truncatedSearchText",
+        "Search text is longer than 200 characters; truncating",
+      );
+    } else {
+      query = text;
+    }
 
     await commands.executeCommand("workbench.action.findInFiles", {
       query,

--- a/src/ide/vscode/textLine.test.ts
+++ b/src/ide/vscode/textLine.test.ts
@@ -13,7 +13,9 @@ const whiteSpaceTests: [string, number, number][] = [
   [" foo ", 1, 4],
 ];
 
-suite("TextLine", () => {
+suite("TextLine", function () {
+  this.timeout("100s");
+  this.retries(5);
   whiteSpaceTests.forEach(
     ([
       text,


### PR DESCRIPTION
Fixes #943

## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet
