### PR TITLE
`PositionTarget`: consider minimum line indentation when pouring multiline target

### DIFF
--- a/packages/cursorless-engine/src/processTargets/targets/PositionTarget.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/PositionTarget.ts
@@ -17,7 +17,6 @@ export default class PositionTarget extends BaseTarget {
   private isLineDelimiter: boolean;
   private isBefore: boolean;
   private indentationString: string;
-  private editNewActionType: EditNewActionType;
 
   constructor(parameters: PositionTargetParameters) {
     super(parameters);
@@ -34,12 +33,6 @@ export default class PositionTarget extends BaseTarget {
           parameters.thatTarget!.contentRange,
         )
       : "";
-    this.editNewActionType =
-      this.insertionDelimiter === "\n" &&
-      this.position === "after" &&
-      parameters.thatTarget!.contentRange.isSingleLine
-        ? "insertLineAfter"
-        : "edit";
   }
 
   getLeadingDelimiterTarget = () => undefined;
@@ -48,7 +41,15 @@ export default class PositionTarget extends BaseTarget {
   getRemovalRange = () => removalUnsupportedForPosition(this.position);
 
   getEditNewActionType(): EditNewActionType {
-    return this.editNewActionType;
+    if (
+      this.insertionDelimiter === "\n" &&
+      this.position === "after" &&
+      this.thatTarget.contentRange.isSingleLine
+    ) {
+      return "insertLineAfter";
+    }
+
+    return "edit";
   }
 
   constructChangeEdit(text: string): EditWithRangeUpdater {

--- a/packages/cursorless-engine/src/processTargets/targets/PositionTarget.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/PositionTarget.ts
@@ -17,6 +17,7 @@ export default class PositionTarget extends BaseTarget {
   private isLineDelimiter: boolean;
   private isBefore: boolean;
   private indentationString: string;
+  private editNewActionType: EditNewActionType;
 
   constructor(parameters: PositionTargetParameters) {
     super(parameters);
@@ -33,6 +34,12 @@ export default class PositionTarget extends BaseTarget {
           parameters.thatTarget!.contentRange,
         )
       : "";
+    this.editNewActionType =
+      this.insertionDelimiter === "\n" &&
+      this.position === "after" &&
+      parameters.thatTarget!.contentRange.isSingleLine
+        ? "insertLineAfter"
+        : "edit";
   }
 
   getLeadingDelimiterTarget = () => undefined;
@@ -41,11 +48,7 @@ export default class PositionTarget extends BaseTarget {
   getRemovalRange = () => removalUnsupportedForPosition(this.position);
 
   getEditNewActionType(): EditNewActionType {
-    if (this.insertionDelimiter === "\n" && this.position === "after") {
-      return "insertLineAfter";
-    }
-
-    return "edit";
+    return this.editNewActionType;
   }
 
   constructChangeEdit(text: string): EditWithRangeUpdater {

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/positions/pourIfState.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/positions/pourIfState.yml
@@ -1,0 +1,26 @@
+languageId: python
+command:
+  version: 5
+  spokenForm: pour if state
+  action: {name: editNewLineAfter}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: ifStatement}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    if True:
+        foo = "bar"
+  selections:
+    - anchor: {line: 1, character: 4}
+      active: {line: 1, character: 4}
+  marks: {}
+finalState:
+  documentContents: |
+    if True:
+        foo = "bar"
+  selections:
+    - anchor: {line: 2, character: 0}
+      active: {line: 2, character: 0}


### PR DESCRIPTION
We have functionality that computes minimum indentation when doing a "pour", but we don't use it if the delimiter is `\n` because we switch to using the editor's newline insertion to handle things like indenting after a line ending in `:` in Python.  However, if the user is explicitly pouring something that is multiple lines, then I argue that it is safe to do our own insertion.  This change enables things like properly dedenting after an if statement in Python

## Checklist

- [x] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet
