### PR TITLE
Fix `"pour"` across split

### DIFF
--- a/src/apps/cursorless-vscode-e2e/suite/fold.test.ts
+++ b/src/apps/cursorless-vscode-e2e/suite/fold.test.ts
@@ -12,7 +12,9 @@ suite("fold", async function () {
 });
 
 async function foldMade() {
-  const editor = await openNewEditor("function myFunk() {\n\n}", "typescript");
+  const editor = await openNewEditor("function myFunk() {\n\n}", {
+    languageId: "typescript",
+  });
 
   await runCursorlessCommand({
     version: 1,
@@ -35,7 +37,9 @@ async function foldMade() {
 }
 
 async function unfoldMade() {
-  const editor = await openNewEditor("function myFunk() {\n\n}", "typescript");
+  const editor = await openNewEditor("function myFunk() {\n\n}", {
+    languageId: "typescript",
+  });
   await vscode.commands.executeCommand("editor.fold", {
     selectionLines: [0],
   });

--- a/src/apps/cursorless-vscode-e2e/suite/followLink.test.ts
+++ b/src/apps/cursorless-vscode-e2e/suite/followLink.test.ts
@@ -14,10 +14,9 @@ suite("followLink", async function () {
 });
 
 async function followDefinition() {
-  const editor = await openNewEditor(
-    "const foo = 'hello';\nconst bar = foo;",
-    "typescript",
-  );
+  const editor = await openNewEditor("const foo = 'hello';\nconst bar = foo;", {
+    languageId: "typescript",
+  });
   await vscode.commands.executeCommand("revealLine", {
     lineNumber: 1,
     at: "top",

--- a/src/apps/cursorless-vscode-e2e/suite/keyboard/basic.test.ts
+++ b/src/apps/cursorless-vscode-e2e/suite/keyboard/basic.test.ts
@@ -29,7 +29,9 @@ async function checkKeyboardStartup() {
 async function basic() {
   const { graph } = (await getCursorlessApi()).testHelpers!;
 
-  const editor = await openNewEditor("function foo() {}\n", "typescript");
+  const editor = await openNewEditor("function foo() {}\n", {
+    languageId: "typescript",
+  });
   await graph.hatTokenMap.addDecorations();
 
   editor.selection = new vscode.Selection(1, 0, 1, 0);

--- a/src/apps/cursorless-vscode-e2e/suite/pourAcrossSplit.test.ts
+++ b/src/apps/cursorless-vscode-e2e/suite/pourAcrossSplit.test.ts
@@ -1,0 +1,38 @@
+import { getCursorlessApi, openNewEditor } from "@cursorless/vscode-common";
+import * as assert from "assert";
+import { endToEndTestSetup } from "../endToEndTestSetup";
+import { runCursorlessCommand } from "../runCommand";
+
+suite("Pour across split", async function () {
+  endToEndTestSetup(this);
+
+  test("Pour across split", runTest);
+});
+
+async function runTest() {
+  const { graph } = (await getCursorlessApi()).testHelpers!;
+
+  const { document: document1 } = await openNewEditor("hello world");
+  const { document: document2 } = await openNewEditor("", { openBeside: true });
+
+  await graph.hatTokenMap.addDecorations();
+
+  await runCursorlessCommand({
+    version: 4,
+    action: { name: "editNewLineAfter" },
+    targets: [
+      {
+        type: "primitive",
+        mark: {
+          type: "decoratedSymbol",
+          symbolColor: "default",
+          character: "h",
+        },
+      },
+    ],
+    usePrePhraseSnapshot: false,
+  });
+
+  assert.deepStrictEqual(document1.getText(), "hello world\n");
+  assert.deepStrictEqual(document2.getText(), "");
+}

--- a/src/apps/cursorless-vscode-e2e/suite/recorded.test.ts
+++ b/src/apps/cursorless-vscode-e2e/suite/recorded.test.ts
@@ -68,10 +68,9 @@ async function runTest(file: string, spyIde: SpyIDE) {
 
   graph.editStyles.testDecorations = [];
 
-  const editor = await openNewEditor(
-    fixture.initialState.documentContents,
-    fixture.languageId,
-  );
+  const editor = await openNewEditor(fixture.initialState.documentContents, {
+    languageId: fixture.languageId,
+  });
 
   // Override any user settings and make sure tests run with default tabs.
   editor.options = DEFAULT_TEXT_EDITOR_OPTIONS_FOR_TEST;

--- a/src/ide/vscode/VscodeTextEditorImpl.ts
+++ b/src/ide/vscode/VscodeTextEditorImpl.ts
@@ -156,6 +156,7 @@ export class VscodeTextEditorImpl implements EditableTextEditor {
     if (ranges != null) {
       this.selections = ranges.map((range) => range.toSelection(false));
     }
+    await this.focus();
     await vscode.commands.executeCommand("editor.action.insertLineAfter");
   }
 

--- a/src/libs/vscode-common/testUtil/openNewEditor.ts
+++ b/src/libs/vscode-common/testUtil/openNewEditor.ts
@@ -1,20 +1,30 @@
 import { getParseTreeApi } from "@cursorless/vscode-common";
 import * as vscode from "vscode";
 
+interface NewEditorOptions {
+  languageId?: string;
+  openBeside?: boolean;
+}
+
 export async function openNewEditor(
   content: string,
-  language: string = "plaintext",
+  { languageId = "plaintext", openBeside = false }: NewEditorOptions = {},
 ) {
-  await vscode.commands.executeCommand("workbench.action.closeAllEditors");
+  if (!openBeside) {
+    await vscode.commands.executeCommand("workbench.action.closeAllEditors");
+  }
 
   const document = await vscode.workspace.openTextDocument({
-    language,
+    language: languageId,
     content,
   });
 
-  await (await getParseTreeApi()).loadLanguage(language);
+  await (await getParseTreeApi()).loadLanguage(languageId);
 
-  const editor = await vscode.window.showTextDocument(document);
+  const editor = await vscode.window.showTextDocument(
+    document,
+    openBeside ? vscode.ViewColumn.Beside : undefined,
+  );
 
   const eol = content.includes("\r\n")
     ? vscode.EndOfLine.CRLF


### PR DESCRIPTION
- This one most likely broke in #1143, but I'm not certain

## Checklist

- [x] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet
