### PR TITLE
Fix long notebook cell jumping

### DIFF
--- a/src/ide/vscode/VscodeFocusEditor.ts
+++ b/src/ide/vscode/VscodeFocusEditor.ts
@@ -94,7 +94,6 @@ async function focusNotebookCell(editor: VscodeTextEditorImpl) {
     }),
   ];
   desiredNotebookEditor.selections = desiredSelections;
-  desiredNotebookEditor.revealRange(desiredSelections[0]);
 
   // Issue a command to tell VSCode to focus the cell input editor
   // NB: We don't issue the command if it's already focused, because it turns


### PR DESCRIPTION
- Fixes #981

Just doesn't bother with notebook scrolling, as the regular `revealLine` on the cell's `TextEditor` seems to be good enough

## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet
