### PR TITLE
Workaround for VSCode profile creation bug

### DIFF
--- a/docs/contributing/CONTRIBUTING.md
+++ b/docs/contributing/CONTRIBUTING.md
@@ -25,7 +25,7 @@ extension](#running--testing-extension-locally), you may want to check out the
    yarn compile
    ```
 
-4. Run `code --profile=cursorlessDevelopment`, and then close the window that opens (eg say `"window close"`).  This step is necessary to create the [VSCode settings profile](https://code.visualstudio.com/updates/v1_72#_settings-profiles) that acts as a sandbox containing a specific set of VSCode extensions that will be run alongside Cursorless when you launch Cursorless in debug or test mode.  Once https://github.com/microsoft/vscode/issues/176372 is resolved, we will be able to remove this step, as the profile can then automatically be created.
+4. Run `code --profile=cursorlessDevelopment`, and then close the window that opens (eg say `"window close"`). This step is necessary to create the [VSCode settings profile](https://code.visualstudio.com/updates/v1_72#_settings-profiles) that acts as a sandbox containing a specific set of VSCode extensions that will be run alongside Cursorless when you launch Cursorless in debug or test mode. Once https://github.com/microsoft/vscode/issues/176372 is resolved, we will be able to remove this step, as the profile can then automatically be created.
 
 5. Run the following in the terminal:
 
@@ -41,7 +41,7 @@ extension](#running--testing-extension-locally), you may want to check out the
 
    where `some.extension` is the id of the extension you'd like to install into the sandbox
 
-4. Copy / symlink `cursorless-talon-dev` into your Talon user directory for some useful voice commands for developing Cursorless.
+6. Copy / symlink `cursorless-talon-dev` into your Talon user directory for some useful voice commands for developing Cursorless.
 
 ## Running / testing extension locally
 

--- a/docs/contributing/CONTRIBUTING.md
+++ b/docs/contributing/CONTRIBUTING.md
@@ -23,6 +23,13 @@ extension](#running--testing-extension-locally), you may want to check out the
    ```bash
    yarn
    yarn compile
+   ```
+
+4. Run `code --profile=cursorlessDevelopment`, and then close the window that opens (eg say `"window close"`).  This step is necessary to create the [VSCode settings profile](https://code.visualstudio.com/updates/v1_72#_settings-profiles) that acts as a sandbox containing a specific set of VSCode extensions that will be run alongside Cursorless when you launch Cursorless in debug or test mode.  Once https://github.com/microsoft/vscode/issues/176372 is resolved, we will be able to remove this step, as the profile can then automatically be created.
+
+5. Run the following in the terminal:
+
+   ```bash
    yarn init-launch-sandbox
    ```
 


### PR DESCRIPTION
Workaround for https://github.com/cursorless-dev/cursorless/issues/1291, which is caused by https://github.com/microsoft/vscode/issues/176372.

## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet
