### PR TITLE
Fix link in README for cursorless-org-docs

### DIFF
--- a/packages/cursorless-org-docs/README.md
+++ b/packages/cursorless-org-docs/README.md
@@ -1,6 +1,6 @@
 # cursorless.org docs site
 
-This is the source code for the [cursorless.org/docs](https://cursorless.org/docs) portion of the Cursorless website. Note that it is built independently from the rest of the site (which uses Next.js, and can be found in the [`cursorless-org`](../packages/cursorless-org) directory).
+This is the source code for the [cursorless.org/docs](https://cursorless.org/docs) portion of the Cursorless website. Note that it is built independently from the rest of the site (which uses Next.js, and can be found in the [`cursorless-org`](../cursorless-org) directory).
 
 This website is built using [Docusaurus 2](https://docusaurus.io/), a modern static website generator.
 


### PR DESCRIPTION

## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet
