### PR TITLE
Find Linux code-oss and flatpak VSCode/VSCodium settings

### DIFF
--- a/cursorless-talon/src/apps/vscode_settings.py
+++ b/cursorless-talon/src/apps/vscode_settings.py
@@ -87,10 +87,14 @@ class LinuxUserActions:
         xdg_config_home = Path(
             os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config")
         )
+        flatpak_apps = Path.home() / ".var/app"
         return pick_path(
             [
                 xdg_config_home / "Code/User/settings.json",
                 xdg_config_home / "VSCodium/User/settings.json",
+                xdg_config_home / "Code - OSS/User/settings.json",
+                flatpak_apps / "com.visualstudio.code/config/Code/User/settings.json",
+                flatpak_apps / "com.vscodium.codium/config/VSCodium/User/settings.json",
             ]
         )
 


### PR DESCRIPTION
From [#vscode Talon Slack thread](https://talonvoice.slack.com/archives/CCEE45RT7/p1681736253449419)

This adds VSCode settings paths on Linux for:
- `code-oss` (i.e. unbranded builds of microsoft/vscode - notably distributed by Arch)
- the VSCode and VSCodium Flatpaks

## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet
