### PR TITLE
fix broken link syntax in readme

### DIFF
--- a/docs/contributing/CONTRIBUTING.md
+++ b/docs/contributing/CONTRIBUTING.md
@@ -12,7 +12,7 @@ extension](#running--testing-extension-locally), you may want to check out the
 - [Git](https://git-scm.com/)
 - [Node.js](https://nodejs.org/en/)
 - [yarn](https://yarnpkg.com/)
-- [VSCode][https://code.visualstudio.com/]; minimum version for local development is 1.72.0 in order to support settings profiles for sandboxed development. Please file an issue if that is a problem.
+- [VSCode](https://code.visualstudio.com/); minimum version for local development is 1.72.0 in order to support settings profiles for sandboxed development. Please file an issue if that is a problem.
 
 ### Steps
 


### PR DESCRIPTION
## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet
