### PR TITLE
Lint *.tsx from top-level lint script

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "meta-updater": "pnpm run meta-updater:base && pnpm -r exec prettier --write tsconfig.json package.json",
     "lint:meta": "pnpm run meta-updater:base --test",
     "lint": "pnpm run lint:meta && syncpack list-mismatches && pnpm run lint:ts",
-    "lint:ts": "eslint packages --ext ts",
+    "lint:ts": "eslint packages --ext ts,tsx",
     "test": "pnpm compile && pnpm lint && pnpm -F '!test-harness' test && pnpm -F test-harness test",
     "transform-recorded-tests": "pnpm -F @cursorless/cursorless-engine transform-recorded-tests",
     "unused-exports": "ts-unused-exports tsconfig.json --showLineNumber",


### PR DESCRIPTION
The website `*.tsx` files weren't being linted in CI, as `pnpm test` isn't doing a recursive `pnpm lint`:

https://github.com/cursorless-dev/cursorless/blob/68ba545520829a21e26d70437c650fb615d73344/package.json#L18

A single `eslint` run should be enough to lint the entire TypeScript codebase with the correct configs, I think.

## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet
