### PR TITLE
Upgrade typescript and use it for vscode TS server

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -22,5 +22,7 @@
 		"pojo",
 		"subword"
 	],
-	"files.eol": "\n"
+	"files.eol": "\n",
+	"typescript.enablePromptUseWorkspaceTsdk": true,
+	"typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/cursorless-nx/package.json
+++ b/cursorless-nx/package.json
@@ -45,7 +45,7 @@
 		"react-test-renderer": "18.1.0",
 		"ts-jest": "27.1.4",
 		"ts-node": "10.8.2",
-		"typescript": "4.7.4",
+		"typescript": "4.8.3",
 		"typescript-plugin-css-modules": "^3.4.0"
 	},
 	"dependencies": {

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -38,11 +38,11 @@
 	},
 	"devDependencies": {
 		"docusaurus-plugin-typedoc": "^0.17.2",
-		"typedoc": "^0.22.10",
-		"typedoc-plugin-markdown": "^3.11.9",
-		"typedoc-plugin-mdn-links": "^1.0.4",
-		"typedoc-plugin-missing-exports": "^0.22.6",
-		"typedoc-plugin-rename-defaults": "^0.4.0",
-		"typescript": "4.6.3"
+		"typedoc": "^0.23.14",
+		"typedoc-plugin-markdown": "^3.13.6",
+		"typedoc-plugin-mdn-links": "^1.0.6",
+		"typedoc-plugin-missing-exports": "^0.23.0",
+		"typedoc-plugin-rename-defaults": "^0.6.4",
+		"typescript": "^4.8.3"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -762,8 +762,8 @@
 		"prettier": "2.7.1",
 		"semver": "^7.3.7",
 		"sinon": "^11.1.1",
-		"ts-unused-exports": "^8.0.0",
-		"typescript": "4.6.3"
+		"ts-unused-exports": "8.0.0",
+		"typescript": "^4.8.3"
 	},
 	"dependencies": {
 		"immer": "^9.0.15",


### PR DESCRIPTION
- Factored out of https://github.com/cursorless-dev/cursorless/pull/942
- Closes https://github.com/cursorless-dev/cursorless/issues/1044

## Checklist

- [ ] Make sure this PR doesn't break doc links; see https://github.com/cursorless-dev/cursorless/pull/942#discussion_r968556276
- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet
