### PR TITLE
Support "every line air past bat"

### DIFF
--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -397,6 +397,12 @@ For example:
 - `"pre air slice bat"`: Places cursors at the same position on every line (inclusive) between token with hat over the `a` and token with the hat over the `b`. The position will be the start of the token with a hat over the `a`
 - `"chuck tail air slice end of block"`: Delete the end of every line from air through the end of its non-empty line block.
 
+##### `"every"` ranges
+
+If the range target begins with `"every <scope>"`, eg `"take every line air past bat"`, then you will end up with one target for each instance of `<scope>` in the range. For example, `"post every line air past bat"` will put a cursor at the end of every line from the line containing the token with a hat over the letter `a` to the line containing the token with a hat over the letter `b`.
+
+These `"every"` ranges also play nicely with exclusive ranges, eg `"take every funk air until bat"` will select every function starting from the function containing the token with a hat over the letter `a` up until, but not including, the function containing the token with a hat over the letter `b`.
+
 #### List targets
 
 In addition to range targets, cursorless supports list targets, which allow you to refer to multiple targets at the same time. When combined with the `"take"` action, this will result in multiple cursors, for other actions, such as `"chuck"` the action will be applied to all the different targets at once.

--- a/packages/common/src/types/command/PartialTargetDescriptor.types.ts
+++ b/packages/common/src/types/command/PartialTargetDescriptor.types.ts
@@ -344,7 +344,7 @@ export type Modifier =
 
 // continuous is one single continuous selection between the two targets
 // vertical puts a selection on each line vertically between the two targets
-export type RangeType = "continuous" | "vertical";
+export type PartialRangeType = "continuous" | "vertical";
 
 export interface PartialRangeTargetDescriptor {
   type: "range";
@@ -352,7 +352,7 @@ export interface PartialRangeTargetDescriptor {
   active: PartialPrimitiveTargetDescriptor;
   excludeAnchor: boolean;
   excludeActive: boolean;
-  rangeType?: RangeType;
+  rangeType?: PartialRangeType;
 }
 
 export interface PartialListTargetDescriptor {

--- a/packages/cursorless-engine/src/processTargets/TargetPipeline.ts
+++ b/packages/cursorless-engine/src/processTargets/TargetPipeline.ts
@@ -1,6 +1,7 @@
 import { ImplicitTargetDescriptor, Modifier, Range } from "@cursorless/common";
 import { uniqWith, zip } from "lodash";
 import {
+  EveryRangeTargetDescriptor,
   PrimitiveTargetDescriptor,
   RangeTargetDescriptor,
   TargetDescriptor,
@@ -47,6 +48,8 @@ export class TargetPipeline {
         );
       case "range":
         return this.processRangeTarget(target);
+      case "everyRange":
+        return this.processEveryRangeTarget(target);
       case "primitive":
       case "implicit":
         return this.processPrimitiveTarget(target);
@@ -85,6 +88,27 @@ export class TargetPipeline {
         }
       },
     );
+  }
+
+  processEveryRangeTarget(targetDesc: EveryRangeTargetDescriptor): Target[] {
+    const { scopeType, anchor, active, excludeAnchor, excludeActive } =
+      targetDesc;
+
+    const [rangeTarget] = this.processRangeTarget({
+      type: "range",
+      anchor,
+      active,
+      excludeAnchor,
+      excludeActive,
+      rangeType: "continuous",
+    });
+
+    return this.modifierStageFactory
+      .create({
+        type: "everyScope",
+        scopeType,
+      })
+      .run(this.context, rangeTarget);
   }
 
   /**

--- a/packages/cursorless-engine/src/processTargets/modifiers/EveryScopeStage.ts
+++ b/packages/cursorless-engine/src/processTargets/modifiers/EveryScopeStage.ts
@@ -133,6 +133,7 @@ function getScopesOverlappingRange(
     scopeHandler.generateScopes(editor, start, "forward", {
       distalPosition: end,
       skipAncestorScopes: true,
+      allowAdjacentScopes: scopeHandler.includeAdjacentInEvery,
     }),
   );
 }

--- a/packages/cursorless-engine/src/processTargets/modifiers/scopeHandlers/BaseScopeHandler.ts
+++ b/packages/cursorless-engine/src/processTargets/modifiers/scopeHandlers/BaseScopeHandler.ts
@@ -23,6 +23,8 @@ export default abstract class BaseScopeHandler implements ScopeHandler {
   public abstract readonly scopeType: ScopeType | undefined;
   public abstract readonly iterationScopeType: ScopeType | CustomScopeType;
 
+  public readonly includeAdjacentInEvery: boolean = false;
+
   /**
    * Indicates whether scopes are allowed to contain one another.  If `false`, we
    * can optimise the algorithm by making certain assumptions.

--- a/packages/cursorless-engine/src/processTargets/modifiers/scopeHandlers/LineScopeHandler.ts
+++ b/packages/cursorless-engine/src/processTargets/modifiers/scopeHandlers/LineScopeHandler.ts
@@ -8,6 +8,7 @@ export default class LineScopeHandler extends BaseScopeHandler {
   public readonly scopeType = { type: "line" } as const;
   public readonly iterationScopeType = { type: "document" } as const;
   protected readonly isHierarchical = false;
+  public readonly includeAdjacentInEvery: boolean = true;
 
   constructor(_scopeType: ScopeType, _languageId: string) {
     super();

--- a/packages/cursorless-engine/src/processTargets/modifiers/scopeHandlers/scopeHandler.types.ts
+++ b/packages/cursorless-engine/src/processTargets/modifiers/scopeHandlers/scopeHandler.types.ts
@@ -80,6 +80,13 @@ export interface ScopeHandler {
     scopeA: TargetScope,
     scopeB: TargetScope,
   ): boolean | undefined;
+
+  /**
+   * Whether to include adjacent scopes when used in an "every" modifier.  This
+   * was added so that "every line" will include the line you're on even if your
+   * range is at the beginning or end of the line.
+   */
+  readonly includeAdjacentInEvery: boolean;
 }
 
 export type ContainmentPolicy =
@@ -111,7 +118,9 @@ export interface ScopeIteratorRequirements {
   /**
    * Indicates that the {@link TargetScope.domain|domain} of the scopes must
    * start at or before this position for `"forward"`, or at or after this
-   * position for `"backward"`.
+   * position for `"backward"`.  If {@link allowAdjacentScopes} is `false`, then
+   * the domain must start strictly before this position (after for
+   * `"backward").
    *
    * Defaults to the end of the document for `"forward"`, or the start of the
    * document for `"backward"`.
@@ -120,9 +129,9 @@ export interface ScopeIteratorRequirements {
 
   /**
    * Indicates that the {@link TargetScope.domain|domain} of the scopes is
-   * allowed to have empty overlap with the range (position, distalPosition).
-   * If `false`, the domain must have nonempty overlap with (position,
-   * distalPosition), unless the domain is empty.
+   * allowed to have empty overlap with the range `(position, distalPosition)`.
+   * If `false`, the domain must have nonempty overlap with `(position,
+   * distalPosition)`, unless the domain is empty.
    *
    * @default false
    */

--- a/packages/cursorless-engine/src/processTargets/targetUtil/createContinuousRange.ts
+++ b/packages/cursorless-engine/src/processTargets/targetUtil/createContinuousRange.ts
@@ -46,27 +46,6 @@ export function createContinuousLineRange(
   return new Range(start, end);
 }
 
-export function createSimpleContinuousRangeTarget(
-  target1: Target,
-  target2: Target,
-  isReversed: boolean,
-  includeStart: boolean = true,
-  includeEnd: boolean = true,
-) {
-  const isForward = target1.contentRange.start.isBefore(
-    target2.contentRange.start,
-  );
-  const anchorTarget = isForward ? target1 : target2;
-  const activeTarget = isForward ? target2 : target1;
-
-  return anchorTarget.createContinuousRangeTarget(
-    isReversed,
-    activeTarget,
-    includeStart,
-    includeEnd,
-  );
-}
-
 export function createContinuousRangeUntypedTarget(
   isReversed: boolean,
   startTarget: Target,

--- a/packages/cursorless-engine/src/typings/TargetDescriptor.ts
+++ b/packages/cursorless-engine/src/typings/TargetDescriptor.ts
@@ -3,7 +3,7 @@ import {
   Mark,
   Modifier,
   PositionModifier,
-  RangeType,
+  PartialRangeType,
   ImplicitTargetDescriptor,
   ScopeType,
 } from "@cursorless/common";
@@ -33,36 +33,35 @@ export interface PrimitiveTargetDescriptor
   positionModifier?: PositionModifier;
 }
 
-export interface RangeTargetDescriptor {
+interface BaseRangeTargetDescriptor {
   type: "range";
   anchor: PrimitiveTargetDescriptor | ImplicitTargetDescriptor;
   active: PrimitiveTargetDescriptor;
   excludeAnchor: boolean;
   excludeActive: boolean;
-  rangeType: RangeType;
+  rangeType: PartialRangeType | "every";
 }
 
-export interface EveryRangeTargetDescriptor {
-  type: "everyRange";
-  scopeType: ScopeType;
-  anchor: PrimitiveTargetDescriptor | ImplicitTargetDescriptor;
-  active: PrimitiveTargetDescriptor;
-  excludeAnchor: boolean;
-  excludeActive: boolean;
+interface SimpleRangeTargetDescriptor extends BaseRangeTargetDescriptor {
+  rangeType: PartialRangeType;
 }
+
+export interface EveryRangeTargetDescriptor extends BaseRangeTargetDescriptor {
+  rangeType: "every";
+  scopeType: ScopeType;
+}
+
+export type RangeTargetDescriptor =
+  | SimpleRangeTargetDescriptor
+  | EveryRangeTargetDescriptor;
 
 export interface ListTargetDescriptor {
   type: "list";
-  elements: (
-    | PrimitiveTargetDescriptor
-    | RangeTargetDescriptor
-    | EveryRangeTargetDescriptor
-  )[];
+  elements: (PrimitiveTargetDescriptor | RangeTargetDescriptor)[];
 }
 
 export type TargetDescriptor =
   | PrimitiveTargetDescriptor
   | RangeTargetDescriptor
-  | EveryRangeTargetDescriptor
   | ListTargetDescriptor
   | ImplicitTargetDescriptor;

--- a/packages/cursorless-engine/src/typings/TargetDescriptor.ts
+++ b/packages/cursorless-engine/src/typings/TargetDescriptor.ts
@@ -5,6 +5,7 @@ import {
   PositionModifier,
   RangeType,
   ImplicitTargetDescriptor,
+  ScopeType,
 } from "@cursorless/common";
 
 export interface PrimitiveTargetDescriptor
@@ -41,13 +42,27 @@ export interface RangeTargetDescriptor {
   rangeType: RangeType;
 }
 
+export interface EveryRangeTargetDescriptor {
+  type: "everyRange";
+  scopeType: ScopeType;
+  anchor: PrimitiveTargetDescriptor | ImplicitTargetDescriptor;
+  active: PrimitiveTargetDescriptor;
+  excludeAnchor: boolean;
+  excludeActive: boolean;
+}
+
 export interface ListTargetDescriptor {
   type: "list";
-  elements: (PrimitiveTargetDescriptor | RangeTargetDescriptor)[];
+  elements: (
+    | PrimitiveTargetDescriptor
+    | RangeTargetDescriptor
+    | EveryRangeTargetDescriptor
+  )[];
 }
 
 export type TargetDescriptor =
   | PrimitiveTargetDescriptor
   | RangeTargetDescriptor
+  | EveryRangeTargetDescriptor
   | ListTargetDescriptor
   | ImplicitTargetDescriptor;

--- a/packages/cursorless-engine/src/util/getPrimitiveTargets.ts
+++ b/packages/cursorless-engine/src/util/getPrimitiveTargets.ts
@@ -4,10 +4,6 @@ import {
   PartialRangeTargetDescriptor,
   PartialTargetDescriptor,
 } from "@cursorless/common";
-import {
-  PrimitiveTargetDescriptor,
-  TargetDescriptor,
-} from "../typings/TargetDescriptor";
 
 /**
  * Given a list of targets, recursively descends all targets and returns every
@@ -32,31 +28,6 @@ function getPartialPrimitiveTargetsHelper(
       return [target.anchor, target.active].flatMap(
         getPartialPrimitiveTargetsHelper,
       );
-    case "implicit":
-      return [];
-  }
-}
-/**
- * Given a list of targets, recursively descends all targets and returns every
- * contained primitive target.
- *
- * @param targets The targets to extract from
- * @returns A list of primitive targets
- */
-export function getPrimitiveTargets(targets: TargetDescriptor[]) {
-  return targets.flatMap(getPrimitiveTargetsHelper);
-}
-
-function getPrimitiveTargetsHelper(
-  target: TargetDescriptor,
-): PrimitiveTargetDescriptor[] {
-  switch (target.type) {
-    case "primitive":
-      return [target];
-    case "list":
-      return target.elements.flatMap(getPrimitiveTargetsHelper);
-    case "range":
-      return [...getPrimitiveTargetsHelper(target.anchor), target.active];
     case "implicit":
       return [];
   }

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/everyRange/clearEveryFunkNameDrumBetweenEach.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/everyRange/clearEveryFunkNameDrumBetweenEach.yml
@@ -1,0 +1,60 @@
+languageId: python
+command:
+  version: 5
+  spokenForm: clear every funk name drum between each
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: range
+      anchor:
+        type: primitive
+        modifiers:
+          - type: everyScope
+            scopeType: {type: functionName}
+        mark: {type: decoratedSymbol, symbolColor: default, character: d}
+      active:
+        type: primitive
+        mark: {type: decoratedSymbol, symbolColor: default, character: e}
+      excludeAnchor: true
+      excludeActive: true
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |
+    def aaa():
+        pass
+
+    def bbb():
+        pass
+
+    def ccc():
+        pass
+
+    def ddd():
+        pass
+  selections:
+    - anchor: {line: 11, character: 0}
+      active: {line: 11, character: 0}
+  marks:
+    default.d:
+      start: {line: 0, character: 0}
+      end: {line: 0, character: 3}
+    default.e:
+      start: {line: 9, character: 0}
+      end: {line: 9, character: 3}
+finalState:
+  documentContents: |
+    def aaa():
+        pass
+
+    def ():
+        pass
+
+    def ():
+        pass
+
+    def ddd():
+        pass
+  selections:
+    - anchor: {line: 3, character: 4}
+      active: {line: 3, character: 4}
+    - anchor: {line: 6, character: 4}
+      active: {line: 6, character: 4}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/everyRange/clearEveryFunkNameFinePastBlueDrum.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/everyRange/clearEveryFunkNameFinePastBlueDrum.yml
@@ -1,0 +1,60 @@
+languageId: python
+command:
+  version: 5
+  spokenForm: clear every funk name fine past blue drum
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: range
+      anchor:
+        type: primitive
+        modifiers:
+          - type: everyScope
+            scopeType: {type: functionName}
+        mark: {type: decoratedSymbol, symbolColor: default, character: f}
+      active:
+        type: primitive
+        mark: {type: decoratedSymbol, symbolColor: blue, character: d}
+      excludeAnchor: false
+      excludeActive: false
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |
+    def aaa():
+        pass
+
+    def bbb():
+        pass
+
+    def ccc():
+        pass
+
+    def ddd():
+        pass
+  selections:
+    - anchor: {line: 11, character: 0}
+      active: {line: 11, character: 0}
+  marks:
+    default.f:
+      start: {line: 3, character: 0}
+      end: {line: 3, character: 3}
+    blue.d:
+      start: {line: 6, character: 0}
+      end: {line: 6, character: 3}
+finalState:
+  documentContents: |
+    def aaa():
+        pass
+
+    def ():
+        pass
+
+    def ():
+        pass
+
+    def ddd():
+        pass
+  selections:
+    - anchor: {line: 3, character: 4}
+      active: {line: 3, character: 4}
+    - anchor: {line: 6, character: 4}
+      active: {line: 6, character: 4}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/everyRange/clearEveryFunkNamePastBlueDrum.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/everyRange/clearEveryFunkNamePastBlueDrum.yml
@@ -1,0 +1,58 @@
+languageId: python
+command:
+  version: 5
+  spokenForm: clear every funk name past blue drum
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: range
+      anchor:
+        type: primitive
+        modifiers:
+          - type: everyScope
+            scopeType: {type: functionName}
+      active:
+        type: primitive
+        mark: {type: decoratedSymbol, symbolColor: blue, character: d}
+      excludeAnchor: false
+      excludeActive: false
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |
+    def aaa():
+        pass
+
+    def bbb():
+        pass
+
+    def ccc():
+        pass
+
+    def ddd():
+        pass
+  selections:
+    - anchor: {line: 1, character: 4}
+      active: {line: 1, character: 4}
+  marks:
+    blue.d:
+      start: {line: 6, character: 0}
+      end: {line: 6, character: 3}
+finalState:
+  documentContents: |
+    def ():
+        pass
+
+    def ():
+        pass
+
+    def ():
+        pass
+
+    def ddd():
+        pass
+  selections:
+    - anchor: {line: 0, character: 4}
+      active: {line: 0, character: 4}
+    - anchor: {line: 3, character: 4}
+      active: {line: 3, character: 4}
+    - anchor: {line: 6, character: 4}
+      active: {line: 6, character: 4}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/everyRange/clearEveryFunkNameSkipPastBlueDrum.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/everyRange/clearEveryFunkNameSkipPastBlueDrum.yml
@@ -1,0 +1,56 @@
+languageId: python
+command:
+  version: 5
+  spokenForm: clear every funk name skip past blue drum
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: range
+      anchor:
+        type: primitive
+        modifiers:
+          - type: everyScope
+            scopeType: {type: functionName}
+      active:
+        type: primitive
+        mark: {type: decoratedSymbol, symbolColor: blue, character: d}
+      excludeAnchor: true
+      excludeActive: false
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |
+    def aaa():
+        pass
+
+    def bbb():
+        pass
+
+    def ccc():
+        pass
+
+    def ddd():
+        pass
+  selections:
+    - anchor: {line: 1, character: 4}
+      active: {line: 1, character: 4}
+  marks:
+    blue.d:
+      start: {line: 6, character: 0}
+      end: {line: 6, character: 3}
+finalState:
+  documentContents: |
+    def aaa():
+        pass
+
+    def ():
+        pass
+
+    def ():
+        pass
+
+    def ddd():
+        pass
+  selections:
+    - anchor: {line: 3, character: 4}
+      active: {line: 3, character: 4}
+    - anchor: {line: 6, character: 4}
+      active: {line: 6, character: 4}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/everyRange/clearEveryLineAirBetweenHarp.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/everyRange/clearEveryLineAirBetweenHarp.yml
@@ -1,0 +1,40 @@
+languageId: plaintext
+command:
+  version: 5
+  spokenForm: clear every line air between harp
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: range
+      anchor:
+        type: primitive
+        modifiers:
+          - type: everyScope
+            scopeType: {type: line}
+        mark: {type: decoratedSymbol, symbolColor: default, character: a}
+      active:
+        type: primitive
+        mark: {type: decoratedSymbol, symbolColor: default, character: h}
+      excludeAnchor: true
+      excludeActive: true
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |
+    aaa bbb
+    ccc ddd
+    eee fff
+    ggg hhh
+  selections:
+    - anchor: {line: 4, character: 0}
+      active: {line: 4, character: 0}
+  marks: {}
+finalState:
+  documentContents: |
+    aaa bbb
+
+
+    ggg hhh
+  selections:
+    - anchor: {line: 1, character: 0}
+      active: {line: 1, character: 0}
+    - anchor: {line: 2, character: 0}
+      active: {line: 2, character: 0}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/everyRange/clearEveryLineAirPastDrum.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/everyRange/clearEveryLineAirPastDrum.yml
@@ -1,0 +1,38 @@
+languageId: plaintext
+command:
+  version: 5
+  spokenForm: clear every line air past drum
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: range
+      anchor:
+        type: primitive
+        modifiers:
+          - type: everyScope
+            scopeType: {type: line}
+        mark: {type: decoratedSymbol, symbolColor: default, character: a}
+      active:
+        type: primitive
+        mark: {type: decoratedSymbol, symbolColor: default, character: d}
+      excludeAnchor: false
+      excludeActive: false
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |
+    aaa bbb
+    ccc ddd eee
+    fff
+  selections:
+    - anchor: {line: 3, character: 0}
+      active: {line: 3, character: 0}
+  marks: {}
+finalState:
+  documentContents: |
+
+
+    fff
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+    - anchor: {line: 1, character: 0}
+      active: {line: 1, character: 0}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/everyRange/clearEveryLineAirUntilFine.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/everyRange/clearEveryLineAirUntilFine.yml
@@ -1,0 +1,38 @@
+languageId: plaintext
+command:
+  version: 5
+  spokenForm: clear every line air until fine
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: range
+      anchor:
+        type: primitive
+        modifiers:
+          - type: everyScope
+            scopeType: {type: line}
+        mark: {type: decoratedSymbol, symbolColor: default, character: a}
+      active:
+        type: primitive
+        mark: {type: decoratedSymbol, symbolColor: default, character: f}
+      excludeAnchor: false
+      excludeActive: true
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |
+    aaa bbb
+    ccc ddd
+    eee fff
+  selections:
+    - anchor: {line: 3, character: 0}
+      active: {line: 3, character: 0}
+  marks: {}
+finalState:
+  documentContents: |
+
+
+    eee fff
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+    - anchor: {line: 1, character: 0}
+      active: {line: 1, character: 0}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/everyRange/clearEveryLineBlockBatPastFine.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/everyRange/clearEveryLineBlockBatPastFine.yml
@@ -1,0 +1,56 @@
+languageId: plaintext
+command:
+  version: 5
+  spokenForm: clear every line block bat past fine
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: range
+      anchor:
+        type: primitive
+        modifiers:
+          - type: everyScope
+            scopeType: {type: line}
+          - type: containingScope
+            scopeType: {type: paragraph}
+        mark: {type: decoratedSymbol, symbolColor: default, character: b}
+      active:
+        type: primitive
+        mark: {type: decoratedSymbol, symbolColor: default, character: f}
+      excludeAnchor: false
+      excludeActive: false
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |
+    aaa bbb
+    ccc ddd
+
+    eee fff
+    ggg hhh
+
+    iii jjj
+    kkk lll
+  selections:
+    - anchor: {line: 8, character: 0}
+      active: {line: 8, character: 0}
+  marks: {}
+finalState:
+  documentContents: |
+
+
+
+
+
+
+    iii jjj
+    kkk lll
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+    - anchor: {line: 1, character: 0}
+      active: {line: 1, character: 0}
+    - anchor: {line: 2, character: 0}
+      active: {line: 2, character: 0}
+    - anchor: {line: 3, character: 0}
+      active: {line: 3, character: 0}
+    - anchor: {line: 4, character: 0}
+      active: {line: 4, character: 0}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/everyRange/clearEveryLinePastBlockFine.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/everyRange/clearEveryLinePastBlockFine.yml
@@ -1,0 +1,54 @@
+languageId: plaintext
+command:
+  version: 5
+  spokenForm: clear every line past block fine
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: range
+      anchor:
+        type: primitive
+        modifiers:
+          - type: everyScope
+            scopeType: {type: line}
+      active:
+        type: primitive
+        modifiers:
+          - type: containingScope
+            scopeType: {type: paragraph}
+        mark: {type: decoratedSymbol, symbolColor: default, character: f}
+      excludeAnchor: false
+      excludeActive: false
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |
+    aaa bbb
+    ccc ddd
+
+    eee fff
+    ggg hhh
+
+    iii jjj
+    kkk lll
+  selections:
+    - anchor: {line: 1, character: 4}
+      active: {line: 1, character: 4}
+  marks: {}
+finalState:
+  documentContents: |
+    aaa bbb
+
+
+
+
+
+    iii jjj
+    kkk lll
+  selections:
+    - anchor: {line: 1, character: 0}
+      active: {line: 1, character: 0}
+    - anchor: {line: 2, character: 0}
+      active: {line: 2, character: 0}
+    - anchor: {line: 3, character: 0}
+      active: {line: 3, character: 0}
+    - anchor: {line: 4, character: 0}
+      active: {line: 4, character: 0}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/everyRange/clearEveryLinePastDrum.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/everyRange/clearEveryLinePastDrum.yml
@@ -1,0 +1,43 @@
+languageId: plaintext
+command:
+  version: 5
+  spokenForm: clear every line past drum
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: range
+      anchor:
+        type: primitive
+        modifiers:
+          - type: everyScope
+            scopeType: {type: line}
+      active:
+        type: primitive
+        mark: {type: decoratedSymbol, symbolColor: default, character: d}
+      excludeAnchor: false
+      excludeActive: false
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    aaa bbb
+    ccc ddd
+    eee fff
+    ggg hhh
+  selections:
+    - anchor: {line: 3, character: 0}
+      active: {line: 3, character: 0}
+  marks:
+    default.d:
+      start: {line: 1, character: 4}
+      end: {line: 1, character: 7}
+finalState:
+  documentContents: |+
+    aaa bbb
+
+
+  selections:
+    - anchor: {line: 1, character: 0}
+      active: {line: 1, character: 0}
+    - anchor: {line: 2, character: 0}
+      active: {line: 2, character: 0}
+    - anchor: {line: 3, character: 0}
+      active: {line: 3, character: 0}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/everyRange/clearEveryLinePastEach.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/everyRange/clearEveryLinePastEach.yml
@@ -1,0 +1,44 @@
+languageId: plaintext
+command:
+  version: 5
+  spokenForm: clear every line past each
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: range
+      anchor:
+        type: primitive
+        modifiers:
+          - type: everyScope
+            scopeType: {type: line}
+      active:
+        type: primitive
+        mark: {type: decoratedSymbol, symbolColor: default, character: e}
+      excludeAnchor: false
+      excludeActive: false
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    aaa bbb
+    ccc ddd
+    eee fff
+    ggg hhh
+  selections:
+    - anchor: {line: 0, character: 7}
+      active: {line: 0, character: 7}
+  marks:
+    default.e:
+      start: {line: 2, character: 0}
+      end: {line: 2, character: 3}
+finalState:
+  documentContents: |-
+
+
+
+    ggg hhh
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+    - anchor: {line: 1, character: 0}
+      active: {line: 1, character: 0}
+    - anchor: {line: 2, character: 0}
+      active: {line: 2, character: 0}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/everyRange/clearEveryLinePastNextFunk.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/everyRange/clearEveryLinePastNextFunk.yml
@@ -1,0 +1,56 @@
+languageId: python
+command:
+  version: 5
+  spokenForm: clear every line past next funk
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: range
+      anchor:
+        type: primitive
+        modifiers:
+          - type: everyScope
+            scopeType: {type: line}
+      active:
+        type: primitive
+        modifiers:
+          - type: relativeScope
+            scopeType: {type: namedFunction}
+            offset: 1
+            length: 1
+            direction: forward
+      excludeAnchor: false
+      excludeActive: false
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    aaa = "bbb"
+    ccc = "ddd"
+
+    def eee():
+        pass
+
+    fff = "ggg"
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  marks: {}
+finalState:
+  documentContents: |2-
+
+
+
+
+        
+
+    fff = "ggg"
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+    - anchor: {line: 1, character: 0}
+      active: {line: 1, character: 0}
+    - anchor: {line: 2, character: 0}
+      active: {line: 2, character: 0}
+    - anchor: {line: 3, character: 0}
+      active: {line: 3, character: 0}
+    - anchor: {line: 4, character: 4}
+      active: {line: 4, character: 4}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/everyRange/clearEveryLineUntilFunkNamePit.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/everyRange/clearEveryLineUntilFunkNamePit.yml
@@ -1,0 +1,53 @@
+languageId: python
+command:
+  version: 5
+  spokenForm: clear every line until funk name pit
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: range
+      anchor:
+        type: primitive
+        modifiers:
+          - type: everyScope
+            scopeType: {type: line}
+      active:
+        type: primitive
+        modifiers:
+          - type: containingScope
+            scopeType: {type: functionName}
+        mark: {type: decoratedSymbol, symbolColor: default, character: p}
+      excludeAnchor: false
+      excludeActive: true
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    aaa = "bbb"
+    ccc = "ddd"
+
+    def eee():
+        pass
+
+    fff = "ggg"
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  marks:
+    default.p:
+      start: {line: 4, character: 4}
+      end: {line: 4, character: 8}
+finalState:
+  documentContents: |-
+
+
+
+    def eee():
+        pass
+
+    fff = "ggg"
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+    - anchor: {line: 1, character: 0}
+      active: {line: 1, character: 0}
+    - anchor: {line: 2, character: 0}
+      active: {line: 2, character: 0}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/everyRange/clearEveryStatePastFine.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/everyRange/clearEveryStatePastFine.yml
@@ -1,0 +1,44 @@
+languageId: python
+command:
+  version: 5
+  spokenForm: clear every state past fine
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: range
+      anchor:
+        type: primitive
+        modifiers:
+          - type: everyScope
+            scopeType: {type: statement}
+      active:
+        type: primitive
+        mark: {type: decoratedSymbol, symbolColor: default, character: f}
+      excludeAnchor: false
+      excludeActive: false
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    if True:
+        aaa = "bbb"
+
+        ccc = "ddd"
+        eee = "fff"
+  selections:
+    - anchor: {line: 2, character: 0}
+      active: {line: 2, character: 0}
+  marks:
+    default.f:
+      start: {line: 4, character: 11}
+      end: {line: 4, character: 14}
+finalState:
+  documentContents: |-
+    if True:
+        aaa = "bbb"
+
+        
+        
+  selections:
+    - anchor: {line: 3, character: 4}
+      active: {line: 3, character: 4}
+    - anchor: {line: 4, character: 4}
+      active: {line: 4, character: 4}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/everyRange/clearEveryTokenAirUntilLine.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/everyRange/clearEveryTokenAirUntilLine.yml
@@ -1,0 +1,47 @@
+languageId: plaintext
+command:
+  version: 5
+  spokenForm: clear every token air until line
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: range
+      anchor:
+        type: primitive
+        modifiers:
+          - type: everyScope
+            scopeType: {type: token}
+        mark: {type: decoratedSymbol, symbolColor: default, character: a}
+      active:
+        type: primitive
+        modifiers:
+          - type: containingScope
+            scopeType: {type: line}
+      excludeAnchor: false
+      excludeActive: true
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    aaa bbb
+    ccc ddd
+    eee fff
+  selections:
+    - anchor: {line: 2, character: 7}
+      active: {line: 2, character: 7}
+  marks:
+    default.a:
+      start: {line: 0, character: 0}
+      end: {line: 0, character: 3}
+finalState:
+  documentContents: |2-
+     
+     
+    eee fff
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+    - anchor: {line: 0, character: 1}
+      active: {line: 0, character: 1}
+    - anchor: {line: 1, character: 0}
+      active: {line: 1, character: 0}
+    - anchor: {line: 1, character: 1}
+      active: {line: 1, character: 1}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/everyRange/clearEveryTokenAirUntilPoint.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/everyRange/clearEveryTokenAirUntilPoint.yml
@@ -1,0 +1,40 @@
+languageId: plaintext
+command:
+  version: 5
+  spokenForm: clear every token air until point
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: range
+      anchor:
+        type: primitive
+        modifiers:
+          - type: everyScope
+            scopeType: {type: token}
+        mark: {type: decoratedSymbol, symbolColor: default, character: a}
+      active:
+        type: primitive
+        mark: {type: decoratedSymbol, symbolColor: default, character: .}
+      excludeAnchor: false
+      excludeActive: true
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |
+    aaa bbb.
+  selections:
+    - anchor: {line: 1, character: 0}
+      active: {line: 1, character: 0}
+  marks:
+    default.a:
+      start: {line: 0, character: 0}
+      end: {line: 0, character: 3}
+    default..:
+      start: {line: 0, character: 7}
+      end: {line: 0, character: 8}
+finalState:
+  documentContents: |2
+     .
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+    - anchor: {line: 0, character: 1}
+      active: {line: 0, character: 1}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/everyRange/clearEveryTokenBatBetweenEach.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/everyRange/clearEveryTokenBatBetweenEach.yml
@@ -1,0 +1,34 @@
+languageId: plaintext
+command:
+  version: 5
+  spokenForm: clear every token bat between each
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: range
+      anchor:
+        type: primitive
+        modifiers:
+          - type: everyScope
+            scopeType: {type: token}
+        mark: {type: decoratedSymbol, symbolColor: default, character: b}
+      active:
+        type: primitive
+        mark: {type: decoratedSymbol, symbolColor: default, character: e}
+      excludeAnchor: true
+      excludeActive: true
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |
+    aaa bbb ccc ddd eee fff
+  selections:
+    - anchor: {line: 1, character: 0}
+      active: {line: 1, character: 0}
+  marks: {}
+finalState:
+  documentContents: |
+    aaa bbb   eee fff
+  selections:
+    - anchor: {line: 0, character: 8}
+      active: {line: 0, character: 8}
+    - anchor: {line: 0, character: 9}
+      active: {line: 0, character: 9}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/everyRange/clearEveryTokenBatPastDrum.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/everyRange/clearEveryTokenBatPastDrum.yml
@@ -1,0 +1,36 @@
+languageId: plaintext
+command:
+  version: 5
+  spokenForm: clear every token bat past drum
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: range
+      anchor:
+        type: primitive
+        modifiers:
+          - type: everyScope
+            scopeType: {type: token}
+        mark: {type: decoratedSymbol, symbolColor: default, character: b}
+      active:
+        type: primitive
+        mark: {type: decoratedSymbol, symbolColor: default, character: d}
+      excludeAnchor: false
+      excludeActive: false
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |
+    aaa bbb ccc ddd eee
+  selections:
+    - anchor: {line: 1, character: 0}
+      active: {line: 1, character: 0}
+  marks: {}
+finalState:
+  documentContents: |
+    aaa    eee
+  selections:
+    - anchor: {line: 0, character: 4}
+      active: {line: 0, character: 4}
+    - anchor: {line: 0, character: 5}
+      active: {line: 0, character: 5}
+    - anchor: {line: 0, character: 6}
+      active: {line: 0, character: 6}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/everyRange/clearEveryTokenBatSkipPastEach.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/everyRange/clearEveryTokenBatSkipPastEach.yml
@@ -1,0 +1,36 @@
+languageId: plaintext
+command:
+  version: 5
+  spokenForm: clear every token bat skip past each
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: range
+      anchor:
+        type: primitive
+        modifiers:
+          - type: everyScope
+            scopeType: {type: token}
+        mark: {type: decoratedSymbol, symbolColor: default, character: b}
+      active:
+        type: primitive
+        mark: {type: decoratedSymbol, symbolColor: default, character: e}
+      excludeAnchor: true
+      excludeActive: false
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |
+    aaa bbb ccc ddd eee fff
+  selections:
+    - anchor: {line: 1, character: 0}
+      active: {line: 1, character: 0}
+  marks: {}
+finalState:
+  documentContents: |
+    aaa bbb    fff
+  selections:
+    - anchor: {line: 0, character: 8}
+      active: {line: 0, character: 8}
+    - anchor: {line: 0, character: 9}
+      active: {line: 0, character: 9}
+    - anchor: {line: 0, character: 10}
+      active: {line: 0, character: 10}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/everyRange/clearEveryTokenBatUntilEach.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/everyRange/clearEveryTokenBatUntilEach.yml
@@ -1,0 +1,36 @@
+languageId: plaintext
+command:
+  version: 5
+  spokenForm: clear every token bat until each
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: range
+      anchor:
+        type: primitive
+        modifiers:
+          - type: everyScope
+            scopeType: {type: token}
+        mark: {type: decoratedSymbol, symbolColor: default, character: b}
+      active:
+        type: primitive
+        mark: {type: decoratedSymbol, symbolColor: default, character: e}
+      excludeAnchor: false
+      excludeActive: true
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |
+    aaa bbb ccc ddd eee fff
+  selections:
+    - anchor: {line: 1, character: 0}
+      active: {line: 1, character: 0}
+  marks: {}
+finalState:
+  documentContents: |
+    aaa    eee fff
+  selections:
+    - anchor: {line: 0, character: 4}
+      active: {line: 0, character: 4}
+    - anchor: {line: 0, character: 5}
+      active: {line: 0, character: 5}
+    - anchor: {line: 0, character: 6}
+      active: {line: 0, character: 6}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/everyRange/clearEveryTokenPastCap.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/everyRange/clearEveryTokenPastCap.yml
@@ -1,0 +1,34 @@
+languageId: plaintext
+command:
+  version: 5
+  spokenForm: clear every token past cap
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: range
+      anchor:
+        type: primitive
+        modifiers:
+          - type: everyScope
+            scopeType: {type: token}
+      active:
+        type: primitive
+        mark: {type: decoratedSymbol, symbolColor: default, character: c}
+      excludeAnchor: false
+      excludeActive: false
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: aaa  bbb ccc
+  selections:
+    - anchor: {line: 0, character: 4}
+      active: {line: 0, character: 4}
+  marks:
+    default.c:
+      start: {line: 0, character: 9}
+      end: {line: 0, character: 12}
+finalState:
+  documentContents: "aaa   "
+  selections:
+    - anchor: {line: 0, character: 5}
+      active: {line: 0, character: 5}
+    - anchor: {line: 0, character: 6}
+      active: {line: 0, character: 6}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/everyRange/clearEveryTokenPastDownTwo.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/everyRange/clearEveryTokenPastDownTwo.yml
@@ -1,8 +1,8 @@
 languageId: plaintext
 command:
   version: 5
-  spokenForm: pre every token past bat
-  action: {name: setSelectionBefore}
+  spokenForm: clear every token past down two
+  action: {name: clearAndSetSelection}
   targets:
     - type: range
       anchor:
@@ -12,22 +12,24 @@ command:
             scopeType: {type: token}
       active:
         type: primitive
-        mark: {type: decoratedSymbol, symbolColor: default, character: b}
+        mark: {type: lineNumber, lineNumberType: relative, lineNumber: 2}
       excludeAnchor: false
       excludeActive: false
   usePrePhraseSnapshot: true
 initialState:
-  documentContents: |
-    aaa. bbb
+  documentContents: |+
+    aaa  bbb ccc
+
   selections:
-    - anchor: {line: 0, character: 3}
-      active: {line: 0, character: 3}
+    - anchor: {line: 0, character: 4}
+      active: {line: 0, character: 4}
   marks: {}
 finalState:
-  documentContents: |
-    aaa. bbb
+  documentContents: |+
+    aaa   
+
   selections:
-    - anchor: {line: 0, character: 3}
-      active: {line: 0, character: 3}
     - anchor: {line: 0, character: 5}
       active: {line: 0, character: 5}
+    - anchor: {line: 0, character: 6}
+      active: {line: 0, character: 6}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/everyRange/clearEveryTokenPastDrum.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/everyRange/clearEveryTokenPastDrum.yml
@@ -1,0 +1,33 @@
+languageId: plaintext
+command:
+  version: 5
+  spokenForm: clear every token past drum
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: range
+      anchor:
+        type: primitive
+        modifiers:
+          - type: everyScope
+            scopeType: {type: token}
+      active:
+        type: primitive
+        mark: {type: decoratedSymbol, symbolColor: default, character: d}
+      excludeAnchor: false
+      excludeActive: false
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: aaa bbb ccc ddd eee
+  selections:
+    - anchor: {line: 0, character: 7}
+      active: {line: 0, character: 7}
+  marks: {}
+finalState:
+  documentContents: aaa    eee
+  selections:
+    - anchor: {line: 0, character: 4}
+      active: {line: 0, character: 4}
+    - anchor: {line: 0, character: 5}
+      active: {line: 0, character: 5}
+    - anchor: {line: 0, character: 6}
+      active: {line: 0, character: 6}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/everyRange/clearEveryTokenPastDrum.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/everyRange/clearEveryTokenPastDrum.yml
@@ -23,11 +23,9 @@ initialState:
       active: {line: 0, character: 7}
   marks: {}
 finalState:
-  documentContents: aaa    eee
+  documentContents: aaa bbb   eee
   selections:
-    - anchor: {line: 0, character: 4}
-      active: {line: 0, character: 4}
-    - anchor: {line: 0, character: 5}
-      active: {line: 0, character: 5}
-    - anchor: {line: 0, character: 6}
-      active: {line: 0, character: 6}
+    - anchor: {line: 0, character: 8}
+      active: {line: 0, character: 8}
+    - anchor: {line: 0, character: 9}
+      active: {line: 0, character: 9}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/everyRange/clearEveryTokenPastFunkNameEach.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/everyRange/clearEveryTokenPastFunkNameEach.yml
@@ -1,0 +1,49 @@
+languageId: python
+command:
+  version: 5
+  spokenForm: clear every token past funk name each
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: range
+      anchor:
+        type: primitive
+        modifiers:
+          - type: everyScope
+            scopeType: {type: token}
+      active:
+        type: primitive
+        modifiers:
+          - type: containingScope
+            scopeType: {type: functionName}
+        mark: {type: decoratedSymbol, symbolColor: default, character: e}
+      excludeAnchor: false
+      excludeActive: false
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    def aaa():
+        pass
+
+    def bbb():
+        pass
+  selections:
+    - anchor: {line: 1, character: 4}
+      active: {line: 1, character: 4}
+  marks:
+    default.e:
+      start: {line: 3, character: 0}
+      end: {line: 3, character: 3}
+finalState:
+  documentContents: |-
+    def aaa():
+        
+
+     ():
+        pass
+  selections:
+    - anchor: {line: 1, character: 4}
+      active: {line: 1, character: 4}
+    - anchor: {line: 3, character: 0}
+      active: {line: 3, character: 0}
+    - anchor: {line: 3, character: 1}
+      active: {line: 3, character: 1}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/everyRange/clearEveryTokenUntilFunkNameFine.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/everyRange/clearEveryTokenUntilFunkNameFine.yml
@@ -1,0 +1,47 @@
+languageId: python
+command:
+  version: 5
+  spokenForm: clear every token until funk name fine
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: range
+      anchor:
+        type: primitive
+        modifiers:
+          - type: everyScope
+            scopeType: {type: token}
+      active:
+        type: primitive
+        modifiers:
+          - type: containingScope
+            scopeType: {type: functionName}
+        mark: {type: decoratedSymbol, symbolColor: default, character: f}
+      excludeAnchor: false
+      excludeActive: true
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    def aaa():
+        pass
+
+    def bbb():
+        pass
+  selections:
+    - anchor: {line: 1, character: 4}
+      active: {line: 1, character: 4}
+  marks:
+    default.f:
+      start: {line: 3, character: 0}
+      end: {line: 3, character: 3}
+finalState:
+  documentContents: |-
+    def aaa():
+        
+
+     bbb():
+        pass
+  selections:
+    - anchor: {line: 1, character: 4}
+      active: {line: 1, character: 4}
+    - anchor: {line: 3, character: 0}
+      active: {line: 3, character: 0}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/everyRange/postEveryTokenFunkNameSkipPastToken.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/everyRange/postEveryTokenFunkNameSkipPastToken.yml
@@ -1,0 +1,43 @@
+languageId: python
+command:
+  version: 5
+  spokenForm: post every token funk name skip past token
+  action: {name: setSelectionAfter}
+  targets:
+    - type: range
+      anchor:
+        type: primitive
+        modifiers:
+          - type: everyScope
+            scopeType: {type: token}
+          - type: containingScope
+            scopeType: {type: functionName}
+      active:
+        type: primitive
+        modifiers:
+          - type: containingScope
+            scopeType: {type: token}
+      excludeAnchor: true
+      excludeActive: false
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    def aaa():
+        pass
+  selections:
+    - anchor: {line: 1, character: 6}
+      active: {line: 1, character: 6}
+  marks: {}
+finalState:
+  documentContents: |-
+    def aaa():
+        pass
+  selections:
+    - anchor: {line: 0, character: 8}
+      active: {line: 0, character: 8}
+    - anchor: {line: 0, character: 9}
+      active: {line: 0, character: 9}
+    - anchor: {line: 0, character: 10}
+      active: {line: 0, character: 10}
+    - anchor: {line: 1, character: 8}
+      active: {line: 1, character: 8}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/everyRange/preEveryTokenPastBat.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/everyRange/preEveryTokenPastBat.yml
@@ -1,0 +1,35 @@
+languageId: plaintext
+command:
+  version: 5
+  spokenForm: pre every token past bat
+  action: {name: setSelectionBefore}
+  targets:
+    - type: range
+      anchor:
+        type: primitive
+        modifiers:
+          - type: everyScope
+            scopeType: {type: token}
+      active:
+        type: primitive
+        mark: {type: decoratedSymbol, symbolColor: default, character: b}
+      excludeAnchor: false
+      excludeActive: false
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |
+    aaa. bbb
+  selections:
+    - anchor: {line: 0, character: 3}
+      active: {line: 0, character: 3}
+  marks: {}
+finalState:
+  documentContents: |
+    aaa. bbb
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+    - anchor: {line: 0, character: 3}
+      active: {line: 0, character: 3}
+    - anchor: {line: 0, character: 5}
+      active: {line: 0, character: 5}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/everyRange/preEveryTokenThisPastBat.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/everyRange/preEveryTokenThisPastBat.yml
@@ -1,7 +1,7 @@
 languageId: plaintext
 command:
   version: 5
-  spokenForm: pre every token past bat
+  spokenForm: pre every token this past bat
   action: {name: setSelectionBefore}
   targets:
     - type: range
@@ -10,6 +10,7 @@ command:
         modifiers:
           - type: everyScope
             scopeType: {type: token}
+        mark: {type: cursor}
       active:
         type: primitive
         mark: {type: decoratedSymbol, symbolColor: default, character: b}
@@ -17,17 +18,20 @@ command:
       excludeActive: false
   usePrePhraseSnapshot: true
 initialState:
-  documentContents: |
-    aaa. bbb
+  documentContents: aaa.bbb
   selections:
     - anchor: {line: 0, character: 3}
       active: {line: 0, character: 3}
-  marks: {}
+  marks:
+    default.b:
+      start: {line: 0, character: 4}
+      end: {line: 0, character: 7}
 finalState:
-  documentContents: |
-    aaa. bbb
+  documentContents: aaa.bbb
   selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
     - anchor: {line: 0, character: 3}
       active: {line: 0, character: 3}
-    - anchor: {line: 0, character: 5}
-      active: {line: 0, character: 5}
+    - anchor: {line: 0, character: 4}
+      active: {line: 0, character: 4}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/everyRange/preEveryTokenUntilFunkName.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/everyRange/preEveryTokenUntilFunkName.yml
@@ -1,0 +1,41 @@
+languageId: python
+command:
+  version: 5
+  spokenForm: pre every token until funk name
+  action: {name: setSelectionBefore}
+  targets:
+    - type: range
+      anchor:
+        type: primitive
+        modifiers:
+          - type: everyScope
+            scopeType: {type: token}
+      active:
+        type: primitive
+        modifiers:
+          - type: containingScope
+            scopeType: {type: functionName}
+      excludeAnchor: false
+      excludeActive: true
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    def aaa():
+        pass
+  selections:
+    - anchor: {line: 1, character: 8}
+      active: {line: 1, character: 8}
+  marks: {}
+finalState:
+  documentContents: |-
+    def aaa():
+        pass
+  selections:
+    - anchor: {line: 0, character: 7}
+      active: {line: 0, character: 7}
+    - anchor: {line: 0, character: 8}
+      active: {line: 0, character: 8}
+    - anchor: {line: 0, character: 9}
+      active: {line: 0, character: 9}
+    - anchor: {line: 1, character: 4}
+      active: {line: 1, character: 4}


### PR DESCRIPTION
We also support fancier constructs like the following:

- "every line block air past bat"
- "every line air past block bat"
- "every line past bat"
- "every line past block bat"

The approach is to detect ranges of the form `"every <scope> <target> past <target>"` and to turn them into a special range target, distinct from `"continuous"` or `"slice"`.  We remove the `"every <scope>"` modifier as well because that's done after we construct the range.

The reason we need a special range target is that exclusion needs to be smart to handle scopes whose domain is larger than their content range

We also add slight special casing for line targets so that when you're at the beginning / end of a line, that line is considered part of the range

## Checklist

- [x] Only expand to containing scope if the given end is excluded, eg expand end target if "until".  Might need to tweak construction of ranges so that each side is responsible for exclusion to make "every token until line bat" work, because otherwise it gets downgraded so we won't actually skip the right thing.  eg try "every token air past state bat" if "bat" is in the middle of the statement.  
- [x] Add tests for above examples
- [x] Handle case where one side is not in a scope
- [x] Handle case where one side is in a scope but you don't want it to jump to parent (eg "take every state past bat" when we're inside a function but between statements)
- [x] Add test for "every line air until bat"
- [x] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [x] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [x] I have not broken the cheatsheet
