### PR TITLE
Move `hats` back onto `ide()`

### DIFF
--- a/packages/common/src/ide/PassthroughIDEBase.ts
+++ b/packages/common/src/ide/PassthroughIDEBase.ts
@@ -10,6 +10,7 @@ import {
   TextEditorVisibleRangesChangeEvent,
 } from "./types/events.types";
 import { FlashDescriptor } from "./types/FlashDescriptor";
+import { Hats } from "./types/Hats";
 import { Disposable, IDE, RunMode, WorkspaceFolder } from "./types/ide.types";
 import { Messages } from "./types/Messages";
 import { QuickPickOptions } from "./types/QuickPickOptions";
@@ -21,6 +22,7 @@ export default class PassthroughIDEBase implements IDE {
   clipboard: Clipboard;
   messages: Messages;
   capabilities: Capabilities;
+  hats: Hats;
 
   constructor(private original: IDE) {
     this.configuration = original.configuration;
@@ -28,6 +30,7 @@ export default class PassthroughIDEBase implements IDE {
     this.clipboard = original.clipboard;
     this.messages = original.messages;
     this.capabilities = original.capabilities;
+    this.hats = original.hats;
   }
 
   flashRanges(flashDescriptors: FlashDescriptor[]): Promise<void> {

--- a/packages/common/src/ide/fake/FakeHats.ts
+++ b/packages/common/src/ide/fake/FakeHats.ts
@@ -1,0 +1,19 @@
+import { Listener } from "../../util/Notifier";
+import { HatRange, Hats, HatStyleMap } from "../types/Hats";
+import { Disposable } from "../types/ide.types";
+
+export class FakeHats implements Hats {
+  setHatRanges(_hatRanges: HatRange[]): Promise<void> {
+    throw new Error("Method not implemented.");
+  }
+
+  enabledHatStyles: HatStyleMap = {};
+  onDidChangeEnabledHatStyles(_listener: Listener<[HatStyleMap]>): Disposable {
+    throw new Error("Method not implemented.");
+  }
+
+  isEnabled: boolean = false;
+  onDidChangeIsEnabled(_listener: Listener<[boolean]>): Disposable {
+    throw new Error("Method not implemented.");
+  }
+}

--- a/packages/common/src/ide/fake/FakeIDE.ts
+++ b/packages/common/src/ide/fake/FakeIDE.ts
@@ -20,6 +20,7 @@ import { FakeCapabilities } from "./FakeCapabilities";
 import FakeClipboard from "./FakeClipboard";
 import FakeConfiguration from "./FakeConfiguration";
 import FakeGlobalState from "./FakeGlobalState";
+import { FakeHats } from "./FakeHats";
 import FakeMessages from "./FakeMessages";
 
 export default class FakeIDE implements IDE {
@@ -28,6 +29,7 @@ export default class FakeIDE implements IDE {
   globalState: FakeGlobalState = new FakeGlobalState();
   clipboard: FakeClipboard = new FakeClipboard();
   capabilities: FakeCapabilities = new FakeCapabilities();
+  hats: FakeHats = new FakeHats();
 
   runMode: RunMode = "test";
   workspaceFolders: readonly WorkspaceFolder[] | undefined = undefined;

--- a/packages/common/src/ide/types/ide.types.ts
+++ b/packages/common/src/ide/types/ide.types.ts
@@ -16,6 +16,7 @@ import {
   TextEditorVisibleRangesChangeEvent,
 } from "./events.types";
 import { FlashDescriptor } from "./FlashDescriptor";
+import { Hats } from "./Hats";
 import { Messages } from "./Messages";
 import { QuickPickOptions } from "./QuickPickOptions";
 import { State } from "./State";
@@ -28,6 +29,7 @@ export interface IDE {
   readonly messages: Messages;
   readonly globalState: State;
   readonly clipboard: Clipboard;
+  readonly hats: Hats;
 
   /**
    * Register disposables to be disposed of on IDE exit.

--- a/packages/cursorless-vscode-core/src/ide/vscode/VscodeIDE.ts
+++ b/packages/cursorless-vscode-core/src/ide/vscode/VscodeIDE.ts
@@ -20,6 +20,7 @@ import { pull } from "lodash";
 import { v4 as uuid } from "uuid";
 import * as vscode from "vscode";
 import { ExtensionContext, window, workspace, WorkspaceFolder } from "vscode";
+import { VscodeHats } from "./hats/VscodeHats";
 import { VscodeCapabilities } from "./VscodeCapabilities";
 import VscodeClipboard from "./VscodeClipboard";
 import VscodeConfiguration from "./VscodeConfiguration";
@@ -39,6 +40,7 @@ export class VscodeIDE implements IDE {
   readonly messages: VscodeMessages;
   readonly clipboard: VscodeClipboard;
   readonly capabilities: VscodeCapabilities;
+  readonly hats: VscodeHats;
   private flashHandler: VscodeFlashHandler;
   private highlights: VscodeHighlights;
   private editorMap;
@@ -51,6 +53,7 @@ export class VscodeIDE implements IDE {
     this.highlights = new VscodeHighlights(extensionContext);
     this.flashHandler = new VscodeFlashHandler(this, this.highlights);
     this.capabilities = new VscodeCapabilities();
+    this.hats = new VscodeHats(this, extensionContext);
     this.editorMap = new WeakMap<vscode.TextEditor, VscodeTextEditorImpl>();
   }
 
@@ -59,6 +62,10 @@ export class VscodeIDE implements IDE {
     options?: QuickPickOptions,
   ): Promise<string | undefined> {
     return await vscodeShowQuickPick(items, options);
+  }
+
+  async init() {
+    await this.hats.init();
   }
 
   setHighlightRanges(

--- a/packages/cursorless-vscode-core/src/index.ts
+++ b/packages/cursorless-vscode-core/src/index.ts
@@ -1,6 +1,5 @@
 export * from "./StatusBarItem";
 export * from "./commands";
 export * from "./ide/vscode/VscodeIDE";
-export * from "./ide/vscode/hats/VscodeHats";
 export * from "./ide/vscode/toVscodeEditor";
 export * from "./keyboard/KeyboardCommands";

--- a/packages/cursorless-vscode/src/extension.ts
+++ b/packages/cursorless-vscode/src/extension.ts
@@ -24,7 +24,6 @@ import {
   commandIds,
   KeyboardCommands,
   StatusBarItem,
-  VscodeHats,
   VscodeIDE,
 } from "@cursorless/cursorless-vscode-core";
 import {
@@ -51,6 +50,7 @@ export async function activate(
   const parseTreeApi = await getParseTreeApi();
 
   const vscodeIDE = new VscodeIDE(context);
+  await vscodeIDE.init();
 
   if (vscodeIDE.runMode !== "production") {
     injectIde(
@@ -80,10 +80,7 @@ export async function activate(
   } as FactoryMap<Graph>);
   graph.snippets.init();
 
-  const hats = new VscodeHats(vscodeIDE, context);
-  await hats.init();
-
-  const hatTokenMap = new HatTokenMapImpl(graph, debug, hats);
+  const hatTokenMap = new HatTokenMapImpl(graph, debug, vscodeIDE.hats);
   hatTokenMap.allocateHats();
 
   const testCaseRecorder = new TestCaseRecorder(hatTokenMap);


### PR DESCRIPTION
This PR partially rolls back #1378. After some discussion, we decided that it is nice to have a unified definition of what we expect from an ide.  The main benefit of #1378 was making the dependencies of our components more granular.  We'd like to still have a unified interface (`ide`) that defines the api surface of an ide, but to only refer to that interface from the composition root.  The composition root will divvy out the pieces that components depend on

## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet
