### PR TITLE
Increase sleep for rename to allow chaining

### DIFF
--- a/cursorless-talon/src/actions/actions_simple.py
+++ b/cursorless-talon/src/actions/actions_simple.py
@@ -58,7 +58,7 @@ no_wait_actions = [
 
 # These are actions that we don't wait for, but still want to have a post action sleep
 no_wait_actions_post_sleep = {
-    "rename": 0.2,
+    "rename": 0.3,
 }
 
 mod = Module()


### PR DESCRIPTION
The current value of 200ms means chaining consistently doesn't work for me.  300ms seems to fix it consistently.

I could add a setting instead, but I still think 300ms is a better default, given it consistently breaks for me

## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet
