### PR TITLE
[talon] Fix confusing replace action type hint

### DIFF
--- a/cursorless-talon/src/actions/replace.py
+++ b/cursorless-talon/src/actions/replace.py
@@ -5,6 +5,6 @@ mod = Module()
 
 @mod.action_class
 class Actions:
-    def cursorless_replace(target: dict, texts: list[str] or dict):
+    def cursorless_replace(target: dict, texts: list[str]):
         """Replace targets with texts"""
         actions.user.cursorless_single_target_command("replace", target, texts)


### PR DESCRIPTION
The type hint `list[str] or dict` always evaluated to `list[str]` at runtime.

`cursorless_replace` was only ever used in homophones and reformat, both of which always pass a list.

## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet
