### PR TITLE
Fix test case recorder

### DIFF
--- a/packages/common/src/ide/fake/FakeIDE.ts
+++ b/packages/common/src/ide/fake/FakeIDE.ts
@@ -35,6 +35,7 @@ export default class FakeIDE implements IDE {
   workspaceFolders: readonly WorkspaceFolder[] | undefined = undefined;
   private disposables: Disposable[] = [];
   private assetsRoot_: string | undefined;
+  private quickPickReturnValue: string | undefined = undefined;
 
   async flashRanges(_flashDescriptors: FlashDescriptor[]): Promise<void> {
     // empty
@@ -93,11 +94,15 @@ export default class FakeIDE implements IDE {
     throw Error("Not implemented");
   }
 
-  public showQuickPick(
+  public setQuickPickReturnValue(value: string | undefined) {
+    this.quickPickReturnValue = value;
+  }
+
+  public async showQuickPick(
     _items: readonly string[],
     _options?: QuickPickOptions,
   ): Promise<string | undefined> {
-    throw new Error("Method not implemented.");
+    return this.quickPickReturnValue;
   }
 
   public showInputBox(_options?: any): Promise<string | undefined> {

--- a/packages/common/src/ide/normalized/NormalizedIDE.ts
+++ b/packages/common/src/ide/normalized/NormalizedIDE.ts
@@ -7,6 +7,7 @@ import FakeIDE from "../fake/FakeIDE";
 import PassthroughIDEBase from "../PassthroughIDEBase";
 import { FlashDescriptor } from "../types/FlashDescriptor";
 import type { IDE } from "../types/ide.types";
+import { QuickPickOptions } from "../types/QuickPickOptions";
 
 export class NormalizedIDE extends PassthroughIDEBase {
   configuration: FakeConfiguration;
@@ -15,7 +16,7 @@ export class NormalizedIDE extends PassthroughIDEBase {
 
   constructor(
     original: IDE,
-    private fakeIde: FakeIDE,
+    public fakeIde: FakeIDE,
     private isSilent: boolean,
   ) {
     super(original);
@@ -60,5 +61,14 @@ export class NormalizedIDE extends PassthroughIDEBase {
     return this.isSilent
       ? this.fakeIde.setHighlightRanges(highlightId, editor, ranges)
       : super.setHighlightRanges(highlightId, editor, ranges);
+  }
+
+  public async showQuickPick(
+    _items: readonly string[],
+    _options?: QuickPickOptions,
+  ): Promise<string | undefined> {
+    return this.isSilent
+      ? this.fakeIde.showQuickPick(_items, _options)
+      : super.showQuickPick(_items, _options);
   }
 }

--- a/packages/common/src/testUtil/getFixturePaths.ts
+++ b/packages/common/src/testUtil/getFixturePaths.ts
@@ -17,8 +17,12 @@ export function getFixturePath(fixturePath: string) {
   return path.join(getFixturesPath(), fixturePath);
 }
 
+export function getRecordedTestsDirPath() {
+  return path.join(getFixturesPath(), "recorded");
+}
+
 export function getRecordedTestPaths() {
-  const directory = path.join(getFixturesPath(), "recorded");
+  const directory = getRecordedTestsDirPath();
 
   return walkFilesSync(directory).filter(
     (path) => path.endsWith(".yml") || path.endsWith(".yaml"),

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/testCaseRecorder/takeHarp.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/testCaseRecorder/takeHarp.yml
@@ -1,0 +1,23 @@
+languageId: plaintext
+command:
+  version: 4
+  spokenForm: take harp
+  action: {name: setSelection}
+  targets:
+    - type: primitive
+      mark: {type: decoratedSymbol, symbolColor: default, character: h}
+  usePrePhraseSnapshot: false
+initialState:
+  documentContents: hello world
+  selections:
+    - anchor: {line: 0, character: 11}
+      active: {line: 0, character: 11}
+  marks:
+    default.h:
+      start: {line: 0, character: 0}
+      end: {line: 0, character: 5}
+finalState:
+  documentContents: hello world
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 5}

--- a/packages/cursorless-vscode-e2e/src/suite/testCaseRecorder.test.ts
+++ b/packages/cursorless-vscode-e2e/src/suite/testCaseRecorder.test.ts
@@ -1,0 +1,115 @@
+import {
+  getFixturePath,
+  getRecordedTestsDirPath,
+  HatTokenMap,
+} from "@cursorless/common";
+import {
+  getCursorlessApi,
+  openNewEditor,
+  runCursorlessCommand,
+} from "@cursorless/vscode-common";
+import { assert } from "chai";
+import * as crypto from "crypto";
+import { mkdir, readdir, readFile, rm } from "fs/promises";
+import * as path from "path";
+import * as os from "os";
+import { basename } from "path";
+import * as vscode from "vscode";
+import { endToEndTestSetup } from "../endToEndTestSetup";
+
+// Ensure that the test case recorder works
+suite("testCaseRecorder", async function () {
+  endToEndTestSetup(this);
+
+  test("no args", testCaseRecorderNoArgs);
+  test("path arg", testCaseRecorderPathArg);
+});
+
+async function testCaseRecorderNoArgs() {
+  const {
+    hatTokenMap,
+    ide: { fakeIde },
+  } = (await getCursorlessApi()).testHelpers!;
+  const dirName = crypto.randomBytes(16).toString("hex");
+  fakeIde.setQuickPickReturnValue(dirName);
+  const tmpdir = path.join(getRecordedTestsDirPath(), dirName);
+
+  try {
+    await runAndCheckTestCaseRecorder(hatTokenMap, tmpdir);
+  } finally {
+    fakeIde.setQuickPickReturnValue(undefined);
+    await rm(tmpdir, { recursive: true, force: true });
+  }
+}
+
+async function testCaseRecorderPathArg() {
+  const { hatTokenMap } = (await getCursorlessApi()).testHelpers!;
+  const tmpdir = path.join(os.tmpdir(), crypto.randomBytes(16).toString("hex"));
+  await mkdir(tmpdir, { recursive: true });
+
+  try {
+    await runAndCheckTestCaseRecorder(hatTokenMap, tmpdir, {
+      directory: tmpdir,
+    });
+  } finally {
+    await rm(tmpdir, { recursive: true, force: true });
+  }
+}
+
+async function runAndCheckTestCaseRecorder(
+  hatTokenMap: HatTokenMap,
+  tmpdir: string,
+  ...extraArgs: unknown[]
+) {
+  const editor = await openNewEditor("hello world");
+
+  editor.selections = [new vscode.Selection(0, 11, 0, 11)];
+
+  await hatTokenMap.allocateHats();
+
+  await vscode.commands.executeCommand(
+    "cursorless.recordTestCase",
+    ...extraArgs,
+  );
+
+  await runCursorlessCommand({
+    version: 4,
+    action: { name: "setSelection" },
+    targets: [
+      {
+        type: "primitive",
+        mark: {
+          type: "decoratedSymbol",
+          symbolColor: "default",
+          character: "h",
+        },
+      },
+    ],
+    usePrePhraseSnapshot: false,
+    spokenForm: "take harp",
+  });
+
+  await vscode.commands.executeCommand("cursorless.recordTestCase");
+
+  const paths = await readdir(tmpdir);
+  assert.lengthOf(paths, 1);
+
+  const actualRecordedTestPath = paths[0];
+  assert.equal(basename(actualRecordedTestPath), "takeHarp.yml");
+
+  const expected = (
+    await readFile(
+      getFixturePath("recorded/testCaseRecorder/takeHarp.yml"),
+      "utf8",
+    )
+  )
+    // We use this to ensure that the test works on Windows. Depending on user
+    // / CI git config, the file might be checked out with CRLF line endings
+    .replaceAll("\r\n", "\n");
+  const actualRecordedTest = await readFile(
+    path.join(tmpdir, actualRecordedTestPath),
+    "utf8",
+  );
+
+  assert.equal(actualRecordedTest, expected);
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -4,7 +4,7 @@
     "moduleResolution": "nodenext",
     "moduleDetection": "force",
     "target": "es6",
-    "lib": ["es2020"],
+    "lib": ["es2022"],
     "sourceMap": true,
     "declarationMap": true,
     "resolveJsonModule": true,


### PR DESCRIPTION
The test case recorder broke in #1281 due to the fact we're now launching extension in subdirectory called `dist` rather than top-level repo.  This PR fixes it

## Checklist

- [x] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet
