### PR TITLE
Add xaml support

### DIFF
--- a/cursorless-talon/src/modifiers/scopes.py
+++ b/cursorless-talon/src/modifiers/scopes.py
@@ -51,7 +51,7 @@ scope_types = {
     "value": "value",
     "condition": "condition",
     "unit": "unit",
-    #  XML, JSX
+    #  XML, JSX, XAML
     "element": "xmlElement",
     "tags": "xmlBothTags",
     "start tag": "xmlStartTag",

--- a/src/languages/getNodeMatcher.ts
+++ b/src/languages/getNodeMatcher.ts
@@ -77,6 +77,7 @@ const languageMatchers: Record<
   typescript,
   typescriptreact: typescript,
   xml: html,
+  xaml: html,
 };
 
 function matcherIncludeSiblings(matcher: NodeMatcher): NodeMatcher {

--- a/src/languages/getTextFragmentExtractor.ts
+++ b/src/languages/getTextFragmentExtractor.ts
@@ -193,4 +193,8 @@ const textFragmentExtractors: Record<
     "xml",
     htmlStringTextFragmentExtractor,
   ),
+  xaml: constructDefaultTextFragmentExtractor(
+    "xaml",
+    htmlStringTextFragmentExtractor,
+  ),
 };

--- a/src/libs/cursorless-engine/languages/constants.ts
+++ b/src/libs/cursorless-engine/languages/constants.ts
@@ -23,6 +23,7 @@ export const supportedLanguageIds = [
   "typescript",
   "typescriptreact",
   "xml",
+  "xaml",
 ] as const;
 
 /**


### PR DESCRIPTION
I have also got a pull request to update the visual studio code  parse tree  to add support for XAML.  I guess before something like this can be merged  it would need to be merged  first.