### PR TITLE
Support specifying text fragments via queries

### DIFF
--- a/packages/cursorless-engine/src/cursorlessEngine.ts
+++ b/packages/cursorless-engine/src/cursorlessEngine.ts
@@ -41,6 +41,7 @@ export function createCursorlessEngine(
   const scopeHandlerFactory = new ScopeHandlerFactoryImpl(languageDefinitions);
   const markStageFactory = new MarkStageFactoryImpl();
   const modifierStageFactory = new ModifierStageFactoryImpl(
+    languageDefinitions,
     scopeHandlerFactory,
   );
   const actions = new Actions(snippets, rangeUpdater, modifierStageFactory);

--- a/packages/cursorless-engine/src/languages/LanguageDefinition.ts
+++ b/packages/cursorless-engine/src/languages/LanguageDefinition.ts
@@ -2,10 +2,13 @@ import { ScopeType, SimpleScopeType } from "@cursorless/common";
 import { existsSync, readFileSync } from "fs";
 import { join } from "path";
 import { TreeSitterScopeHandler } from "../processTargets/modifiers/scopeHandlers";
+import { TreeSitterTextFragmentScopeHandler } from "../processTargets/modifiers/scopeHandlers/TreeSitterScopeHandler/TreeSitterTextFragmentScopeHandler";
+import { ScopeHandler } from "../processTargets/modifiers/scopeHandlers/scopeHandler.types";
 import { ide } from "../singletons/ide.singleton";
 import { TreeSitter } from "../typings/TreeSitter";
-import { LanguageId } from "./constants";
 import { TreeSitterQuery } from "./TreeSitterQuery";
+import { TEXT_FRAGMENT_CAPTURE_NAME } from "./captureNames";
+import { LanguageId } from "./constants";
 
 /**
  * Represents a language definition for a single language, including the
@@ -62,5 +65,13 @@ export class LanguageDefinition {
     }
 
     return new TreeSitterScopeHandler(this.query, scopeType as SimpleScopeType);
+  }
+
+  getTextFragmentScopeHandler(): ScopeHandler | undefined {
+    if (!this.query.captureNames.includes(TEXT_FRAGMENT_CAPTURE_NAME)) {
+      return undefined;
+    }
+
+    return new TreeSitterTextFragmentScopeHandler(this.query);
   }
 }

--- a/packages/cursorless-engine/src/languages/captureNames.ts
+++ b/packages/cursorless-engine/src/languages/captureNames.ts
@@ -1,0 +1,5 @@
+/**
+ * The name of the capture group that captures text fragments, for use with
+ * surrounding pairs.
+ */
+export const TEXT_FRAGMENT_CAPTURE_NAME = "textFragment";

--- a/packages/cursorless-engine/src/processTargets/ModifierStageFactoryImpl.ts
+++ b/packages/cursorless-engine/src/processTargets/ModifierStageFactoryImpl.ts
@@ -4,6 +4,7 @@ import {
   Modifier,
   SurroundingPairModifier,
 } from "@cursorless/common";
+import { LanguageDefinitions } from "../languages/LanguageDefinitions";
 import { ModifierStageFactory } from "./ModifierStageFactory";
 import { ModifierStage } from "./PipelineStages.types";
 import CascadingStage from "./modifiers/CascadingStage";
@@ -42,7 +43,10 @@ import {
 } from "./modifiers/scopeTypeStages/RegexStage";
 
 export class ModifierStageFactoryImpl implements ModifierStageFactory {
-  constructor(private scopeHandlerFactory: ScopeHandlerFactory) {
+  constructor(
+    private languageDefinitions: LanguageDefinitions,
+    private scopeHandlerFactory: ScopeHandlerFactory,
+  ) {
     this.create = this.create.bind(this);
   }
 
@@ -115,15 +119,22 @@ export class ModifierStageFactoryImpl implements ModifierStageFactory {
       case "nonWhitespaceSequence":
         return new NonWhitespaceSequenceStage(modifier);
       case "boundedNonWhitespaceSequence":
-        return new BoundedNonWhitespaceSequenceStage(this, modifier);
+        return new BoundedNonWhitespaceSequenceStage(
+          this.languageDefinitions,
+          this,
+          modifier,
+        );
       case "url":
         return new UrlStage(modifier);
       case "collectionItem":
-        return new ItemStage(modifier);
+        return new ItemStage(this.languageDefinitions, modifier);
       case "customRegex":
         return new CustomRegexStage(modifier as CustomRegexModifier);
       case "surroundingPair":
-        return new SurroundingPairStage(modifier as SurroundingPairModifier);
+        return new SurroundingPairStage(
+          this.languageDefinitions,
+          modifier as SurroundingPairModifier,
+        );
       default:
         // Default to containing syntax scope using tree sitter
         return new ContainingSyntaxScopeStage(

--- a/packages/cursorless-engine/src/processTargets/modifiers/ItemStage/getIterationScope.ts
+++ b/packages/cursorless-engine/src/processTargets/modifiers/ItemStage/getIterationScope.ts
@@ -18,37 +18,42 @@ export function getIterationScope(
   context: ProcessedTargetsContext,
   target: Target,
 ): { range: Range; boundary?: [Range, Range] } {
-  let pairInfo = getSurroundingPair(languageDefinition, context, target);
+  let surroundingTarget = getSurroundingPair(
+    languageDefinition,
+    context,
+    target,
+  );
 
   // Iteration is necessary in case of nested strings
-  while (pairInfo != null) {
-    const stringPairInfo = getStringSurroundingPair(
+  while (surroundingTarget != null) {
+    const surroundingStringTarget = getStringSurroundingPair(
       languageDefinition,
       context,
-      pairInfo,
+      surroundingTarget,
     );
 
     // We don't look for items inside strings.
     if (
       // Not in a string
-      stringPairInfo == null ||
+      surroundingStringTarget == null ||
       // In a non-string surrounding pair that is inside a surrounding string. This is fine.
-      stringPairInfo.contentRange.start.isBefore(pairInfo.contentRange.start)
+      surroundingStringTarget.contentRange.start.isBefore(
+        surroundingTarget.contentRange.start,
+      )
     ) {
       return {
-        range: pairInfo.getInteriorStrict()[0].contentRange,
-        boundary: pairInfo.getBoundaryStrict().map((t) => t.contentRange) as [
-          Range,
-          Range,
-        ],
+        range: surroundingTarget.getInteriorStrict()[0].contentRange,
+        boundary: surroundingTarget
+          .getBoundaryStrict()
+          .map((t) => t.contentRange) as [Range, Range],
       };
     }
 
-    pairInfo = getParentSurroundingPair(
+    surroundingTarget = getParentSurroundingPair(
       languageDefinition,
       context,
       target.editor,
-      pairInfo,
+      surroundingTarget,
     );
   }
 

--- a/packages/cursorless-engine/src/processTargets/modifiers/scopeHandlers/TreeSitterScopeHandler/TreeSitterTextFragmentScopeHandler.ts
+++ b/packages/cursorless-engine/src/processTargets/modifiers/scopeHandlers/TreeSitterScopeHandler/TreeSitterTextFragmentScopeHandler.ts
@@ -1,0 +1,53 @@
+import { ScopeType, TextEditor } from "@cursorless/common";
+import { QueryMatch } from "web-tree-sitter";
+import { TreeSitterQuery } from "../../../../languages/TreeSitterQuery";
+import { TEXT_FRAGMENT_CAPTURE_NAME } from "../../../../languages/captureNames";
+import { PlainTarget } from "../../../targets";
+import { TargetScope } from "../scope.types";
+import { BaseTreeSitterScopeHandler } from "./BaseTreeSitterScopeHandler";
+import { getCaptureRangeByName } from "./captureUtils";
+
+/** Scope handler to be used for extracting text fragments from the perspective
+ * of surrounding pairs */
+export class TreeSitterTextFragmentScopeHandler extends BaseTreeSitterScopeHandler {
+  protected isHierarchical = true;
+
+  // Doesn't correspond to any scope type
+  public scopeType = undefined;
+
+  // Doesn't have any iteration scope type itself; that would correspond to
+  // something like "every every"
+  public get iterationScopeType(): ScopeType {
+    throw Error("Not implemented");
+  }
+
+  constructor(query: TreeSitterQuery) {
+    super(query);
+  }
+
+  protected matchToScope(
+    editor: TextEditor,
+    match: QueryMatch,
+  ): TargetScope | undefined {
+    const contentRange = getCaptureRangeByName(
+      match,
+      TEXT_FRAGMENT_CAPTURE_NAME,
+    );
+
+    if (contentRange == null) {
+      // This capture was for some unrelated scope type
+      return undefined;
+    }
+
+    return {
+      editor,
+      domain: contentRange,
+      getTarget: (isReversed) =>
+        new PlainTarget({
+          editor,
+          isReversed,
+          contentRange,
+        }),
+    };
+  }
+}

--- a/packages/cursorless-engine/src/processTargets/modifiers/scopeTypeStages/BoundedNonWhitespaceStage.ts
+++ b/packages/cursorless-engine/src/processTargets/modifiers/scopeTypeStages/BoundedNonWhitespaceStage.ts
@@ -3,6 +3,7 @@ import {
   EveryScopeModifier,
   NoContainingScopeError,
 } from "@cursorless/common";
+import { LanguageDefinitions } from "../../../languages/LanguageDefinitions";
 import { ProcessedTargetsContext } from "../../../typings/Types";
 import { Target } from "../../../typings/target.types";
 import { ModifierStageFactory } from "../../ModifierStageFactory";
@@ -19,6 +20,7 @@ export default class BoundedNonWhitespaceSequenceStage
   implements ModifierStage
 {
   constructor(
+    private languageDefinitions: LanguageDefinitions,
     private modifierStageFactory: ModifierStageFactory,
     private modifier: ContainingScopeModifier | EveryScopeModifier,
   ) {}
@@ -32,9 +34,9 @@ export default class BoundedNonWhitespaceSequenceStage
     const paintTargets = paintStage.run(context, target);
 
     const pairInfo = processSurroundingPair(
+      this.languageDefinitions.get(target.editor.document.languageId),
       context,
-      target.editor,
-      target.contentRange,
+      target,
       {
         type: "surroundingPair",
         delimiter: "any",
@@ -48,7 +50,7 @@ export default class BoundedNonWhitespaceSequenceStage
 
     const targets = paintTargets.flatMap((paintTarget) => {
       const contentRange = paintTarget.contentRange.intersection(
-        pairInfo.interiorRange,
+        pairInfo.getInteriorStrict()[0].contentRange,
       );
 
       if (contentRange == null || contentRange.isEmpty) {

--- a/packages/cursorless-engine/src/processTargets/modifiers/surroundingPair/index.ts
+++ b/packages/cursorless-engine/src/processTargets/modifiers/surroundingPair/index.ts
@@ -37,7 +37,7 @@ export function processSurroundingPair(
   target: Target,
   scopeType: SurroundingPairScopeType,
 ): SurroundingPairTarget | null {
-  const pairInfo = getSurroundingPairInfo(
+  const pairInfo = processSurroundingPairCore(
     languageDefinition,
     context,
     target,
@@ -55,7 +55,12 @@ export function processSurroundingPair(
   });
 }
 
-function getSurroundingPairInfo(
+/**
+ * Helper function that does the real work; caller just calls this function and
+ * converts output from a {@link SurroundingPairInfo} to a
+ * {@link SurroundingPairTarget}.
+ */
+function processSurroundingPairCore(
   languageDefinition: LanguageDefinition | undefined,
   context: ProcessedTargetsContext,
   target: Target,


### PR DESCRIPTION
Allows specifying which nodes should be treated as raw text from the perspective of surrounding pairs.  For example

```scm
(comment) @textFragment
```

- see eg https://github.com/cursorless-dev/cursorless/pull/1448/files#diff-83dc43cab688debd9b40743b835d49f7a047d393df9da5bb39e354f39aa09966R7-R8

## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet
