### PR TITLE
`Thenable` => `Promise`; tweak clipboard mock

### DIFF
--- a/packages/common/ide/fake/FakeGlobalState.ts
+++ b/packages/common/ide/fake/FakeGlobalState.ts
@@ -8,7 +8,7 @@ export default class FakeGlobalState implements State {
     return this.data[key];
   }
 
-  set<K extends StateKey>(key: K, value: StateData[K]): Thenable<void> {
+  set<K extends StateKey>(key: K, value: StateData[K]): Promise<void> {
     this.data[key] = value;
     return Promise.resolve();
   }

--- a/packages/common/ide/types/Clipboard.ts
+++ b/packages/common/ide/types/Clipboard.ts
@@ -5,13 +5,13 @@
 export interface Clipboard {
   /**
    * Read the current clipboard contents as text.
-   * @returns A thenable that resolves to a string.
+   * @returns A promise that resolves to a string.
    */
-  readText(): Thenable<string>;
+  readText(): Promise<string>;
 
   /**
    * Writes text into the clipboard.
-   * @returns A thenable that resolves when writing happened.
+   * @returns A promise that resolves when writing happened.
    */
-  writeText(value: string): Thenable<void>;
+  writeText(value: string): Promise<void>;
 }

--- a/packages/common/ide/types/State.ts
+++ b/packages/common/ide/types/State.ts
@@ -26,5 +26,5 @@ export interface State {
    * @param key A string.
    * @param value A value. MUST not contain cyclic references.
    */
-  set<K extends StateKey>(key: K, value: StateData[K]): Thenable<void>;
+  set<K extends StateKey>(key: K, value: StateData[K]): Promise<void>;
 }

--- a/packages/cursorless-engine/core/updateSelections/updateSelections.ts
+++ b/packages/cursorless-engine/core/updateSelections/updateSelections.ts
@@ -146,7 +146,7 @@ function selectionInfosToSelections(
  */
 export async function callFunctionAndUpdateSelections(
   rangeUpdater: RangeUpdater,
-  func: () => Thenable<void>,
+  func: () => Promise<void>,
   document: TextDocument,
   selectionMatrix: (readonly Selection[])[],
 ): Promise<Selection[][]> {
@@ -165,7 +165,7 @@ export async function callFunctionAndUpdateSelections(
 
 export async function callFunctionAndUpdateRanges(
   rangeUpdater: RangeUpdater,
-  func: () => Thenable<void>,
+  func: () => Promise<void>,
   document: TextDocument,
   rangeMatrix: (readonly Range[])[],
 ): Promise<Range[][]> {
@@ -190,7 +190,7 @@ export async function callFunctionAndUpdateRanges(
  */
 export async function callFunctionAndUpdateSelectionInfos(
   rangeUpdater: RangeUpdater,
-  func: () => Thenable<void>,
+  func: () => Promise<void>,
   document: TextDocument,
   selectionInfoMatrix: FullSelectionInfo[][],
 ) {
@@ -217,7 +217,7 @@ export async function callFunctionAndUpdateSelectionInfos(
  */
 export function callFunctionAndUpdateSelectionsWithBehavior(
   rangeUpdater: RangeUpdater,
-  func: () => Thenable<void>,
+  func: () => Promise<void>,
   document: TextDocument,
   originalSelections: SelectionsWithBehavior[],
 ) {

--- a/packages/cursorless-vscode-core/ide/vscode/VscodeClipboard.ts
+++ b/packages/cursorless-vscode-core/ide/vscode/VscodeClipboard.ts
@@ -2,11 +2,11 @@ import * as vscode from "vscode";
 import { Clipboard } from "@cursorless/common";
 
 export default class VscodeClipboard implements Clipboard {
-  readText(): Thenable<string> {
-    return vscode.env.clipboard.readText();
+  async readText(): Promise<string> {
+    return await vscode.env.clipboard.readText();
   }
 
-  writeText(value: string): Thenable<void> {
-    return vscode.env.clipboard.writeText(value);
+  async writeText(value: string): Promise<void> {
+    return await vscode.env.clipboard.writeText(value);
   }
 }

--- a/packages/cursorless-vscode-core/ide/vscode/VscodeGlobalState.ts
+++ b/packages/cursorless-vscode-core/ide/vscode/VscodeGlobalState.ts
@@ -12,7 +12,7 @@ export default class VscodeGlobalState implements State {
     return this.extensionContext.globalState.get(key, STATE_DEFAULTS[key]);
   }
 
-  set<K extends StateKey>(key: K, value: StateData[K]): Thenable<void> {
-    return this.extensionContext.globalState.update(key, value);
+  async set<K extends StateKey>(key: K, value: StateData[K]): Promise<void> {
+    return await this.extensionContext.globalState.update(key, value);
   }
 }

--- a/packages/cursorless-vscode-core/ide/vscode/VscodeOpenLink.ts
+++ b/packages/cursorless-vscode-core/ide/vscode/VscodeOpenLink.ts
@@ -23,11 +23,13 @@ export default async function vscodeOpenLink(
   return true;
 }
 
-function getLinksForEditor(editor: vscode.TextEditor) {
-  return vscode.commands.executeCommand(
+async function getLinksForEditor(
+  editor: vscode.TextEditor,
+): Promise<vscode.DocumentLink[]> {
+  return (await vscode.commands.executeCommand(
     "vscode.executeLinkProvider",
     editor.document.uri,
-  ) as Thenable<vscode.DocumentLink[]>;
+  ))!;
 }
 
 function openLink(link: vscode.DocumentLink) {

--- a/packages/cursorless-vscode-e2e/suite/recorded.test.ts
+++ b/packages/cursorless-vscode-e2e/suite/recorded.test.ts
@@ -176,10 +176,8 @@ async function runTest(file: string, spyIde: SpyIDE) {
     spyIde.activeTextEditor!,
     spyIde,
     marks,
-    undefined,
-    undefined,
     // FIXME: Stop overriding the clipboard once we have #559
-    vscode.env.clipboard,
+    true,
   );
 
   const rawSpyIdeValues = spyIde.getSpyValues(fixture.ide?.flashes != null);

--- a/packages/cursorless-vscode/constructTestHelpers.ts
+++ b/packages/cursorless-vscode/constructTestHelpers.ts
@@ -1,7 +1,6 @@
 import {
   CommandServerApi,
   ExcludableSnapshotField,
-  ExtraContext,
   ExtraSnapshotField,
   IDE,
   NormalizedIDE,
@@ -43,10 +42,8 @@ export function constructTestHelpers(
       extraFields: ExtraSnapshotField[],
       editor: TextEditor,
       ide: IDE,
-      marks?: SerializedMarks,
-      extraContext?: ExtraContext,
-      metadata?: unknown,
-      clipboard?: vscode.Clipboard,
+      marks: SerializedMarks | undefined,
+      forceRealClipboard: boolean,
     ): Promise<TestCaseSnapshot> {
       return takeSnapshot(
         thatMark,
@@ -56,9 +53,9 @@ export function constructTestHelpers(
         editor,
         ide,
         marks,
-        extraContext,
-        metadata,
-        clipboard,
+        undefined,
+        undefined,
+        forceRealClipboard ? vscodeIDE.clipboard : undefined,
       );
     },
 

--- a/packages/vscode-common/getExtensionApi.ts
+++ b/packages/vscode-common/getExtensionApi.ts
@@ -1,7 +1,6 @@
 import type {
   CommandServerApi,
   ExcludableSnapshotField,
-  ExtraContext,
   ExtraSnapshotField,
   HatTokenMap,
   IDE,
@@ -41,10 +40,8 @@ export interface TestHelpers {
     extraFields: ExtraSnapshotField[],
     editor: TextEditor,
     ide: IDE,
-    marks?: SerializedMarks,
-    extraContext?: ExtraContext,
-    metadata?: unknown,
-    clipboard?: vscode.Clipboard,
+    marks: SerializedMarks | undefined,
+    forceRealClipboard: boolean,
   ): Promise<TestCaseSnapshot>;
 }
 


### PR DESCRIPTION
Extracted from #1281 with fixes

- [x] fix `takeSnapshot` taking `vscode.Clipboard`

## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet
