### PR TITLE
Bump engine/VSCode TypeScript target to ES2020

### DIFF
--- a/packages/cursorless-engine/tsconfig.json
+++ b/packages/cursorless-engine/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "target": "es2020",
     "outDir": "out",
     "rootDir": "src"
   },

--- a/packages/cursorless-vscode/tsconfig.json
+++ b/packages/cursorless-vscode/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "target": "es2020",
     "outDir": "out",
     "rootDir": "src"
   },

--- a/packages/vscode-common/tsconfig.json
+++ b/packages/vscode-common/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "target": "es2020",
     "outDir": "out",
     "rootDir": "src"
   },


### PR DESCRIPTION
Our legacy tests currently run against VSCode 1.66.0:

https://github.com/cursorless-dev/cursorless/blob/68ba545520829a21e26d70437c650fb615d73344/packages/test-harness/src/util/launchVscodeAndRunTests.ts#L37

However, we pull in types for VSCode 1.61:

https://github.com/cursorless-dev/cursorless/blob/68ba545520829a21e26d70437c650fb615d73344/packages/cursorless-vscode-core/package.json#L31

and the extension also declares support for the same version:

https://github.com/cursorless-dev/cursorless/blob/68ba545520829a21e26d70437c650fb615d73344/packages/cursorless-vscode/package.json#L32

so 1.61 shall be our lowest common denominator.

VSCode 1.61.0 uses Electron 13: https://github.com/microsoft/vscode/blob/1.61.0/package.json#L134

Per [Electron's docs](https://www.electronjs.org/docs/latest/tutorial/electron-timelines), Electron 13 included Chromium 91 and Node.js v14.16.

Per the trusty [ECMAScript compatibility table](https://kangax.github.io/compat-table/es2016plus/) and [Stack Overflow](https://stackoverflow.com/questions/61305578/what-typescript-configuration-produces-output-closest-to-node-js-14-capabilities), Node 14 fully supports ES2020.

This bumps the TypeScript target to ES2020 to reduce bundle sizes.

## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet
