### PR TITLE
Added typescript language support for jsx fragment node

### DIFF
--- a/packages/cursorless-engine/src/languages/typescript.ts
+++ b/packages/cursorless-engine/src/languages/typescript.ts
@@ -71,7 +71,7 @@ const STATEMENT_TYPES = [
   "with_statement",
 ];
 
-function jsxTag(isStartTag: boolean): NodeMatcher {
+function getJsxFragmentTag(isStartTag: boolean): NodeMatcher {
   return matcher(
     typedNodeFinder("jsx_fragment"),
     (editor: TextEditor, node: SyntaxNode) => {
@@ -93,11 +93,11 @@ function jsxTag(isStartTag: boolean): NodeMatcher {
 
 const getStartTag = cascadingMatcher(
   patternMatcher("jsx_element.jsx_opening_element!"),
-  jsxTag(true),
+  getJsxFragmentTag(true),
 );
 const getEndTag = cascadingMatcher(
   patternMatcher("jsx_element.jsx_closing_element!"),
-  jsxTag(false),
+  getJsxFragmentTag(false),
 );
 
 const getTags = (selection: SelectionWithEditor, node: SyntaxNode) => {

--- a/packages/cursorless-engine/src/languages/typescript.ts
+++ b/packages/cursorless-engine/src/languages/typescript.ts
@@ -71,6 +71,7 @@ const STATEMENT_TYPES = [
   "with_statement",
 ];
 
+/** Handles jsx fragment start or end tag, eg the `<>` in `<>foo</>` **/
 function getJsxFragmentTag(isStartTag: boolean): NodeMatcher {
   return matcher(
     typedNodeFinder("jsx_fragment"),

--- a/packages/cursorless-engine/src/languages/typescript.ts
+++ b/packages/cursorless-engine/src/languages/typescript.ts
@@ -70,11 +70,11 @@ const STATEMENT_TYPES = [
   "with_statement",
 ];
 
-function jsxTags(isStart: boolean): NodeMatcher {
+function jsxTag(isStartTag: boolean): NodeMatcher {
   return matcher(
-    patternFinder("jsx_fragment"),
+    typedNodeFinder("jsx_fragment"),
     (editor: TextEditor, node: SyntaxNode) => {
-      const [start, end] = isStart
+      const [start, end] = isStartTag
         ? [node.children[0], node.children[1]]
         : [node.children.at(-3)!, node.children.at(-1)!];
       return {
@@ -92,11 +92,11 @@ function jsxTags(isStart: boolean): NodeMatcher {
 
 const getStartTag = cascadingMatcher(
   patternMatcher("jsx_element.jsx_opening_element!"),
-  jsxTags(true),
+  jsxTag(true),
 );
 const getEndTag = cascadingMatcher(
   patternMatcher("jsx_element.jsx_closing_element!"),
-  jsxTags(false),
+  jsxTag(false),
 );
 
 const getTags = (selection: SelectionWithEditor, node: SyntaxNode) => {

--- a/packages/cursorless-engine/src/languages/typescript.ts
+++ b/packages/cursorless-engine/src/languages/typescript.ts
@@ -20,6 +20,7 @@ import {
   extendForwardPastOptional,
   getNodeInternalRange,
   getNodeRange,
+  jsxFragmentExtractor,
   pairSelectionExtractor,
   selectWithLeadingDelimiter,
   simpleSelectionExtractor,
@@ -335,9 +336,12 @@ const nodeMatchers: Partial<
   argumentOrParameter: argumentMatcher("formal_parameters", "arguments"),
   // XML, JSX
   attribute: ["jsx_attribute"],
-  xmlElement: matcher(
-    typedNodeFinder("jsx_element", "jsx_self_closing_element", "jsx_fragment"),
-    xmlElementExtractor,
+  xmlElement: cascadingMatcher(
+    matcher(
+      typedNodeFinder("jsx_element", "jsx_self_closing_element"),
+      xmlElementExtractor,
+    ),
+    matcher(typedNodeFinder("jsx_fragment"), jsxFragmentExtractor),
   ),
   xmlBothTags: getTags,
   xmlStartTag: getStartTag,

--- a/packages/cursorless-engine/src/util/nodeSelectors.ts
+++ b/packages/cursorless-engine/src/util/nodeSelectors.ts
@@ -427,6 +427,28 @@ export function xmlElementExtractor(
   return selection;
 }
 
+export function jsxFragmentExtractor(
+  editor: TextEditor,
+  node: SyntaxNode,
+): SelectionWithContext {
+  const selection = simpleSelectionExtractor(editor, node);
+
+  // Interior range for an element is found by excluding the start and end nodes.
+  if (node.namedChildCount > 0) {
+    const { firstNamedChild, lastNamedChild } = node;
+    if (firstNamedChild != null && lastNamedChild != null) {
+      selection.context.interiorRange = new Range(
+        firstNamedChild.endPosition.row,
+        firstNamedChild.endPosition.column,
+        lastNamedChild.startPosition.row,
+        lastNamedChild.startPosition.column,
+      );
+    }
+  }
+
+  return selection;
+}
+
 export function getInsertionDelimiter(
   editor: TextEditor,
   leadingDelimiterRange: Range | undefined,

--- a/packages/cursorless-engine/src/util/nodeSelectors.ts
+++ b/packages/cursorless-engine/src/util/nodeSelectors.ts
@@ -434,17 +434,14 @@ export function jsxFragmentExtractor(
   const selection = simpleSelectionExtractor(editor, node);
 
   // Interior range for an element is found by excluding the start and end nodes.
-  if (node.namedChildCount > 0) {
-    const { firstNamedChild, lastNamedChild } = node;
-    if (firstNamedChild != null && lastNamedChild != null) {
-      selection.context.interiorRange = new Range(
-        firstNamedChild.endPosition.row,
-        firstNamedChild.endPosition.column,
-        lastNamedChild.startPosition.row,
-        lastNamedChild.startPosition.column,
-      );
-    }
-  }
+  const startPosition = node.children[1].endPosition;
+  const endPosition = node.children.at(-3)!.startPosition;
+  selection.context.interiorRange = new Range(
+    startPosition.row,
+    startPosition.column,
+    endPosition.row,
+    endPosition.column,
+  );
 
   return selection;
 }

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/typescript/clearCoreElement3.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/typescript/clearCoreElement3.yml
@@ -1,0 +1,29 @@
+languageId: javascriptreact
+command:
+  version: 5
+  spokenForm: clear core element
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - {type: interiorOnly}
+        - type: containingScope
+          scopeType: {type: xmlElement}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    function Comp() {
+        return <>text</>;
+    }
+  selections:
+    - anchor: {line: 1, character: 15}
+      active: {line: 1, character: 15}
+  marks: {}
+finalState:
+  documentContents: |-
+    function Comp() {
+        return <></>;
+    }
+  selections:
+    - anchor: {line: 1, character: 13}
+      active: {line: 1, character: 13}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/typescript/clearElement.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/typescript/clearElement.yml
@@ -1,0 +1,28 @@
+languageId: javascriptreact
+command:
+  version: 5
+  spokenForm: clear element
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: xmlElement}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    function Comp() {
+        return <>text</>;
+    }
+  selections:
+    - anchor: {line: 1, character: 15}
+      active: {line: 1, character: 15}
+  marks: {}
+finalState:
+  documentContents: |-
+    function Comp() {
+        return ;
+    }
+  selections:
+    - anchor: {line: 1, character: 11}
+      active: {line: 1, character: 11}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/typescript/clearEndTag.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/typescript/clearEndTag.yml
@@ -1,0 +1,28 @@
+languageId: javascriptreact
+command:
+  version: 5
+  spokenForm: clear end tag
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: xmlEndTag}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    function Comp() {
+        return <>text</>;
+    }
+  selections:
+    - anchor: {line: 1, character: 15}
+      active: {line: 1, character: 15}
+  marks: {}
+finalState:
+  documentContents: |-
+    function Comp() {
+        return <>text;
+    }
+  selections:
+    - anchor: {line: 1, character: 17}
+      active: {line: 1, character: 17}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/typescript/clearStartTag.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/typescript/clearStartTag.yml
@@ -1,0 +1,28 @@
+languageId: javascriptreact
+command:
+  version: 5
+  spokenForm: clear start tag
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: xmlStartTag}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    function Comp() {
+        return <>text</>;
+    }
+  selections:
+    - anchor: {line: 1, character: 15}
+      active: {line: 1, character: 15}
+  marks: {}
+finalState:
+  documentContents: |-
+    function Comp() {
+        return text</>;
+    }
+  selections:
+    - anchor: {line: 1, character: 11}
+      active: {line: 1, character: 11}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/typescript/clearTags.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/typescript/clearTags.yml
@@ -1,0 +1,30 @@
+languageId: javascriptreact
+command:
+  version: 5
+  spokenForm: clear tags
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: xmlBothTags}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    function Comp() {
+        return <>text</>;
+    }
+  selections:
+    - anchor: {line: 1, character: 15}
+      active: {line: 1, character: 15}
+  marks: {}
+finalState:
+  documentContents: |-
+    function Comp() {
+        return text;
+    }
+  selections:
+    - anchor: {line: 1, character: 11}
+      active: {line: 1, character: 11}
+    - anchor: {line: 1, character: 15}
+      active: {line: 1, character: 15}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/typescript/takeCoreElement.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/typescript/takeCoreElement.yml
@@ -1,0 +1,29 @@
+languageId: javascriptreact
+command:
+  version: 5
+  spokenForm: take core element
+  action: {name: setSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - {type: interiorOnly}
+        - type: containingScope
+          scopeType: {type: xmlElement}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    function Comp() {
+        return <></>;
+    }
+  selections:
+    - anchor: {line: 1, character: 15}
+      active: {line: 1, character: 15}
+  marks: {}
+finalState:
+  documentContents: |-
+    function Comp() {
+        return <></>;
+    }
+  selections:
+    - anchor: {line: 1, character: 13}
+      active: {line: 1, character: 13}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/typescript/takeCoreElement2.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/typescript/takeCoreElement2.yml
@@ -1,0 +1,29 @@
+languageId: javascriptreact
+command:
+  version: 5
+  spokenForm: take core element
+  action: {name: setSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - {type: interiorOnly}
+        - type: containingScope
+          scopeType: {type: xmlElement}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    function Comp() {
+        return <div></div>;
+    }
+  selections:
+    - anchor: {line: 1, character: 20}
+      active: {line: 1, character: 20}
+  marks: {}
+finalState:
+  documentContents: |-
+    function Comp() {
+        return <div></div>;
+    }
+  selections:
+    - anchor: {line: 1, character: 16}
+      active: {line: 1, character: 16}


### PR DESCRIPTION
Fixes #1450

## Checklist

- [x] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [x] I have not broken the cheatsheet
