### PR TITLE
Fix `getCursorlessRepoRoot`; normalize snippet dir

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     environment: production
+    env:
+      CURSORLESS_REPO_ROOT: ${{ github.workspace }}
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   test-docs-build:
     runs-on: ubuntu-latest
+    env:
+      CURSORLESS_REPO_ROOT: ${{ github.workspace }}
     steps:
       - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,7 @@ jobs:
       VSCODE_VERSION: ${{ matrix.vscode_version }}
       VSCODE_CRASH_DIR: ${{ github.workspace }}/artifacts/dumps
       VSCODE_LOGS_DIR: ${{ github.workspace }}/artifacts/logs
+      CURSORLESS_REPO_ROOT: ${{ github.workspace }}
     steps:
       - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v2

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,6 +9,9 @@
       "name": "Run Extension",
       "type": "extensionHost",
       "request": "launch",
+      "env": {
+        "CURSORLESS_REPO_ROOT": "${workspaceFolder}"
+      },
       "args": [
         "--extensionDevelopmentPath=${workspaceFolder}/packages/cursorless-vscode/dist",
         "--profile=cursorlessDevelopment"
@@ -25,7 +28,8 @@
       "type": "extensionHost",
       "request": "launch",
       "env": {
-        "CURSORLESS_TEST": "true"
+        "CURSORLESS_TEST": "true",
+        "CURSORLESS_REPO_ROOT": "${workspaceFolder}"
       },
       "args": [
         "--profile=cursorlessDevelopment",
@@ -45,7 +49,8 @@
       "name": "Unit tests only",
       "program": "${workspaceFolder}/packages/test-harness/out/scripts/runUnitTestsOnly",
       "env": {
-        "CURSORLESS_TEST": "true"
+        "CURSORLESS_TEST": "true",
+        "CURSORLESS_REPO_ROOT": "${workspaceFolder}"
       },
       "outFiles": ["${workspaceFolder}/**/out/**/*.js"],
       "preLaunchTask": "${defaultBuildTask}",
@@ -60,7 +65,8 @@
       "request": "launch",
       "env": {
         "CURSORLESS_TEST": "true",
-        "CURSORLESS_RUN_TEST_SUBSET": "true"
+        "CURSORLESS_RUN_TEST_SUBSET": "true",
+        "CURSORLESS_REPO_ROOT": "${workspaceFolder}"
       },
       "args": [
         "--profile=cursorlessDevelopment",
@@ -80,7 +86,8 @@
       "request": "launch",
       "env": {
         "CURSORLESS_TEST": "true",
-        "CURSORLESS_TEST_UPDATE_FIXTURES": "true"
+        "CURSORLESS_TEST_UPDATE_FIXTURES": "true",
+        "CURSORLESS_REPO_ROOT": "${workspaceFolder}"
       },
       "args": [
         "--profile=cursorlessDevelopment",
@@ -101,7 +108,8 @@
       "env": {
         "CURSORLESS_TEST": "true",
         "CURSORLESS_TEST_UPDATE_FIXTURES": "true",
-        "CURSORLESS_RUN_TEST_SUBSET": "true"
+        "CURSORLESS_RUN_TEST_SUBSET": "true",
+        "CURSORLESS_REPO_ROOT": "${workspaceFolder}"
       },
       "args": [
         "--profile=cursorlessDevelopment",
@@ -119,6 +127,9 @@
       "name": "Docusaurus Start (Debug)",
       "type": "node",
       "request": "launch",
+      "env": {
+        "CURSORLESS_REPO_ROOT": "${workspaceFolder}"
+      },
       "cwd": "${workspaceFolder}/packages/cursorless-org-docs",
       "runtimeExecutable": "pnpm",
       "runtimeArgs": ["start"],
@@ -131,6 +142,9 @@
       "name": "Docusaurus Build (Debug)",
       "type": "node",
       "request": "launch",
+      "env": {
+        "CURSORLESS_REPO_ROOT": "${workspaceFolder}"
+      },
       "cwd": "${workspaceFolder}/packages/cursorless-org-docs",
       "runtimeExecutable": "pnpm",
       "runtimeArgs": ["build"],

--- a/packages/common/src/ide/normalized/NormalizedIDE.ts
+++ b/packages/common/src/ide/normalized/NormalizedIDE.ts
@@ -1,3 +1,4 @@
+import { getFixturePath } from "../../index";
 import { GeneralizedRange } from "../../types/GeneralizedRange";
 import { TextEditor } from "../../types/TextEditor";
 import FakeClipboard from "../fake/FakeClipboard";
@@ -45,6 +46,12 @@ export class NormalizedIDE extends PassthroughIDEBase {
       { wordSeparators: ["_", "-"] },
       true,
     );
+    this.configuration.mockConfiguration("experimental", {
+      hatStability: this.configuration.getOwnConfiguration(
+        "experimental.hatStability",
+      ),
+      snippetsDir: getFixturePath("cursorless-snippets"),
+    });
   }
 
   flashRanges(flashDescriptors: FlashDescriptor[]): Promise<void> {

--- a/packages/common/src/testUtil/getCursorlessRepoRoot.ts
+++ b/packages/common/src/testUtil/getCursorlessRepoRoot.ts
@@ -1,4 +1,4 @@
-import path = require("path");
+import * as path from "path";
 
 /**
  * Gets the path to the root of the cursorless repo; used for scripts and tests,
@@ -6,5 +6,8 @@ import path = require("path");
  * @returns The path to the root of the cursorless repo
  */
 export function getCursorlessRepoRoot() {
-  return path.join(__dirname, "..", "..", "..", "..");
+  return (
+    process.env["CURSORLESS_REPO_ROOT"] ??
+    path.join(__dirname, "..", "..", "..", "..")
+  );
 }

--- a/packages/cursorless-engine/src/testCaseRecorder/TestCaseRecorder.ts
+++ b/packages/cursorless-engine/src/testCaseRecorder/TestCaseRecorder.ts
@@ -4,18 +4,19 @@ import {
   extractTargetedMarks,
   ExtraSnapshotField,
   getKey,
+  getRecordedTestsDirPath,
   IDE,
   marksToPlainObject,
   serialize,
   SerializedMarks,
+  showError,
   showInfo,
   sleep,
   SpyIDE,
+  TestCaseCommand,
   TextEditorOptions,
   toLineRange,
   walkDirsSync,
-  TestCaseCommand,
-  showError,
 } from "@cursorless/common";
 import * as fs from "fs";
 import { access, readFile } from "fs/promises";
@@ -97,19 +98,12 @@ export class TestCaseRecorder {
   private originalIde: IDE | undefined;
 
   constructor(private graph: Graph) {
-    const { runMode, assetsRoot, workspaceFolders } = ide();
+    const { runMode } = ide();
 
-    const workspacePath =
+    this.fixtureRoot =
       runMode === "development" || runMode === "test"
-        ? path.join(assetsRoot, "../../..")
-        : workspaceFolders?.[0].uri.path ?? null;
-
-    this.fixtureRoot = workspacePath
-      ? path.join(
-          workspacePath,
-          "packages/cursorless-vscode-e2e/src/suite/fixtures/recorded",
-        )
-      : null;
+        ? getRecordedTestsDirPath()
+        : null;
 
     this.toggle = this.toggle.bind(this);
     this.pause = this.pause.bind(this);

--- a/packages/cursorless-vscode-e2e/src/suite/setupFake.ts
+++ b/packages/cursorless-vscode-e2e/src/suite/setupFake.ts
@@ -1,12 +1,8 @@
-import {
-  getFixturePath,
-  HatStability,
-  NormalizedIDE,
-} from "@cursorless/common";
+import { HatStability, NormalizedIDE } from "@cursorless/common";
 
 export function setupFake(ide: NormalizedIDE, hatStability: HatStability) {
   ide.configuration.mockConfiguration("experimental", {
-    snippetsDir: getFixturePath("cursorless-snippets"),
+    ...ide.configuration.getOwnConfiguration("experimental"),
     hatStability,
   });
 }


### PR DESCRIPTION
- Makes it so that we can use `getCursorlessRepoRoot` anywhere
- Normalizes snippets dir so that recording snippets tests has same snippets available as in actual testing

## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet
