### PR TITLE
Add `merge_group` triggers

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,6 +17,8 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches: ["main"]
+  merge_group:
+    branches: [main]
   schedule:
     - cron: "34 12 * * 5"
 

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -3,6 +3,8 @@ name: Test docs
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+  merge_group:
+    branches: [main]
 
 jobs:
   test-docs-build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,8 @@ on:
       - main
   pull_request:
     types: [opened, synchronize, reopened]
+  merge_group:
+    branches: [main]
 
 jobs:
   test:


### PR DESCRIPTION
See https://github.blog/changelog/2023-02-08-pull-request-merge-queue-public-beta/
## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet
