### PR TITLE
Fix modal keyboard interface broken by #1094

### DIFF
--- a/src/apps/cursorless-vscode-e2e/suite/keyboard/basic.test.ts
+++ b/src/apps/cursorless-vscode-e2e/suite/keyboard/basic.test.ts
@@ -6,8 +6,14 @@ import { endToEndTestSetup, sleepWithBackoff } from "../../endToEndTestSetup";
 suite("Basic keyboard test", async function () {
   endToEndTestSetup(this);
 
+  this.afterEach(async () => {
+    await vscode.commands.executeCommand("cursorless.keyboard.modal.modeOff");
+  });
+
   test("Don't take keyboard control on startup", () => checkKeyboardStartup());
   test("Basic keyboard test", () => basic());
+  test("Check that entering and leaving mode is no-op", () =>
+    enterAndLeaveIsNoOp());
 });
 
 async function checkKeyboardStartup() {
@@ -46,6 +52,21 @@ async function basic() {
   await typeText("a");
 
   assert.equal(editor.document.getText().trim(), "a");
+}
+
+async function enterAndLeaveIsNoOp() {
+  const editor = await openNewEditor("hello");
+
+  const originalSelection = new vscode.Selection(0, 0, 0, 0);
+  editor.selection = originalSelection;
+
+  await vscode.commands.executeCommand("cursorless.keyboard.modal.modeOn");
+
+  assert.isTrue(editor.selection.isEqual(originalSelection));
+
+  await vscode.commands.executeCommand("cursorless.keyboard.modal.modeOff");
+
+  assert.isTrue(editor.selection.isEqual(originalSelection));
 }
 
 async function typeText(text: string) {

--- a/src/keyboard/KeyboardCommandsTargeted.ts
+++ b/src/keyboard/KeyboardCommandsTargeted.ts
@@ -247,7 +247,7 @@ export default class KeyboardCommandsTargeted {
   targetSelection = () =>
     executeCursorlessCommand({
       action: {
-        name: "setSelection",
+        name: "highlight",
       },
       targets: [
         {
@@ -255,6 +255,7 @@ export default class KeyboardCommandsTargeted {
           mark: {
             type: "cursor",
           },
+          modifiers: [{ type: "toRawSelection" }],
         },
       ],
     });


### PR DESCRIPTION
We were using the equivalent of "take this" to set the target to be the current selection when you enter cursorless keyboard mode, but that obviously broke when we made "take this" refer to token.  This PR effectively changes the command we use to `"highlight just this"`

## Checklist

- [x] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet
