### PR TITLE
Add Cursorless support for tree-sitter query `.scm` files

### DIFF
--- a/packages/common/src/extensionDependencies.ts
+++ b/packages/common/src/extensionDependencies.ts
@@ -4,4 +4,5 @@ export const extensionDependencies = [
   "scalameta.metals",
   "ms-python.python",
   "mrob95.vscode-talonscript",
+  "jrieken.vscode-tree-sitter-query",
 ];

--- a/packages/cursorless-engine/src/languages/TreeSitterQuery/checkCaptureStartEnd.test.ts
+++ b/packages/cursorless-engine/src/languages/TreeSitterQuery/checkCaptureStartEnd.test.ts
@@ -130,7 +130,7 @@ const testCases: TestCase[] = [
   },
 
   {
-    name: "should show error for capture with multiple start",
+    name: "should allow capture with multiple start",
     captures: [
       {
         name: "@foo.start",
@@ -145,8 +145,8 @@ const testCases: TestCase[] = [
         range: new Range(0, 2, 0, 3),
       },
     ],
-    isValid: false,
-    expectedErrorMessageIds: ["TreeSitterQuery.checkCaptures.duplicate"],
+    isValid: true,
+    expectedErrorMessageIds: [],
   },
 
   {
@@ -157,7 +157,7 @@ const testCases: TestCase[] = [
         range: new Range(0, 0, 0, 0),
       },
       {
-        name: "@foo.start",
+        name: "@foo",
         range: new Range(0, 1, 0, 2),
       },
       {

--- a/packages/cursorless-engine/src/languages/TreeSitterQuery/queryPredicateOperators.ts
+++ b/packages/cursorless-engine/src/languages/TreeSitterQuery/queryPredicateOperators.ts
@@ -58,19 +58,18 @@ class IsNthChild extends QueryPredicateOperator<IsNthChild> {
 }
 
 /**
- * A predicate operator that returns true if the node has between {@link min}
- * and {@link max} children of type {@link type} (inclusive).  For example,
- * `(has-n-children-of-type? @foo bar 1 2)` will accept the match if the `@foo`
- * capture has 1, 2 or 3 children of type `bar`. If {@link max} is -1, then we
- * don't limit the maximum.
+ * A predicate operator that returns true if the node has more than 1 child of
+ * type {@link type} (inclusive).  For example, `(has-multiple-children-of-type?
+ * @foo bar)` will accept the match if the `@foo` capture has 2 or more children
+ * of type `bar`.
  */
-class HasNChildrenOfType extends QueryPredicateOperator<HasNChildrenOfType> {
-  name = "has-n-children-of-type?" as const;
-  schema = z.tuple([q.node, q.string, q.integer, q.integer]);
+class HasMultipleChildrenOfType extends QueryPredicateOperator<HasMultipleChildrenOfType> {
+  name = "has-multiple-children-of-type?" as const;
+  schema = z.tuple([q.node, q.string]);
 
-  run({ node }: MutableQueryCapture, type: string, min: number, max: number) {
+  run({ node }: MutableQueryCapture, type: string) {
     const count = node.children.filter((n) => n.type === type).length;
-    return count >= min && (max === -1 || count <= max);
+    return count > 1;
   }
 }
 
@@ -187,5 +186,5 @@ export const queryPredicateOperators = [
   new ShrinkToMatch(),
   new AllowMultiple(),
   new InsertionDelimiter(),
-  new HasNChildrenOfType(),
+  new HasMultipleChildrenOfType(),
 ];

--- a/packages/cursorless-engine/src/languages/TreeSitterQuery/queryPredicateOperators.ts
+++ b/packages/cursorless-engine/src/languages/TreeSitterQuery/queryPredicateOperators.ts
@@ -57,6 +57,23 @@ class IsNthChild extends QueryPredicateOperator<IsNthChild> {
   }
 }
 
+/**
+ * A predicate operator that returns true if the node has between {@link min}
+ * and {@link max} children of type {@link type} (inclusive).  For example,
+ * `(has-n-children-of-type? @foo bar 1 2)` will accept the match if the `@foo`
+ * capture has 1, 2 or 3 children of type `bar`. If {@link max} is -1, then we
+ * don't limit the maximum.
+ */
+class HasNChildrenOfType extends QueryPredicateOperator<HasNChildrenOfType> {
+  name = "has-n-children-of-type?" as const;
+  schema = z.tuple([q.node, q.string, q.integer, q.integer]);
+
+  run({ node }: MutableQueryCapture, type: string, min: number, max: number) {
+    const count = node.children.filter((n) => n.type === type).length;
+    return count >= min && (max === -1 || count <= max);
+  }
+}
+
 class ChildRange extends QueryPredicateOperator<ChildRange> {
   name = "child-range!" as const;
   schema = z.union([
@@ -170,4 +187,5 @@ export const queryPredicateOperators = [
   new ShrinkToMatch(),
   new AllowMultiple(),
   new InsertionDelimiter(),
+  new HasNChildrenOfType(),
 ];

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/bringNameToAir.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/bringNameToAir.yml
@@ -1,0 +1,36 @@
+languageId: scm
+command:
+  version: 6
+  spokenForm: bring name to air
+  action:
+    name: replaceWithTarget
+    source:
+      type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: name}
+    destination:
+      type: primitive
+      insertionMode: to
+      target:
+        type: primitive
+        mark: {type: decoratedSymbol, symbolColor: default, character: a}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    (aaa) @bbb @ccc @ddd
+    (eee) @fff
+  selections:
+    - anchor: {line: 1, character: 0}
+      active: {line: 1, character: 0}
+  marks:
+    default.a:
+      start: {line: 0, character: 1}
+      end: {line: 0, character: 4}
+finalState:
+  documentContents: |-
+    (aaa) @fff
+    (eee) @fff
+  selections:
+    - anchor: {line: 1, character: 0}
+      active: {line: 1, character: 0}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/changeEveryName.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/changeEveryName.yml
@@ -1,0 +1,27 @@
+languageId: scm
+command:
+  version: 6
+  spokenForm: change every name
+  action:
+    name: clearAndSetSelection
+    target:
+      type: primitive
+      modifiers:
+        - type: everyScope
+          scopeType: {type: name}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: (aaa) @bbb @ccc @ddd
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  marks: {}
+finalState:
+  documentContents: (aaa) @ @ @
+  selections:
+    - anchor: {line: 0, character: 7}
+      active: {line: 0, character: 7}
+    - anchor: {line: 0, character: 9}
+      active: {line: 0, character: 9}
+    - anchor: {line: 0, character: 11}
+      active: {line: 0, character: 11}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/changeName.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/changeName.yml
@@ -1,0 +1,23 @@
+languageId: scm
+command:
+  version: 6
+  spokenForm: change name
+  action:
+    name: clearAndSetSelection
+    target:
+      type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: name}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: (aaa) @bbb @ccc @ddd
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  marks: {}
+finalState:
+  documentContents: (aaa) @
+  selections:
+    - anchor: {line: 0, character: 7}
+      active: {line: 0, character: 7}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/changeName2.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/changeName2.yml
@@ -1,0 +1,23 @@
+languageId: scm
+command:
+  version: 6
+  spokenForm: change name
+  action:
+    name: clearAndSetSelection
+    target:
+      type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: name}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: "eee: (aaa) @bbb @ccc @ddd"
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  marks: {}
+finalState:
+  documentContents: "eee: (aaa) @"
+  selections:
+    - anchor: {line: 0, character: 12}
+      active: {line: 0, character: 12}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/changeName3.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/changeName3.yml
@@ -1,0 +1,23 @@
+languageId: scm
+command:
+  version: 6
+  spokenForm: change name
+  action:
+    name: clearAndSetSelection
+    target:
+      type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: name}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: "eee: _ @bbb @ccc @ddd"
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  marks: {}
+finalState:
+  documentContents: "eee: _ @"
+  selections:
+    - anchor: {line: 0, character: 8}
+      active: {line: 0, character: 8}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/changeValue.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/changeValue.yml
@@ -1,0 +1,59 @@
+languageId: scm
+command:
+  version: 6
+  spokenForm: change value
+  action:
+    name: clearAndSetSelection
+    target:
+      type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: value}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    (
+        aaa: (bbb) @ccc @ddd
+        eee: "fff" @ggg
+        hhh: (iii)
+        jjj: [(kkk)] @lll
+        mmm: ((nnn) (ooo))* @ppp
+        qqq: _ @rrr
+    )
+  selections:
+    - anchor: {line: 1, character: 4}
+      active: {line: 1, character: 4}
+    - anchor: {line: 2, character: 4}
+      active: {line: 2, character: 4}
+    - anchor: {line: 3, character: 4}
+      active: {line: 3, character: 4}
+    - anchor: {line: 4, character: 4}
+      active: {line: 4, character: 4}
+    - anchor: {line: 5, character: 4}
+      active: {line: 5, character: 4}
+    - anchor: {line: 6, character: 4}
+      active: {line: 6, character: 4}
+  marks: {}
+finalState:
+  documentContents: |-
+    (
+        aaa:  @ccc @ddd
+        eee:  @ggg
+        hhh: 
+        jjj:  @lll
+        mmm:  @ppp
+        qqq:  @rrr
+    )
+  selections:
+    - anchor: {line: 1, character: 9}
+      active: {line: 1, character: 9}
+    - anchor: {line: 2, character: 9}
+      active: {line: 2, character: 9}
+    - anchor: {line: 3, character: 9}
+      active: {line: 3, character: 9}
+    - anchor: {line: 4, character: 9}
+      active: {line: 4, character: 9}
+    - anchor: {line: 5, character: 9}
+      active: {line: 5, character: 9}
+    - anchor: {line: 6, character: 9}
+      active: {line: 6, character: 9}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/chuckKey.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/chuckKey.yml
@@ -1,0 +1,29 @@
+languageId: scm
+command:
+  version: 6
+  spokenForm: chuck key
+  action:
+    name: remove
+    target:
+      type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: collectionKey}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    (
+        aaa: (bbb) @ccc
+    )
+  selections:
+    - anchor: {line: 1, character: 19}
+      active: {line: 1, character: 19}
+  marks: {}
+finalState:
+  documentContents: |-
+    (
+        (bbb) @ccc
+    )
+  selections:
+    - anchor: {line: 1, character: 14}
+      active: {line: 1, character: 14}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/chuckName.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/chuckName.yml
@@ -1,0 +1,23 @@
+languageId: scm
+command:
+  version: 6
+  spokenForm: chuck name
+  action:
+    name: remove
+    target:
+      type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: name}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: (aaa) @bbb @ccc @ddd
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  marks: {}
+finalState:
+  documentContents: "(aaa) "
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/chuckName2.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/chuckName2.yml
@@ -1,0 +1,23 @@
+languageId: scm
+command:
+  version: 6
+  spokenForm: chuck name
+  action:
+    name: remove
+    target:
+      type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: name}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: (aaa) @bbb @ccc @ddd
+  selections:
+    - anchor: {line: 0, character: 20}
+      active: {line: 0, character: 20}
+  marks: {}
+finalState:
+  documentContents: "(aaa) @bbb @ccc "
+  selections:
+    - anchor: {line: 0, character: 16}
+      active: {line: 0, character: 16}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/clearCall.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/clearCall.yml
@@ -1,0 +1,30 @@
+languageId: scm
+command:
+  version: 5
+  spokenForm: change call
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: functionCall}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    (
+        (aaa)
+        (#bbb! @aaa)
+    )
+  selections:
+    - anchor: {line: 2, character: 4}
+      active: {line: 2, character: 4}
+  marks: {}
+finalState:
+  documentContents: |-
+    (
+        (aaa)
+        
+    )
+  selections:
+    - anchor: {line: 2, character: 4}
+      active: {line: 2, character: 4}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/clearCallee.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/clearCallee.yml
@@ -1,0 +1,30 @@
+languageId: scm
+command:
+  version: 5
+  spokenForm: change callee
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: functionCallee}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    (
+        (aaa)
+        (#bbb! @aaa)
+    )
+  selections:
+    - anchor: {line: 2, character: 4}
+      active: {line: 2, character: 4}
+  marks: {}
+finalState:
+  documentContents: |-
+    (
+        (aaa)
+        (# @aaa)
+    )
+  selections:
+    - anchor: {line: 2, character: 6}
+      active: {line: 2, character: 6}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/clearComment.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/clearComment.yml
@@ -1,0 +1,22 @@
+languageId: scm
+command:
+  version: 5
+  spokenForm: change comment
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: comment}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: ;; aaa
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  marks: {}
+finalState:
+  documentContents: ""
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/clearEveryArgue.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/clearEveryArgue.yml
@@ -1,0 +1,32 @@
+languageId: scm
+command:
+  version: 5
+  spokenForm: change every arg
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: everyScope
+          scopeType: {type: argumentOrParameter}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    (
+        (aaa)
+        (#bbb! @aaa "ccc")
+    )
+  selections:
+    - anchor: {line: 2, character: 4}
+      active: {line: 2, character: 4}
+  marks: {}
+finalState:
+  documentContents: |-
+    (
+        (aaa)
+        (#bbb!  )
+    )
+  selections:
+    - anchor: {line: 2, character: 11}
+      active: {line: 2, character: 11}
+    - anchor: {line: 2, character: 12}
+      active: {line: 2, character: 12}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/clearEveryCall.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/clearEveryCall.yml
@@ -1,0 +1,34 @@
+languageId: scm
+command:
+  version: 5
+  spokenForm: change every call
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: everyScope
+          scopeType: {type: functionCall}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    (
+        (aaa)
+        (#bbb! @aaa)
+        (#ccc! @aaa)
+    )
+  selections:
+    - anchor: {line: 1, character: 4}
+      active: {line: 1, character: 4}
+  marks: {}
+finalState:
+  documentContents: |-
+    (
+        (aaa)
+        
+        
+    )
+  selections:
+    - anchor: {line: 2, character: 4}
+      active: {line: 2, character: 4}
+    - anchor: {line: 3, character: 4}
+      active: {line: 3, character: 4}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/clearEveryCallee.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/clearEveryCallee.yml
@@ -1,0 +1,34 @@
+languageId: scm
+command:
+  version: 5
+  spokenForm: change every callee
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: everyScope
+          scopeType: {type: functionCallee}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    (
+        (aaa)
+        (#bbb! @aaa)
+        (#ccc! @aaa)
+    )
+  selections:
+    - anchor: {line: 1, character: 4}
+      active: {line: 1, character: 4}
+  marks: {}
+finalState:
+  documentContents: |-
+    (
+        (aaa)
+        (# @aaa)
+        (# @aaa)
+    )
+  selections:
+    - anchor: {line: 2, character: 6}
+      active: {line: 2, character: 6}
+    - anchor: {line: 3, character: 6}
+      active: {line: 3, character: 6}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/clearEveryEntry.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/clearEveryEntry.yml
@@ -1,0 +1,24 @@
+languageId: scm
+command:
+  version: 5
+  spokenForm: change every item
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: everyScope
+          scopeType: {type: collectionItem}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: "[(aaa) (bbb)]"
+  selections:
+    - anchor: {line: 0, character: 1}
+      active: {line: 0, character: 1}
+  marks: {}
+finalState:
+  documentContents: "[ ]"
+  selections:
+    - anchor: {line: 0, character: 1}
+      active: {line: 0, character: 1}
+    - anchor: {line: 0, character: 2}
+      active: {line: 0, character: 2}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/clearEveryEntry2.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/clearEveryEntry2.yml
@@ -1,0 +1,32 @@
+languageId: scm
+command:
+  version: 5
+  spokenForm: change every item
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: everyScope
+          scopeType: {type: collectionItem}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    (
+        [(aaa) (bbb)]
+        (ccc)
+    )
+  selections:
+    - anchor: {line: 1, character: 4}
+      active: {line: 1, character: 4}
+  marks: {}
+finalState:
+  documentContents: |-
+    (
+        
+        
+    )
+  selections:
+    - anchor: {line: 1, character: 4}
+      active: {line: 1, character: 4}
+    - anchor: {line: 2, character: 4}
+      active: {line: 2, character: 4}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/clearEveryEntry3.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/clearEveryEntry3.yml
@@ -1,0 +1,32 @@
+languageId: scm
+command:
+  version: 5
+  spokenForm: change every item
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: everyScope
+          scopeType: {type: collectionItem}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    (ddd
+        [(aaa) (bbb)]
+        (ccc)
+    )
+  selections:
+    - anchor: {line: 0, character: 1}
+      active: {line: 0, character: 1}
+  marks: {}
+finalState:
+  documentContents: |-
+    (ddd
+        
+        
+    )
+  selections:
+    - anchor: {line: 1, character: 4}
+      active: {line: 1, character: 4}
+    - anchor: {line: 2, character: 4}
+      active: {line: 2, character: 4}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/clearEveryEntry4.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/clearEveryEntry4.yml
@@ -1,0 +1,36 @@
+languageId: scm
+command:
+  version: 5
+  spokenForm: change every item
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: everyScope
+          scopeType: {type: collectionItem}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    (
+      (_
+        (_) @dummy
+        (capture) @name @_.domain.end
+      ) @_.domain.start
+    )
+  selections:
+    - anchor: {line: 2, character: 3}
+      active: {line: 2, character: 3}
+  marks: {}
+finalState:
+  documentContents: |-
+    (
+      (_
+        
+        
+      ) @_.domain.start
+    )
+  selections:
+    - anchor: {line: 2, character: 4}
+      active: {line: 2, character: 4}
+    - anchor: {line: 3, character: 4}
+      active: {line: 3, character: 4}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/clearEveryName.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/clearEveryName.yml
@@ -1,0 +1,24 @@
+languageId: scm
+command:
+  version: 5
+  spokenForm: change every name
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: everyScope
+          scopeType: {type: name}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: (aaa) @bbb @ccc
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  marks: {}
+finalState:
+  documentContents: (aaa) @ @
+  selections:
+    - anchor: {line: 0, character: 7}
+      active: {line: 0, character: 7}
+    - anchor: {line: 0, character: 9}
+      active: {line: 0, character: 9}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/clearEveryName2.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/clearEveryName2.yml
@@ -1,0 +1,24 @@
+languageId: scm
+command:
+  version: 5
+  spokenForm: change every name
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: everyScope
+          scopeType: {type: name}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: "[(aaa) (bbb)] @ccc @ddd"
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  marks: {}
+finalState:
+  documentContents: "[(aaa) (bbb)] @ @"
+  selections:
+    - anchor: {line: 0, character: 15}
+      active: {line: 0, character: 15}
+    - anchor: {line: 0, character: 17}
+      active: {line: 0, character: 17}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/clearEveryName3.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/clearEveryName3.yml
@@ -1,0 +1,30 @@
+languageId: scm
+command:
+  version: 5
+  spokenForm: change every name
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: everyScope
+          scopeType: {type: name}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    (anonymous_node
+      name: (_) @string @textFragment
+    )
+  selections:
+    - anchor: {line: 1, character: 2}
+      active: {line: 1, character: 2}
+  marks: {}
+finalState:
+  documentContents: |-
+    (anonymous_node
+      name: (_) @ @
+    )
+  selections:
+    - anchor: {line: 1, character: 13}
+      active: {line: 1, character: 13}
+    - anchor: {line: 1, character: 15}
+      active: {line: 1, character: 15}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/clearEveryState.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/clearEveryState.yml
@@ -1,0 +1,29 @@
+languageId: scm
+command:
+  version: 5
+  spokenForm: change every state
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: everyScope
+          scopeType: {type: statement}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    (aaa) @bbb
+    ;; ccc
+    (ddd) @eee
+  selections:
+    - anchor: {line: 2, character: 10}
+      active: {line: 2, character: 10}
+  marks: {}
+finalState:
+  documentContents: |
+
+    ;; ccc
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+    - anchor: {line: 2, character: 0}
+      active: {line: 2, character: 0}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/clearItem.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/clearItem.yml
@@ -1,0 +1,22 @@
+languageId: scm
+command:
+  version: 5
+  spokenForm: change item
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: collectionItem}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: ;; (aaa)
+  selections:
+    - anchor: {line: 0, character: 4}
+      active: {line: 0, character: 4}
+  marks: {}
+finalState:
+  documentContents: ;; ()
+  selections:
+    - anchor: {line: 0, character: 4}
+      active: {line: 0, character: 4}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/clearKey.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/clearKey.yml
@@ -1,0 +1,28 @@
+languageId: scm
+command:
+  version: 5
+  spokenForm: change key
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: collectionKey}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    (aaa
+        bbb: (ccc) @ccc
+    )
+  selections:
+    - anchor: {line: 1, character: 9}
+      active: {line: 1, character: 9}
+  marks: {}
+finalState:
+  documentContents: |-
+    (aaa
+        : (ccc) @ccc
+    )
+  selections:
+    - anchor: {line: 1, character: 4}
+      active: {line: 1, character: 4}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/clearList.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/clearList.yml
@@ -1,0 +1,22 @@
+languageId: scm
+command:
+  version: 5
+  spokenForm: change list
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: list}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: "[(aaa) (bbb)] @ccc"
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  marks: {}
+finalState:
+  documentContents: " @ccc"
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/clearList2.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/clearList2.yml
@@ -1,0 +1,22 @@
+languageId: scm
+command:
+  version: 5
+  spokenForm: change list
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: list}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: "[(aaa) (bbb)] @ccc @ddd"
+  selections:
+    - anchor: {line: 0, character: 23}
+      active: {line: 0, character: 23}
+  marks: {}
+finalState:
+  documentContents: " @ccc @ddd"
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/clearName.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/clearName.yml
@@ -1,0 +1,24 @@
+languageId: scm
+command:
+  version: 5
+  spokenForm: change name
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: name}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: (aaa) @bbb @ccc
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  marks: {}
+finalState:
+  documentContents: (aaa) @ @
+  selections:
+    - anchor: {line: 0, character: 7}
+      active: {line: 0, character: 7}
+    - anchor: {line: 0, character: 9}
+      active: {line: 0, character: 9}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/clearName.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/clearName.yml
@@ -16,9 +16,7 @@ initialState:
       active: {line: 0, character: 0}
   marks: {}
 finalState:
-  documentContents: (aaa) @ @
+  documentContents: (aaa) @
   selections:
     - anchor: {line: 0, character: 7}
       active: {line: 0, character: 7}
-    - anchor: {line: 0, character: 9}
-      active: {line: 0, character: 9}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/clearName2.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/clearName2.yml
@@ -1,0 +1,22 @@
+languageId: scm
+command:
+  version: 5
+  spokenForm: change name
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: name}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: (aaa) @bbb @ccc
+  selections:
+    - anchor: {line: 0, character: 11}
+      active: {line: 0, character: 11}
+  marks: {}
+finalState:
+  documentContents: (aaa) @bbb @
+  selections:
+    - anchor: {line: 0, character: 12}
+      active: {line: 0, character: 12}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/clearName3.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/clearName3.yml
@@ -1,0 +1,22 @@
+languageId: scm
+command:
+  version: 5
+  spokenForm: change name
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: name}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: (aaa) @bbb
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  marks: {}
+finalState:
+  documentContents: (aaa) @
+  selections:
+    - anchor: {line: 0, character: 7}
+      active: {line: 0, character: 7}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/clearName4.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/clearName4.yml
@@ -1,0 +1,22 @@
+languageId: scm
+command:
+  version: 5
+  spokenForm: change name
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: name}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: "\"aaa\" @bbb"
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  marks: {}
+finalState:
+  documentContents: "\"aaa\" @"
+  selections:
+    - anchor: {line: 0, character: 7}
+      active: {line: 0, character: 7}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/clearName5.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/clearName5.yml
@@ -1,0 +1,22 @@
+languageId: scm
+command:
+  version: 5
+  spokenForm: change name
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: name}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: "[(aaa) (bbb)] @ccc"
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  marks: {}
+finalState:
+  documentContents: "[(aaa) (bbb)] @"
+  selections:
+    - anchor: {line: 0, character: 15}
+      active: {line: 0, character: 15}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/clearName6.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/clearName6.yml
@@ -23,10 +23,8 @@ finalState:
   documentContents: |-
 
     (anonymous_node
-      name: (_) @ @
+      name: (_) @
     )
   selections:
     - anchor: {line: 2, character: 13}
       active: {line: 2, character: 13}
-    - anchor: {line: 2, character: 15}
-      active: {line: 2, character: 15}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/clearName6.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/clearName6.yml
@@ -1,0 +1,32 @@
+languageId: scm
+command:
+  version: 5
+  spokenForm: change name
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: name}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+
+    (anonymous_node
+      name: (_) @string @textFragment
+    )
+  selections:
+    - anchor: {line: 2, character: 8}
+      active: {line: 2, character: 8}
+  marks: {}
+finalState:
+  documentContents: |-
+
+    (anonymous_node
+      name: (_) @ @
+    )
+  selections:
+    - anchor: {line: 2, character: 13}
+      active: {line: 2, character: 13}
+    - anchor: {line: 2, character: 15}
+      active: {line: 2, character: 15}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/clearName7.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/clearName7.yml
@@ -21,10 +21,8 @@ initialState:
 finalState:
   documentContents: |-
     (anonymous_node
-      name: (_) @ @
+      name: (_) @
     )
   selections:
     - anchor: {line: 1, character: 13}
       active: {line: 1, character: 13}
-    - anchor: {line: 1, character: 15}
-      active: {line: 1, character: 15}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/clearName7.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/clearName7.yml
@@ -1,0 +1,30 @@
+languageId: scm
+command:
+  version: 5
+  spokenForm: change name
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: name}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    (anonymous_node
+      name: (_) @string @textFragment
+    )
+  selections:
+    - anchor: {line: 1, character: 2}
+      active: {line: 1, character: 2}
+  marks: {}
+finalState:
+  documentContents: |-
+    (anonymous_node
+      name: (_) @ @
+    )
+  selections:
+    - anchor: {line: 1, character: 13}
+      active: {line: 1, character: 13}
+    - anchor: {line: 1, character: 15}
+      active: {line: 1, character: 15}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/clearRound.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/clearRound.yml
@@ -1,0 +1,22 @@
+languageId: scm
+command:
+  version: 5
+  spokenForm: change round
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: surroundingPair, delimiter: parentheses}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: (aaa)
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  marks: {}
+finalState:
+  documentContents: ""
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/clearRound2.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/clearRound2.yml
@@ -1,0 +1,22 @@
+languageId: scm
+command:
+  version: 5
+  spokenForm: change round
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: surroundingPair, delimiter: parentheses}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: ;; (aaa)
+  selections:
+    - anchor: {line: 0, character: 3}
+      active: {line: 0, character: 3}
+  marks: {}
+finalState:
+  documentContents: ";; "
+  selections:
+    - anchor: {line: 0, character: 3}
+      active: {line: 0, character: 3}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/clearRound3.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/clearRound3.yml
@@ -1,0 +1,22 @@
+languageId: scm
+command:
+  version: 5
+  spokenForm: change round
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: surroundingPair, delimiter: parentheses}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: "\"(aaa)\" @bbb"
+  selections:
+    - anchor: {line: 0, character: 1}
+      active: {line: 0, character: 1}
+  marks: {}
+finalState:
+  documentContents: "\"\" @bbb"
+  selections:
+    - anchor: {line: 0, character: 1}
+      active: {line: 0, character: 1}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/clearState.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/clearState.yml
@@ -1,0 +1,18 @@
+languageId: scm
+command:
+  version: 5
+  spokenForm: change state
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: statement}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: ;; aaa
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  marks: {}
+thrownError: {name: NoContainingScopeError}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/clearState2.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/clearState2.yml
@@ -1,0 +1,22 @@
+languageId: scm
+command:
+  version: 5
+  spokenForm: change state
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: statement}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: (aaa) @bbb
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  marks: {}
+finalState:
+  documentContents: ""
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/clearState3.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/clearState3.yml
@@ -1,0 +1,26 @@
+languageId: scm
+command:
+  version: 5
+  spokenForm: change state
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: statement}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    (
+        (aaa) @bbb
+        (#ccc? @bbb)
+    )
+  selections:
+    - anchor: {line: 1, character: 4}
+      active: {line: 1, character: 4}
+  marks: {}
+finalState:
+  documentContents: ""
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/clearState4.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/clearState4.yml
@@ -1,0 +1,26 @@
+languageId: scm
+command:
+  version: 5
+  spokenForm: change state
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: statement}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    (
+        (aaa) @bbb
+        (#ccc? @bbb)
+    )
+  selections:
+    - anchor: {line: 2, character: 4}
+      active: {line: 2, character: 4}
+  marks: {}
+finalState:
+  documentContents: ""
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/clearState5.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/clearState5.yml
@@ -1,0 +1,22 @@
+languageId: scm
+command:
+  version: 5
+  spokenForm: change state
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: statement}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: "[(aaa) (bbb)] @ccc"
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  marks: {}
+finalState:
+  documentContents: ""
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/clearType.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/clearType.yml
@@ -1,0 +1,22 @@
+languageId: scm
+command:
+  version: 5
+  spokenForm: change type
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: type}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: (aaa) @bbb @ccc
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  marks: {}
+finalState:
+  documentContents: () @bbb @ccc
+  selections:
+    - anchor: {line: 0, character: 1}
+      active: {line: 0, character: 1}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/clearType2.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/clearType2.yml
@@ -1,0 +1,22 @@
+languageId: scm
+command:
+  version: 5
+  spokenForm: change type
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: type}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: "\"aaa\" @bbb"
+  selections:
+    - anchor: {line: 0, character: 6}
+      active: {line: 0, character: 6}
+  marks: {}
+finalState:
+  documentContents: "\"\" @bbb"
+  selections:
+    - anchor: {line: 0, character: 1}
+      active: {line: 0, character: 1}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/clearType3.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/clearType3.yml
@@ -1,0 +1,24 @@
+languageId: scm
+command:
+  version: 5
+  spokenForm: change type
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: type}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |
+    (aaa) @bbb @ccc
+  selections:
+    - anchor: {line: 0, character: 7}
+      active: {line: 0, character: 7}
+  marks: {}
+finalState:
+  documentContents: |
+    () @bbb @ccc
+  selections:
+    - anchor: {line: 0, character: 1}
+      active: {line: 0, character: 1}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/clearValue.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/clearValue.yml
@@ -1,0 +1,28 @@
+languageId: scm
+command:
+  version: 5
+  spokenForm: change value
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: value}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    (aaa
+        bbb: (ccc) @ccc
+    )
+  selections:
+    - anchor: {line: 1, character: 4}
+      active: {line: 1, character: 4}
+  marks: {}
+finalState:
+  documentContents: |-
+    (aaa
+        bbb:  @ccc
+    )
+  selections:
+    - anchor: {line: 1, character: 9}
+      active: {line: 1, character: 9}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/cloneName.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/cloneName.yml
@@ -1,0 +1,23 @@
+languageId: scm
+command:
+  version: 6
+  spokenForm: clone name
+  action:
+    name: insertCopyAfter
+    target:
+      type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: name}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: "eee: _ @bbb @ccc"
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  marks: {}
+finalState:
+  documentContents: "eee: _ @bbb @ccc @bbb @ccc"
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/drinkName.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/drinkName.yml
@@ -1,0 +1,23 @@
+languageId: scm
+command:
+  version: 6
+  spokenForm: drink name
+  action:
+    name: editNewLineBefore
+    target:
+      type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: name}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: "eee: _ @bbb @ccc"
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  marks: {}
+finalState:
+  documentContents: "eee: _ @ @bbb @ccc"
+  selections:
+    - anchor: {line: 0, character: 8}
+      active: {line: 0, character: 8}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/pourName.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/pourName.yml
@@ -1,0 +1,23 @@
+languageId: scm
+command:
+  version: 6
+  spokenForm: pour name
+  action:
+    name: editNewLineAfter
+    target:
+      type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: name}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: "eee: _ @bbb @ccc"
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  marks: {}
+finalState:
+  documentContents: "eee: _ @bbb @ccc @"
+  selections:
+    - anchor: {line: 0, character: 18}
+      active: {line: 0, character: 18}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/pourName2.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/pourName2.yml
@@ -1,0 +1,23 @@
+languageId: scm
+command:
+  version: 6
+  spokenForm: pour name
+  action:
+    name: editNewLineAfter
+    target:
+      type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: name}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: "eee: _ @bbb @ccc"
+  selections:
+    - anchor: {line: 0, character: 7}
+      active: {line: 0, character: 7}
+  marks: {}
+finalState:
+  documentContents: "eee: _ @bbb @ @ccc"
+  selections:
+    - anchor: {line: 0, character: 13}
+      active: {line: 0, character: 13}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/takeName.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/scm/takeName.yml
@@ -1,0 +1,23 @@
+languageId: scm
+command:
+  version: 6
+  spokenForm: take name
+  action:
+    name: setSelection
+    target:
+      type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: name}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: (aaa) @bbb @ccc @ddd
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  marks: {}
+finalState:
+  documentContents: (aaa) @bbb @ccc @ddd
+  selections:
+    - anchor: {line: 0, character: 7}
+      active: {line: 0, character: 20}

--- a/queries/scm.collections.scm
+++ b/queries/scm.collections.scm
@@ -1,3 +1,6 @@
+;;!! (aaa (bbb) (ccc))
+;;!       ^^^^^ ^^^^^
+;;!   ***************
 (
   (named_node
     "(" @collectionItem.iteration.start.endOf
@@ -7,6 +10,9 @@
   )
 )
 
+;;!! ((aaa) (bbb))
+;;!   ^^^^^ ^^^^^
+;;!   ***********
 (
   (grouping
     "(" @collectionItem.iteration.start.endOf
@@ -15,6 +21,14 @@
   )
 )
 
+;; collectionItem:
+;;!! [(aaa) (bbb)] @ccc
+;;!   ^^^^^ ^^^^^
+;;!   ***********
+;; list:
+;;!! [(aaa) (bbb)] @ccc
+;;!  ^^^^^^^^^^^^^
+;;!  ------------------
 (
   (list
     "[" @list.start @collectionItem.iteration.start.endOf

--- a/queries/scm.collections.scm
+++ b/queries/scm.collections.scm
@@ -1,0 +1,24 @@
+(
+  (named_node
+    "(" @collectionItem.iteration.start.endOf
+    name: _
+    _ @collectionItem
+    ")" @collectionItem.iteration.end.startOf
+  )
+)
+
+(
+  (grouping
+    "(" @collectionItem.iteration.start.endOf
+    (_) @collectionItem
+    ")" @collectionItem.iteration.end.startOf
+  )
+)
+
+(
+  (list
+    "[" @list.start @collectionItem.iteration.start.endOf
+    (_) @collectionItem
+    "]" @list.end @collectionItem.iteration.end.startOf
+  ) @list.domain
+)

--- a/queries/scm.name.scm
+++ b/queries/scm.name.scm
@@ -1,0 +1,64 @@
+;; Include everything leading up to the first capture in the domain for name
+(
+  (_
+    (capture
+      "@" @_.leading
+      name: (identifier) @name
+    )
+  ) @_.domain
+  (#not-type? @_.domain parameters)
+  (#not-parent-type? @_.domain field_definition)
+  (#allow-multiple! @name)
+  (#insertion-delimiter! @name " @")
+)
+
+;; Include everything leading up to the first capture in the domain for name
+(
+  (field_definition
+    (_
+      (capture
+        "@" @_.leading
+        name: (identifier) @name
+      )
+    )
+  ) @_.domain
+  (#allow-multiple! @name)
+  (#insertion-delimiter! @name " @")
+)
+
+;; Only include the capture itself in its domain after the first capture
+(
+  (_
+    (capture
+      "@" @_.leading
+      name: (identifier) @name
+    ) @_.domain
+  ) @dummy
+  (#not-type? @dummy parameters)
+  (#has-n-children-of-type? @dummy capture 2 -1)
+  (#insertion-delimiter! @name " @")
+)
+
+(
+  (_
+    (capture)
+  ) @name.iteration
+  (#not-type? @name.iteration parameters)
+  (#not-parent-type? @name.iteration field_definition)
+)
+
+(field_definition
+  [
+    ;; Note that we can't use wildcard node due to
+    ;; https://github.com/tree-sitter/tree-sitter/issues/2483
+    (named_node
+      (capture)
+    )
+    (anonymous_node
+      (capture)
+    )
+    (list
+      (capture)
+    )
+  ]
+) @name.iteration

--- a/queries/scm.name.scm
+++ b/queries/scm.name.scm
@@ -52,7 +52,7 @@
     ) @_.domain
   ) @dummy
   (#not-type? @dummy parameters)
-  (#has-n-children-of-type? @dummy capture 2 -1)
+  (#has-multiple-children-of-type? @dummy capture)
   (#insertion-delimiter! @name " @")
 )
 

--- a/queries/scm.name.scm
+++ b/queries/scm.name.scm
@@ -1,4 +1,7 @@
-;; Include everything leading up to the first capture in the domain for name
+;;!! (aaa) @bbb @ccc
+;;!         ^^^^^^^^
+;;!        xxxxxxxxx
+;;!  ---------------
 (
   (_
     _ @dummy
@@ -16,7 +19,10 @@
   (#insertion-delimiter! @name.start " @")
 )
 
-;; Include everything leading up to the first capture in the domain for name
+;;!! eee: (aaa) @bbb @ccc
+;;!              ^^^^^^^^
+;;!             xxxxxxxxx
+;;!  --------------------
 (
   (field_definition
     (_
@@ -34,7 +40,10 @@
   (#insertion-delimiter! @name.start " @")
 )
 
-;; Only include the capture itself in its domain after the first capture
+;;!! (aaa) @bbb @ccc
+;;!         ^^^  ^^^
+;;!        xxxx xxxx
+;;!        ---- ----
 (
   (_
     (capture
@@ -47,6 +56,9 @@
   (#insertion-delimiter! @name " @")
 )
 
+;;!! (aaa) @bbb @ccc
+;;!        *********
+;;!  --------------- <~ iteration domain
 (
   (_
     _ @dummy
@@ -58,6 +70,9 @@
   (#not-parent-type? @name.iteration.domain field_definition)
 )
 
+;;!! ddd: (aaa) @bbb @ccc
+;;!             *********
+;;!  -------------------- <~ iteration domain
 (
   (field_definition
     [

--- a/queries/scm.name.scm
+++ b/queries/scm.name.scm
@@ -1,29 +1,37 @@
 ;; Include everything leading up to the first capture in the domain for name
 (
   (_
+    _ @dummy
+    .
     (capture
       "@" @_.leading
-      name: (identifier) @name
+      name: (identifier) @name.start
     )
+    (capture)? @name.end
+    .
   ) @_.domain
   (#not-type? @_.domain parameters)
+  (#not-type? @dummy capture)
   (#not-parent-type? @_.domain field_definition)
-  (#allow-multiple! @name)
-  (#insertion-delimiter! @name " @")
+  (#insertion-delimiter! @name.start " @")
 )
 
 ;; Include everything leading up to the first capture in the domain for name
 (
   (field_definition
     (_
+      _ @dummy
+      .
       (capture
         "@" @_.leading
-        name: (identifier) @name
+        name: (identifier) @name.start
       )
+      (capture)? @name.end
+      .
     )
   ) @_.domain
-  (#allow-multiple! @name)
-  (#insertion-delimiter! @name " @")
+  (#not-type? @dummy capture)
+  (#insertion-delimiter! @name.start " @")
 )
 
 ;; Only include the capture itself in its domain after the first capture
@@ -41,24 +49,36 @@
 
 (
   (_
-    (capture)
-  ) @name.iteration
-  (#not-type? @name.iteration parameters)
-  (#not-parent-type? @name.iteration field_definition)
+    _ @dummy
+    .
+    (capture) @name.iteration.start
+  ) @name.iteration.end.endOf @name.iteration.domain
+  (#not-type? @dummy capture)
+  (#not-type? @name.iteration.start parameters)
+  (#not-parent-type? @name.iteration.domain field_definition)
 )
 
-(field_definition
-  [
-    ;; Note that we can't use wildcard node due to
-    ;; https://github.com/tree-sitter/tree-sitter/issues/2483
-    (named_node
-      (capture)
-    )
-    (anonymous_node
-      (capture)
-    )
-    (list
-      (capture)
-    )
-  ]
-) @name.iteration
+(
+  (field_definition
+    [
+      ;; Note that we can't use wildcard node due to
+      ;; https://github.com/tree-sitter/tree-sitter/issues/2483
+      (named_node
+        _ @dummy
+        .
+        (capture) @name.iteration.start
+      )
+      (anonymous_node
+        _ @dummy
+        .
+        (capture) @name.iteration.start
+      )
+      (list
+        _ @dummy
+        .
+        (capture) @name.iteration.start
+      )
+    ]
+  ) @name.iteration.end.endOf @name.iteration.domain
+  (#not-type? @dummy capture)
+)

--- a/queries/scm.scm
+++ b/queries/scm.scm
@@ -1,6 +1,7 @@
 ;; import scm.collections.scm
 ;; import scm.name.scm
 
+;; A statement is any top-level node that's not a comment
 (
   (program
     (_) @statement
@@ -16,23 +17,23 @@
 
 ;; functionCall:
 ;;!! (#aaa? @bbb "ccc")
-;;!    ^^^^
-;;!  ------------------
+;;!  ^^^^^^^^^^^^^^^^^^
 ;; functionCallee:
 ;;!! (#aaa? @bbb "ccc")
-;;!  ^^^^^^^^^^^^^^^^^^
+;;!    ^^^^
+;;!  ------------------
 (predicate
   name: (identifier) @functionCallee.start
   type: (predicate_type) @functionCallee.end
 ) @functionCall @functionCallee.domain
 
 ;;!! ((#aaa!) (#bbb!))
-;;!  *********************
+;;!  *****************
 (grouping) @functionCall.iteration @functionCallee.iteration
 
 ;;!! (#aaa? @bbb "ccc")
-;;!           ^^^^ ^^^^^
-;;!  ********************
+;;!         ^^^^ ^^^^^
+;;!  ******************
 (predicate
   (parameters
     (_) @argumentOrParameter
@@ -61,6 +62,7 @@
 
 ;;!! aaa: (bbb) @ccc
 ;;!  ^^^
+;;!  xxxxx
 ;;!  ---------------
 (field_definition
   name: (identifier) @collectionKey @collectionKey.trailing.start.endOf

--- a/queries/scm.scm
+++ b/queries/scm.scm
@@ -1,0 +1,104 @@
+;; import scm.collections.scm
+;; import scm.name.scm
+
+(
+  (program
+    (_) @statement
+  ) @_.iteration
+  (#not-type? @statement comment)
+)
+
+(comment) @comment @textFragment
+
+(anonymous_node
+  name: (_) @string @textFragment
+)
+
+;; functionCall:
+;;!! (#aaa? @bbb "ccc")
+;;!    ^^^^
+;;!  ------------------
+;; functionCallee:
+;;!! (#aaa? @bbb "ccc")
+;;!  ^^^^^^^^^^^^^^^^^^
+(predicate
+  name: (identifier) @functionCallee.start
+  type: (predicate_type) @functionCallee.end
+) @functionCall @functionCallee.domain
+
+;;!! ((#aaa!) (#bbb!))
+;;!  *********************
+(grouping) @functionCall.iteration @functionCallee.iteration
+
+;;!! (#aaa? @bbb "ccc")
+;;!           ^^^^ ^^^^^
+;;!  ********************
+(predicate
+  (parameters
+    (_) @argumentOrParameter
+  )
+) @_.iteration
+
+;;!! (aaa) @bbb
+;;!   ^^^
+;;!  ----------
+(named_node
+  name: _ @type
+) @_.domain
+
+;;!! "aaa" @bbb
+;;!   ^^^
+;;!  ----------
+(anonymous_node
+  name: [
+    "_" @type
+    (identifier
+      "\"" @type.start.endOf
+      "\"" @type.end.startOf
+    )
+  ]
+) @_.domain
+
+;;!! aaa: (bbb) @ccc
+;;!  ^^^
+;;!  ---------------
+(field_definition
+  name: (identifier) @collectionKey @collectionKey.trailing.start.endOf
+  .
+  (_) @collectionKey.trailing.end.startOf
+) @_.domain
+
+;;!! aaa: (bbb) @ccc
+;;!       ^^^^^
+;;!  ---------------
+;;!! aaa: [(bbb)]* @ccc
+;;!       ^^^^^^^^
+;;!  ------------------
+;; Note that this pattern is a bit ugly in order to exclude the capture (@foo).
+;; Unfortunately the capture is part of the node to the right of the `:`, so we
+;; kinda need to reach inside that node to exclude it.
+(field_definition
+  ":"
+  (_
+    [
+      ")"
+      "]"
+    ] @value.end
+    (quantifier)? @value.end
+  ) @value.start.startOf
+) @_.domain
+
+;;!! aaa: "bbb" @ccc
+;;!       ^^^^^
+;;!  ---------------
+;; As above, this pattern is a bit ugly in order to exclude the capture (@foo).
+(field_definition
+  ":"
+  (anonymous_node
+    [
+      (identifier)
+      "_"
+    ] @value.end
+    (quantifier)? @value.end
+  ) @value.start.startOf
+) @_.domain


### PR DESCRIPTION
This PR allows us to say things like `"take state"` when we're working on `.scm` files.

- Depends on #1763
- Depends on https://github.com/cursorless-dev/cursorless/pull/1800

## Checklist

- [x] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [x] Add trailing delimiter to "key"
- [x] File issue for "bring to name" when there are multiple names
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet
