### PR TITLE
Fix bug with injected ide in test case recorder

### DIFF
--- a/packages/cursorless-engine/src/testCaseRecorder/TestCaseRecorder.ts
+++ b/packages/cursorless-engine/src/testCaseRecorder/TestCaseRecorder.ts
@@ -432,7 +432,9 @@ export class TestCaseRecorder {
   }
 
   finallyHook() {
-    injectIde(this.originalIde!);
+    if (this.originalIde != null) {
+      injectIde(this.originalIde);
+    }
     this.spyIde = undefined;
     this.originalIde = undefined;
 


### PR DESCRIPTION
This PR fixes a bug with our test case recorder.  If an exception is thrown during command processing before we inject a spy ide during `TestCaseRecorder.preCommandHook`, we don't set the `originalIde` member variable on `TestCaseRecorder`.  During `TestCaseRecorder.finallyHook`, we unconditionally call `injectIde(this.originalIde)` even in the case of an error, which means that we will inject an `undefined` ide, so Cursorless becomes completely broken, because `ide()` is now `undefined`, so we get an error about not having injected ide for every single subsequent command

This PR just checks that `this.originalIde != null` before trying to inject it

## Checklist

- [x] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet
