### PR TITLE
Remove vscode references from test case recorder

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,6 +146,15 @@
           "light": "#60daff7a",
           "highContrast": "#60daff7a"
         }
+      },
+      {
+        "id": "cursorless.timingCalibrationBackground",
+        "description": "Background color to use for calibrating timing when recording a video",
+        "defaults": {
+          "dark": "#230026",
+          "light": "#230026",
+          "highContrast": "#230026"
+        }
       }
     ],
     "configurationDefaults": {

--- a/src/core/commandRunner/CommandRunner.ts
+++ b/src/core/commandRunner/CommandRunner.ts
@@ -153,6 +153,7 @@ export default class CommandRunner {
     } catch (e) {
       const err = e as Error;
       console.error(err.stack);
+      await this.graph.testCaseRecorder.commandErrorHook(err);
       throw e;
     } finally {
       if (this.graph.testCaseRecorder.isActive()) {

--- a/src/ide/vscode/VscodeHighlights.ts
+++ b/src/ide/vscode/VscodeHighlights.ts
@@ -14,6 +14,10 @@ import { VscodeTextEditorImpl } from "./VscodeTextEditorImpl";
 export enum HighlightStyle {
   highlight0 = "highlight0",
   highlight1 = "highlight1",
+  /**
+   * Used for calibrating timing when recording a video
+   */
+  timingCalibration = "timingCalibration",
 }
 
 export type VscodeStyle = FlashStyle | HighlightStyle;

--- a/src/ide/vscode/VscodeIDE.ts
+++ b/src/ide/vscode/VscodeIDE.ts
@@ -17,6 +17,7 @@ import type {
   IDE,
   RunMode,
 } from "../../libs/common/ide/types/ide.types";
+import { QuickPickOptions } from "../../libs/common/ide/types/QuickPickOptions";
 import {
   fromVscodeRange,
   fromVscodeSelection,
@@ -31,6 +32,7 @@ import VscodeGlobalState from "./VscodeGlobalState";
 import VscodeHighlights, { HighlightStyle } from "./VscodeHighlights";
 import VscodeMessages from "./VscodeMessages";
 import { vscodeRunMode } from "./VscodeRunMode";
+import { vscodeShowQuickPick } from "./vscodeShowQuickPick";
 import { VscodeTextDocumentImpl } from "./VscodeTextDocumentImpl";
 import { VscodeTextEditorImpl } from "./VscodeTextEditorImpl";
 
@@ -55,6 +57,13 @@ export default class VscodeIDE implements IDE {
     this.capabilities = new VscodeCapabilities();
     this.hats = new VscodeHats(this, extensionContext);
     this.editorMap = new WeakMap<vscode.TextEditor, VscodeTextEditorImpl>();
+  }
+
+  async showQuickPick(
+    items: readonly string[],
+    options?: QuickPickOptions,
+  ): Promise<string | undefined> {
+    return await vscodeShowQuickPick(items, options);
   }
 
   async init() {

--- a/src/ide/vscode/vscodeShowQuickPick.ts
+++ b/src/ide/vscode/vscodeShowQuickPick.ts
@@ -1,0 +1,82 @@
+import * as vscode from "vscode";
+import {
+  QuickPickOptions,
+  UnknownValuesOptions,
+} from "../../libs/common/ide/types/QuickPickOptions";
+
+export async function vscodeShowQuickPick(
+  items: readonly string[],
+  options: QuickPickOptions | undefined,
+) {
+  if (options?.unknownValues == null) {
+    return await vscode.window.showQuickPick(items, options);
+  }
+
+  const { unknownValues, ...rest } = options;
+  return await showQuickPickAllowingUnknown(items, unknownValues, rest);
+}
+
+interface CustomQuickPickItem extends vscode.QuickPickItem {
+  value: string;
+}
+
+const DEFAULT_NEW_VALUE_TEMPLATE = "Add new value '{}' →";
+
+/**
+ * Show a quick pick that allows the user to enter a new value.  We do this by
+ * adding a new dummy item to the list as the user is typing.  If they select
+ * the dummy item, we return the value they typed.  It is up to the client to
+ * detect that it is an unknown value and handle that case.
+ *
+ * Based on https://stackoverflow.com/a/69842249
+ * @param items
+ * @param options
+ */
+function showQuickPickAllowingUnknown(
+  choices: readonly string[],
+  unknownValues: UnknownValuesOptions,
+  options: vscode.QuickPickOptions,
+) {
+  return new Promise<string | undefined>((resolve, _reject) => {
+    const quickPick = vscode.window.createQuickPick<CustomQuickPickItem>();
+    const quickPickItems = choices.map((choice) => ({
+      label: choice,
+      value: choice,
+    }));
+    quickPick.items = quickPickItems;
+
+    if (options.title != null) {
+      quickPick.title = options.title;
+    }
+
+    const { newValueTemplate = DEFAULT_NEW_VALUE_TEMPLATE } = unknownValues;
+
+    quickPick.onDidChangeValue(() => {
+      quickPick.items = [
+        ...quickPickItems,
+
+        // INJECT user values into proposed values
+        ...(choices.includes(quickPick.value)
+          ? []
+          : [
+              {
+                label: newValueTemplate.replace("{}", quickPick.value),
+                value: quickPick.value,
+              },
+            ]),
+      ];
+    });
+
+    quickPick.onDidAccept(() => {
+      const selection = quickPick.activeItems[0];
+      resolve(selection.value);
+      quickPick.hide();
+    });
+
+    quickPick.onDidHide(() => {
+      resolve(undefined);
+    });
+
+    quickPick.show();
+  });
+}

--- a/src/libs/common/ide/PassthroughIDEBase.ts
+++ b/src/libs/common/ide/PassthroughIDEBase.ts
@@ -13,6 +13,7 @@ import { FlashDescriptor } from "./types/FlashDescriptor";
 import { Hats } from "./types/Hats";
 import { Disposable, IDE, RunMode, WorkspaceFolder } from "./types/ide.types";
 import { Messages } from "./types/Messages";
+import { QuickPickOptions } from "./types/QuickPickOptions";
 import { State } from "./types/State";
 
 export default class PassthroughIDEBase implements IDE {
@@ -137,6 +138,13 @@ export default class PassthroughIDEBase implements IDE {
 
   public openTextDocument(path: string): Promise<TextEditor> {
     return this.original.openTextDocument(path);
+  }
+
+  public showQuickPick(
+    items: readonly string[],
+    options?: QuickPickOptions,
+  ): Promise<string | undefined> {
+    return this.original.showQuickPick(items, options);
   }
 
   public showInputBox(options?: any): Promise<string | undefined> {

--- a/src/libs/common/ide/fake/FakeIDE.ts
+++ b/src/libs/common/ide/fake/FakeIDE.ts
@@ -15,6 +15,7 @@ import type {
   RunMode,
   WorkspaceFolder,
 } from "../types/ide.types";
+import { QuickPickOptions } from "../types/QuickPickOptions";
 import { FakeCapabilities } from "./FakeCapabilities";
 import FakeClipboard from "./FakeClipboard";
 import FakeConfiguration from "./FakeConfiguration";
@@ -90,6 +91,13 @@ export default class FakeIDE implements IDE {
 
   public openTextDocument(_path: string): Promise<TextEditor> {
     throw Error("Not implemented");
+  }
+
+  public showQuickPick(
+    _items: readonly string[],
+    _options?: QuickPickOptions,
+  ): Promise<string | undefined> {
+    throw new Error("Method not implemented.");
   }
 
   public showInputBox(_options?: any): Promise<string | undefined> {

--- a/src/libs/common/ide/types/QuickPickOptions.ts
+++ b/src/libs/common/ide/types/QuickPickOptions.ts
@@ -1,0 +1,33 @@
+export interface UnknownValuesOptions {
+  allowed: true;
+
+  /**
+   * An optional template to use when displaying the new option to the user. The
+   * template must include `{}` as a substring, which will be replaced with the
+   * user's input when displaying an option to add the unknown item.
+   *
+   * For example:
+   *
+   * "Add new value '{}' →"
+   *
+   * In this case, when the user types `foo`, the following option will be
+   * displayed in the quickpick that will allow the user to select the unknown
+   * value `foo`:
+   *
+   * "Add new value 'foo' →"
+   */
+  newValueTemplate?: string;
+}
+
+export interface QuickPickOptions {
+  /**
+   * An optional string that represents the title of the quick pick.
+   */
+  title?: string;
+
+  /**
+   * Indicates whether the quick pick should allow unknown values, and if so,
+   * how to handle them.
+   */
+  unknownValues?: UnknownValuesOptions;
+}

--- a/src/libs/common/ide/types/ide.types.ts
+++ b/src/libs/common/ide/types/ide.types.ts
@@ -18,6 +18,7 @@ import {
 import { FlashDescriptor } from "./FlashDescriptor";
 import { Hats } from "./Hats";
 import { Messages } from "./Messages";
+import { QuickPickOptions } from "./QuickPickOptions";
 import { State } from "./State";
 
 export type RunMode = "production" | "development" | "test";
@@ -166,6 +167,18 @@ export interface IDE {
    * @return A promise that resolves to a string the user provided or to `undefined` in case of dismissal.
    */
   showInputBox(options?: InputBoxOptions): Promise<string | undefined>;
+
+  /**
+   * Shows a selection list.
+   *
+   * @param items An array of string choices to present to the user.
+   * @param options Configures the behavior of the selection list.
+   * @return A promise that resolves to the selection or `undefined`.
+   */
+  showQuickPick(
+    items: readonly string[],
+    options?: QuickPickOptions,
+  ): Promise<string | undefined>;
 
   /**
    * Executes the built-in ide command denoted by the given command identifier.

--- a/src/libs/common/ide/util/messages.ts
+++ b/src/libs/common/ide/util/messages.ts
@@ -45,3 +45,26 @@ export function showError(
 ): Promise<string | undefined> {
   return messages.showMessage(MessageType.error, id, message, ...options);
 }
+
+/**
+ * Displays an informational message {@link message} to the user along with
+ * possible {@link options} for them to select.
+ *
+ * @param id Each code site where we issue a message should have a unique, human
+ * readable id for testability, eg "deprecatedPositionInference". This allows us
+ * to write tests without tying ourself to the specific wording of the info
+ * message provided in {@link message}.
+ * @param message The message to display to the user
+ * @param options A list of options to display to the user. The selected option
+ * will be returned by this function
+ * @returns The option selected by the user, or `undefined` if no option was
+ * selected
+ */
+export function showInfo(
+  messages: Messages,
+  id: MessageId,
+  message: string,
+  ...options: string[]
+): Promise<string | undefined> {
+  return messages.showMessage(MessageType.info, id, message, ...options);
+}

--- a/src/testUtil/TestCaseRecorder.ts
+++ b/src/testUtil/TestCaseRecorder.ts
@@ -390,7 +390,7 @@ export class TestCaseRecorder {
       );
     }
 
-    const subdirectorySelection: string | undefined = await ide().showQuickPick(
+    const subdirectorySelection = await ide().showQuickPick(
       walkDirsSync(this.fixtureRoot).concat("/"),
       {
         title: "Select directory for new test cases",

--- a/src/testUtil/TestCaseRecorder.ts
+++ b/src/testUtil/TestCaseRecorder.ts
@@ -255,7 +255,7 @@ export class TestCaseRecorder {
 
     showInfo(
       ide().messages,
-      "recordStart ",
+      "recordStart",
       `Recording test cases for following commands in:\n${this.targetDirectory}`,
     );
 
@@ -390,10 +390,8 @@ export class TestCaseRecorder {
       );
     }
 
-    const subdirectories = walkDirsSync(this.fixtureRoot).concat("/");
-
     const subdirectorySelection: string | undefined = await ide().showQuickPick(
-      [...subdirectories],
+      walkDirsSync(this.fixtureRoot).concat("/"),
       {
         title: "Select directory for new test cases",
         unknownValues: {


### PR DESCRIPTION
Also simplifies workflow for adding a new directory to recorded test case dir by adding an inline option:

<img width="870" alt="image" src="https://user-images.githubusercontent.com/755842/219060655-8a8d3a1d-5989-403e-b56e-80ede9f5526f.png">

## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet
