### PR TITLE
Add `type` annotations to tree-sitter imports

### DIFF
--- a/packages/cursorless-engine/core/Debug.ts
+++ b/packages/cursorless-engine/core/Debug.ts
@@ -1,5 +1,5 @@
 import { Disposable, TextEditorSelectionChangeEvent } from "@cursorless/common";
-import { SyntaxNode, TreeCursor } from "web-tree-sitter";
+import type { SyntaxNode, TreeCursor } from "web-tree-sitter";
 import { ide } from "../singletons/ide.singleton";
 import { Graph } from "../typings/Graph";
 

--- a/packages/cursorless-engine/languages/clojure.ts
+++ b/packages/cursorless-engine/languages/clojure.ts
@@ -7,7 +7,7 @@ import {
 } from "../util/nodeMatchers";
 import { NodeMatcherAlternative, NodeFinder } from "../typings/Types";
 import { SimpleScopeTypeType } from "@cursorless/common";
-import { SyntaxNode } from "web-tree-sitter";
+import type { SyntaxNode } from "web-tree-sitter";
 import { delimitedSelector } from "../util/nodeSelectors";
 import { identity } from "lodash";
 import { getChildNodesForFieldName } from "../util/treeSitterUtils";

--- a/packages/cursorless-engine/languages/csharp.ts
+++ b/packages/cursorless-engine/languages/csharp.ts
@@ -1,4 +1,4 @@
-import { SyntaxNode } from "web-tree-sitter";
+import type { SyntaxNode } from "web-tree-sitter";
 import {
   cascadingMatcher,
   chainedMatcher,

--- a/packages/cursorless-engine/languages/elseIfExtractor.ts
+++ b/packages/cursorless-engine/languages/elseIfExtractor.ts
@@ -1,5 +1,5 @@
 import { Selection, TextEditor } from "@cursorless/common";
-import { SyntaxNode } from "web-tree-sitter";
+import type { SyntaxNode } from "web-tree-sitter";
 import { SelectionExtractor, SelectionWithContext } from "../typings/Types";
 import {
   childRangeSelector,

--- a/packages/cursorless-engine/languages/getNodeMatcher.ts
+++ b/packages/cursorless-engine/languages/getNodeMatcher.ts
@@ -1,5 +1,5 @@
 import { UnsupportedLanguageError } from "@cursorless/common";
-import { SyntaxNode } from "web-tree-sitter";
+import type { SyntaxNode } from "web-tree-sitter";
 import { SimpleScopeTypeType } from "@cursorless/common";
 import {
   NodeMatcher,

--- a/packages/cursorless-engine/languages/getTextFragmentExtractor.ts
+++ b/packages/cursorless-engine/languages/getTextFragmentExtractor.ts
@@ -1,5 +1,5 @@
 import { Range, UnsupportedLanguageError } from "@cursorless/common";
-import { SyntaxNode } from "web-tree-sitter";
+import type { SyntaxNode } from "web-tree-sitter";
 import { SelectionWithEditor } from "../typings/Types";
 import { notSupported } from "../util/nodeMatchers";
 import { getNodeInternalRange, getNodeRange } from "../util/nodeSelectors";

--- a/packages/cursorless-engine/languages/html.ts
+++ b/packages/cursorless-engine/languages/html.ts
@@ -1,4 +1,4 @@
-import { SyntaxNode } from "web-tree-sitter";
+import type { SyntaxNode } from "web-tree-sitter";
 import { SimpleScopeTypeType } from "@cursorless/common";
 import { NodeMatcherAlternative, SelectionWithEditor } from "../typings/Types";
 import { typedNodeFinder } from "../util/nodeFinders";

--- a/packages/cursorless-engine/languages/json.ts
+++ b/packages/cursorless-engine/languages/json.ts
@@ -1,4 +1,4 @@
-import { SyntaxNode } from "web-tree-sitter";
+import type { SyntaxNode } from "web-tree-sitter";
 import { SimpleScopeTypeType } from "@cursorless/common";
 import { NodeMatcherAlternative, SelectionWithEditor } from "../typings/Types";
 import {

--- a/packages/cursorless-engine/languages/latex.ts
+++ b/packages/cursorless-engine/languages/latex.ts
@@ -1,5 +1,5 @@
 import { Range, Selection, TextEditor } from "@cursorless/common";
-import { SyntaxNode } from "web-tree-sitter";
+import type { SyntaxNode } from "web-tree-sitter";
 import { SimpleScopeTypeType } from "@cursorless/common";
 import { NodeMatcherAlternative, SelectionWithContext } from "../typings/Types";
 import { patternFinder } from "../util/nodeFinders";

--- a/packages/cursorless-engine/languages/markdown.ts
+++ b/packages/cursorless-engine/languages/markdown.ts
@@ -1,5 +1,5 @@
 import { Range, Selection, TextEditor } from "@cursorless/common";
-import { SyntaxNode } from "web-tree-sitter";
+import type { SyntaxNode } from "web-tree-sitter";
 import { getMatchesInRange } from "../util/getMatchesInRange";
 import { SimpleScopeTypeType } from "@cursorless/common";
 import {

--- a/packages/cursorless-engine/languages/php.ts
+++ b/packages/cursorless-engine/languages/php.ts
@@ -1,5 +1,5 @@
 import { Selection, TextEditor } from "@cursorless/common";
-import { SyntaxNode } from "web-tree-sitter";
+import type { SyntaxNode } from "web-tree-sitter";
 import { SimpleScopeTypeType } from "@cursorless/common";
 import {
   NodeMatcherAlternative,

--- a/packages/cursorless-engine/languages/python.ts
+++ b/packages/cursorless-engine/languages/python.ts
@@ -1,5 +1,5 @@
 import { Selection } from "@cursorless/common";
-import { SyntaxNode } from "web-tree-sitter";
+import type { SyntaxNode } from "web-tree-sitter";
 import { SimpleScopeTypeType } from "@cursorless/common";
 import { NodeFinder, NodeMatcherAlternative } from "../typings/Types";
 import { argumentNodeFinder, patternFinder } from "../util/nodeFinders";

--- a/packages/cursorless-engine/languages/ruby.ts
+++ b/packages/cursorless-engine/languages/ruby.ts
@@ -11,7 +11,7 @@ import {
 } from "../util/nodeMatchers";
 import { NodeMatcherAlternative, SelectionWithEditor } from "../typings/Types";
 import { SimpleScopeTypeType } from "@cursorless/common";
-import { SyntaxNode } from "web-tree-sitter";
+import type { SyntaxNode } from "web-tree-sitter";
 import { getNodeRange } from "../util/nodeSelectors";
 import { patternFinder } from "../util/nodeFinders";
 

--- a/packages/cursorless-engine/languages/rust.ts
+++ b/packages/cursorless-engine/languages/rust.ts
@@ -1,5 +1,5 @@
 import { TextEditor } from "@cursorless/common";
-import { SyntaxNode } from "web-tree-sitter";
+import type { SyntaxNode } from "web-tree-sitter";
 import { SimpleScopeTypeType } from "@cursorless/common";
 import { NodeMatcherAlternative, SelectionWithContext } from "../typings/Types";
 import { patternFinder } from "../util/nodeFinders";

--- a/packages/cursorless-engine/languages/scss.ts
+++ b/packages/cursorless-engine/languages/scss.ts
@@ -1,4 +1,4 @@
-import { SyntaxNode } from "web-tree-sitter";
+import type { SyntaxNode } from "web-tree-sitter";
 import { SimpleScopeTypeType } from "@cursorless/common";
 import {
   NodeMatcherAlternative,

--- a/packages/cursorless-engine/languages/ternaryBranchMatcher.ts
+++ b/packages/cursorless-engine/languages/ternaryBranchMatcher.ts
@@ -1,4 +1,4 @@
-import { SyntaxNode } from "web-tree-sitter";
+import type { SyntaxNode } from "web-tree-sitter";
 import { NodeMatcher } from "../typings/Types";
 import { matcher } from "../util/nodeMatchers";
 

--- a/packages/cursorless-engine/languages/typescript.ts
+++ b/packages/cursorless-engine/languages/typescript.ts
@@ -1,4 +1,4 @@
-import { SyntaxNode } from "web-tree-sitter";
+import type { SyntaxNode } from "web-tree-sitter";
 import { SimpleScopeTypeType } from "@cursorless/common";
 import {
   NodeMatcher,

--- a/packages/cursorless-engine/processTargets/modifiers/surroundingPair/findSurroundingPairParseTreeBased.ts
+++ b/packages/cursorless-engine/processTargets/modifiers/surroundingPair/findSurroundingPairParseTreeBased.ts
@@ -1,5 +1,5 @@
 import { Range, TextDocument, TextEditor } from "@cursorless/common";
-import { SyntaxNode } from "web-tree-sitter";
+import type { SyntaxNode } from "web-tree-sitter";
 import {
   SimpleSurroundingPairName,
   SurroundingPairScopeType,

--- a/packages/cursorless-engine/processTargets/modifiers/surroundingPair/index.ts
+++ b/packages/cursorless-engine/processTargets/modifiers/surroundingPair/index.ts
@@ -1,5 +1,5 @@
 import { Range, Selection, TextEditor } from "@cursorless/common";
-import { SyntaxNode } from "web-tree-sitter";
+import type { SyntaxNode } from "web-tree-sitter";
 import getTextFragmentExtractor, {
   TextFragmentExtractor,
 } from "../../../languages/getTextFragmentExtractor";

--- a/packages/cursorless-engine/typings/Graph.ts
+++ b/packages/cursorless-engine/typings/Graph.ts
@@ -1,5 +1,5 @@
 import { CommandServerApi, Range, TextDocument } from "@cursorless/common";
-import { SyntaxNode } from "web-tree-sitter";
+import type { SyntaxNode } from "web-tree-sitter";
 import { ActionRecord } from "../actions/actions.types";
 import Debug from "../core/Debug";
 import HatTokenMapImpl from "../core/HatTokenMapImpl";

--- a/packages/cursorless-engine/typings/Types.ts
+++ b/packages/cursorless-engine/typings/Types.ts
@@ -5,7 +5,7 @@ import type {
   TextDocument,
   TextEditor,
 } from "@cursorless/common";
-import { SyntaxNode } from "web-tree-sitter";
+import type { SyntaxNode } from "web-tree-sitter";
 import { ModifierStage } from "../processTargets/PipelineStages.types";
 import { Target } from "./target.types";
 

--- a/packages/cursorless-engine/util/nodeFinders.ts
+++ b/packages/cursorless-engine/util/nodeFinders.ts
@@ -1,5 +1,5 @@
 import { Position, Selection } from "@cursorless/common";
-import { Point, SyntaxNode } from "web-tree-sitter";
+import type { Point, SyntaxNode } from "web-tree-sitter";
 import { NodeFinder } from "../typings/Types";
 
 export const nodeFinder = (

--- a/packages/cursorless-engine/util/nodeMatchers.ts
+++ b/packages/cursorless-engine/util/nodeMatchers.ts
@@ -1,4 +1,4 @@
-import { SyntaxNode } from "web-tree-sitter";
+import type { SyntaxNode } from "web-tree-sitter";
 import { SimpleScopeTypeType } from "@cursorless/common";
 import {
   NodeFinder,

--- a/packages/cursorless-engine/util/nodeSelectors.ts
+++ b/packages/cursorless-engine/util/nodeSelectors.ts
@@ -1,6 +1,6 @@
 import { Position, Range, Selection, TextEditor } from "@cursorless/common";
 import { identity, maxBy } from "lodash";
-import { Point, SyntaxNode } from "web-tree-sitter";
+import type { Point, SyntaxNode } from "web-tree-sitter";
 import {
   NodeFinder,
   SelectionExtractor,

--- a/packages/cursorless-engine/util/treeSitterUtils.ts
+++ b/packages/cursorless-engine/util/treeSitterUtils.ts
@@ -1,4 +1,4 @@
-import { SyntaxNode } from "web-tree-sitter";
+import type { SyntaxNode } from "web-tree-sitter";
 
 export const getValueNode = (node: SyntaxNode) =>
   node.childForFieldName("value");


### PR DESCRIPTION
- Split off of #1281 

## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet
