### PR TITLE
Add support for xml scopes to LaTeX

### DIFF
--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/latex/clearElm.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/latex/clearElm.yml
@@ -1,0 +1,25 @@
+languageId: latex
+command:
+  version: 5
+  spokenForm: clear elm
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: xmlElement}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    \begin{quote}
+        Hello
+    \end{quote}
+  selections:
+    - anchor: {line: 1, character: 4}
+      active: {line: 1, character: 4}
+  marks: {}
+finalState:
+  documentContents: ""
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/latex/clearEndTag.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/latex/clearEndTag.yml
@@ -1,0 +1,27 @@
+languageId: latex
+command:
+  version: 5
+  spokenForm: clear end tag
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: xmlEndTag}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    \begin{quote}
+        Hello
+    \end{quote}
+  selections:
+    - anchor: {line: 1, character: 4}
+      active: {line: 1, character: 4}
+  marks: {}
+finalState:
+  documentContents: |
+    \begin{quote}
+        Hello
+  selections:
+    - anchor: {line: 2, character: 0}
+      active: {line: 2, character: 0}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/latex/clearName.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/latex/clearName.yml
@@ -1,0 +1,28 @@
+languageId: latex
+command:
+  version: 5
+  spokenForm: clear name
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: name}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    \begin{quote}
+        Hello
+    \end{quote}
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  marks: {}
+finalState:
+  documentContents: |-
+    \begin{}
+        Hello
+    \end{quote}
+  selections:
+    - anchor: {line: 0, character: 7}
+      active: {line: 0, character: 7}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/latex/clearName2.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/latex/clearName2.yml
@@ -1,0 +1,28 @@
+languageId: latex
+command:
+  version: 5
+  spokenForm: clear name
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: name}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    \begin{quote}
+        Hello
+    \end{quote}
+  selections:
+    - anchor: {line: 2, character: 0}
+      active: {line: 2, character: 0}
+  marks: {}
+finalState:
+  documentContents: |-
+    \begin{quote}
+        Hello
+    \end{}
+  selections:
+    - anchor: {line: 2, character: 5}
+      active: {line: 2, character: 5}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/latex/clearStartTag.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/latex/clearStartTag.yml
@@ -1,0 +1,28 @@
+languageId: latex
+command:
+  version: 5
+  spokenForm: clear start tag
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: xmlStartTag}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    \begin{quote}
+        Hello
+    \end{quote}
+  selections:
+    - anchor: {line: 1, character: 4}
+      active: {line: 1, character: 4}
+  marks: {}
+finalState:
+  documentContents: |2-
+
+        Hello
+    \end{quote}
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/latex/clearTags.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/latex/clearTags.yml
@@ -1,0 +1,29 @@
+languageId: latex
+command:
+  version: 5
+  spokenForm: clear tags
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: xmlBothTags}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    \begin{quote}
+        Hello
+    \end{quote}
+  selections:
+    - anchor: {line: 1, character: 4}
+      active: {line: 1, character: 4}
+  marks: {}
+finalState:
+  documentContents: |2
+
+        Hello
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+    - anchor: {line: 2, character: 0}
+      active: {line: 2, character: 0}


### PR DESCRIPTION
Adds support for "tags", "start tag", "end tag", and "name tags" to LaTeX environments

...and once again regretting making our internal identifiers too specific 🤦‍♂️

## Checklist

- [x] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet
