### PR TITLE
pre-commit: Bump autoupdates from weekly to monthly

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,6 @@
 minimum_pre_commit_version: "2.9.0"
+ci:
+  autoupdate_schedule: monthly
 exclude: /vendor/
 repos:
   - repo: meta


### PR DESCRIPTION
This decreases the frequency of pre-commit.ci autoupdates.

## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet
