### PR TITLE
Add recorded test formatter to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,6 +52,13 @@ repos:
         language: system
         entry: pnpm exec prettier
         args: [--write, --list-different, --ignore-unknown]
+  - repo: local
+    hooks:
+      - id: format-recorded-tests
+        name: format-recorded-tests
+        files: ^packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/.*/[^/]*\.yml$
+        language: system
+        entry: pnpm transform-recorded-tests
   - repo: https://github.com/ikamensh/flynt/
     rev: "0.78"
     hooks:

--- a/docs/contributing/test-case-recorder.md
+++ b/docs/contributing/test-case-recorder.md
@@ -81,7 +81,7 @@ To clean up the formatting of all of the yaml test cases, run `pnpm transform-re
 
 ### Upgrading fixtures
 
-To upgrade all the test fixtures to the latest command version, run the command `pnpm transform-recorded-tests upgrade`. This command should be idempotent.
+To upgrade all the test fixtures to the latest command version, run the command `pnpm transform-recorded-tests --upgrade`. This command should be idempotent.
 
 ### Custom transformation
 
@@ -89,7 +89,7 @@ To upgrade all the test fixtures to the latest command version, run the command 
 1. Change the value at the `custom` key in `AVAILABLE_TRANSFORMATIONS` at the top of
    [`transformRecordedTests/index.ts`](../../packages/cursorless-engine/src/scripts/transformRecordedTests/index.ts) to
    point to your new transformation
-1. Run `pnpm transform-recorded-tests custom`
+1. Run `pnpm transform-recorded-tests --custom`
 
 Example of a custom transformation
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "preinstall": "npx only-allow pnpm",
     "test-compile": "tsc --build",
     "test": "pnpm compile && pnpm lint && pnpm -F '!test-harness' test && pnpm -F test-harness test",
-    "transform-recorded-tests": "pnpm -F @cursorless/cursorless-engine transform-recorded-tests",
+    "transform-recorded-tests": "tsx --conditions=cursorless:bundler packages/cursorless-engine/src/scripts/transformRecordedTests/index.ts",
     "watch": "tsc --build --watch"
   },
   "keywords": [],

--- a/packages/cursorless-engine/package.json
+++ b/packages/cursorless-engine/package.json
@@ -5,7 +5,6 @@
   "main": "./out/index.js",
   "scripts": {
     "compile": "tsc --build",
-    "transform-recorded-tests": "tsx --conditions=cursorless:bundler src/scripts/transformRecordedTests/index.ts",
     "watch": "tsc --build --watch"
   },
   "keywords": [],

--- a/packages/cursorless-engine/src/scripts/transformRecordedTests/index.ts
+++ b/packages/cursorless-engine/src/scripts/transformRecordedTests/index.ts
@@ -7,11 +7,15 @@ import { upgradeDecorations } from "./upgradeDecorations";
 
 const AVAILABLE_TRANSFORMATIONS: Record<string, FixtureTransformation> = {
   upgrade,
-  autoFormat: identity,
+  format: identity,
   custom: upgradeDecorations,
 };
 
-async function main(transformationName: string | undefined) {
+async function main(args: string[]) {
+  const [transformationName, paths] = args?.[0]?.startsWith("--")
+    ? [args[0].slice(2), args.slice(1)]
+    : [null, args];
+
   const transformation =
     transformationName == null
       ? identity
@@ -21,7 +25,9 @@ async function main(transformationName: string | undefined) {
     throw new Error(`Unknown transformation ${transformationName}`);
   }
 
-  getRecordedTestPaths().forEach((path) => transformFile(transformation, path));
+  const testPaths = paths.length > 0 ? paths : getRecordedTestPaths();
+
+  testPaths.forEach((path) => transformFile(transformation, path));
 }
 
-main(process.argv[2]);
+main(process.argv.slice(2));

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/decorations/carveLineHarp.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/decorations/carveLineHarp.yml
@@ -25,7 +25,7 @@ finalState:
   selections:
     - anchor: {line: 0, character: 0}
       active: {line: 0, character: 0}
-  clipboard: "hello world"
+  clipboard: hello world
 ide:
   flashes:
     - style: referenced


### PR DESCRIPTION
## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet
