### PR TITLE
Change `"highlight nothing"` to target all editors

### DIFF
--- a/src/actions/Highlight.ts
+++ b/src/actions/Highlight.ts
@@ -22,17 +22,13 @@ export default class Highlight implements Action {
     }
 
     if (targets.length === 0) {
-      // Special case to clear highlights for the active editor when user says
+      // Special case to clear highlights for all editors when user says
       // "highlight nothing"
-      const { activeTextEditor } = ide();
-
-      if (activeTextEditor == null) {
-        throw Error(
-          "The `highlight nothing` command requires an active text editor",
-        );
-      }
-
-      await ide().setHighlightRanges(highlightId, activeTextEditor, []);
+      await Promise.all(
+        ide().visibleTextEditors.map((editor) =>
+          ide().setHighlightRanges(highlightId, editor, []),
+        ),
+      );
     } else {
       await runOnTargetsForEachEditor(targets, (editor, targets) =>
         ide().setHighlightRanges(


### PR DESCRIPTION
The new behaviour broke my video recorder, because it didn't clear highlights if I targeted something on other side of screen

## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet
