### PR TITLE
[talon] Omit custom actions from action defaults

### DIFF
--- a/cursorless-talon/src/actions/actions.py
+++ b/cursorless-talon/src/actions/actions.py
@@ -3,7 +3,6 @@ from talon import Module, actions, app
 from ..csv_overrides import init_csv_and_watch_changes
 from ..primitive_target import IMPLICIT_TARGET
 from .actions_callback import callback_action_defaults, callback_action_map
-from .actions_custom import custom_action_defaults
 from .actions_simple import (
     no_wait_actions,
     no_wait_actions_post_sleep,
@@ -83,7 +82,6 @@ default_values = {
     "simple_action": simple_action_defaults,
     "positional_action": positional_action_defaults,
     "callback_action": callback_action_defaults,
-    "custom_action": custom_action_defaults,
     "swap_action": {"swap": "swapTargets"},
     "move_bring_action": {"bring": "replaceWithTarget", "move": "moveToTarget"},
     "wrap_action": {"wrap": "wrapWithPairedDelimiter", "repack": "rewrap"},
@@ -95,7 +93,7 @@ default_values = {
 ACTION_LIST_NAMES = default_values.keys()
 
 
-def on_ready():
+def on_ready() -> None:
     init_csv_and_watch_changes("actions", default_values)
 
 

--- a/cursorless-talon/src/actions/actions_custom.py
+++ b/cursorless-talon/src/actions/actions_custom.py
@@ -2,7 +2,7 @@ from talon import Module, app
 
 from ..csv_overrides import SPOKEN_FORM_HEADER, init_csv_and_watch_changes
 
-custom_action_defaults = {}
+custom_action_defaults: dict[str, str] = {}
 
 
 mod = Module()
@@ -12,10 +12,10 @@ mod.list(
 )
 
 
-def on_ready():
+def on_ready() -> None:
     init_csv_and_watch_changes(
         "experimental/actions_custom",
-        custom_action_defaults,
+        {"custom_action": custom_action_defaults},
         headers=[SPOKEN_FORM_HEADER, "VSCode command"],
         allow_unknown_values=True,
         default_list_name="custom_action",


### PR DESCRIPTION
Whilst this effectively does nothing, adding the empty defaults to two different CSVs seems to have been an oversight.

## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet
