### PR TITLE
workflows: Run CI on stacked PRs

### DIFF
--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -2,7 +2,6 @@ name: Test docs
 
 on:
   pull_request:
-    branches: main
     types: [opened, synchronize, reopened]
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
   pull_request:
-    branches: main
     types: [opened, synchronize, reopened]
 
 jobs:


### PR DESCRIPTION
I don't think there's really any reason to not run tests on stacked PRs.

This removes the PR base branch restriction on the test workflows.

## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet
