### PR TITLE
Remove scary-looking error message in test runs

### DIFF
--- a/packages/cursorless-engine/src/core/commandRunner/CommandRunner.ts
+++ b/packages/cursorless-engine/src/core/commandRunner/CommandRunner.ts
@@ -2,6 +2,7 @@ import {
   ActionType,
   Command,
   HatTokenMap,
+  isTesting,
   PartialTargetV0V1,
 } from "@cursorless/common";
 import { ActionRecord } from "../../actions/actions.types";
@@ -161,7 +162,9 @@ export class CommandRunner {
       return returnValue;
     } catch (e) {
       const err = e as Error;
-      console.error(err.stack);
+      if (!isTesting()) {
+        console.error(err.stack);
+      }
       await this.testCaseRecorder.commandErrorHook(err);
       throw e;
     } finally {


### PR DESCRIPTION
Our test runs currently look like this when they're passing:

<img width="1009" alt="image" src="https://user-images.githubusercontent.com/755842/231879688-95a9af27-b690-44d6-97ed-bc4d9ed0d838.png">

That's not particularly reassuring, especially for new contributors.  This PR fixes that.  It's not necessary to log errors from command runner, because the exception bubbles all the way up so we see the stack trace anyway

## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet
