### PR TITLE
Remove `currentSelections` and `currentEditor` from `ProcessedTargetsContext`

### DIFF
--- a/packages/cursorless-engine/src/core/commandRunner/CommandRunner.ts
+++ b/packages/cursorless-engine/src/core/commandRunner/CommandRunner.ts
@@ -12,7 +12,6 @@ import { TestCaseRecorder } from "../../index";
 import { TargetPipelineRunner } from "../../processTargets";
 import { MarkStageFactory } from "../../processTargets/MarkStageFactory";
 import { ModifierStageFactory } from "../../processTargets/ModifierStageFactory";
-import { ide } from "../../singletons/ide.singleton";
 import { TreeSitter } from "../../typings/TreeSitter";
 import {
   ProcessedTargetsContext,
@@ -111,12 +110,6 @@ export class CommandRunner {
           : [];
 
       const processedTargetsContext: ProcessedTargetsContext = {
-        currentSelections:
-          ide().activeTextEditor?.selections.map((selection) => ({
-            selection,
-            editor: ide().activeTextEditor!,
-          })) ?? [],
-        currentEditor: ide().activeTextEditor,
         hatTokenMap: readableHatMap,
         thatMark: this.thatMark.exists() ? this.thatMark.get() : [],
         sourceMark: this.sourceMark.exists() ? this.sourceMark.get() : [],

--- a/packages/cursorless-engine/src/processTargets/marks/CursorStage.ts
+++ b/packages/cursorless-engine/src/processTargets/marks/CursorStage.ts
@@ -1,14 +1,15 @@
-import type { Target } from "../../typings/target.types";
 import type { CursorMark } from "@cursorless/common";
-import type { ProcessedTargetsContext } from "../../typings/Types";
+import { ide } from "../../singletons/ide.singleton";
+import type { Target } from "../../typings/target.types";
 import type { MarkStage } from "../PipelineStages.types";
 import { UntypedTarget } from "../targets";
+import { getActiveSelections } from "./getActiveSelections";
 
 export default class CursorStage implements MarkStage {
   constructor(private mark: CursorMark) {}
 
-  run(context: ProcessedTargetsContext): Target[] {
-    return context.currentSelections.map(
+  run(): Target[] {
+    return getActiveSelections(ide()).map(
       (selection) =>
         new UntypedTarget({
           editor: selection.editor,

--- a/packages/cursorless-engine/src/processTargets/marks/ImplicitStage.ts
+++ b/packages/cursorless-engine/src/processTargets/marks/ImplicitStage.ts
@@ -1,11 +1,12 @@
+import { ide } from "../../singletons/ide.singleton";
 import type { Target } from "../../typings/target.types";
-import type { ProcessedTargetsContext } from "../../typings/Types";
 import type { MarkStage } from "../PipelineStages.types";
 import { ImplicitTarget } from "../targets";
+import { getActiveSelections } from "./getActiveSelections";
 
 export default class ImplicitStage implements MarkStage {
-  run(context: ProcessedTargetsContext): Target[] {
-    return context.currentSelections.map(
+  run(): Target[] {
+    return getActiveSelections(ide()).map(
       (selection) =>
         new ImplicitTarget({
           editor: selection.editor,

--- a/packages/cursorless-engine/src/processTargets/marks/LineNumberStage.ts
+++ b/packages/cursorless-engine/src/processTargets/marks/LineNumberStage.ts
@@ -1,18 +1,18 @@
-import { TextEditor } from "@cursorless/common";
 import type { LineNumberMark, LineNumberType } from "@cursorless/common";
-import type { ProcessedTargetsContext } from "../../typings/Types";
-import { createLineTarget } from "../modifiers/scopeHandlers";
+import { TextEditor } from "@cursorless/common";
+import { ide } from "../../singletons/ide.singleton";
 import type { MarkStage } from "../PipelineStages.types";
+import { createLineTarget } from "../modifiers/scopeHandlers";
 import { LineTarget } from "../targets";
 
 export default class implements MarkStage {
   constructor(private mark: LineNumberMark) {}
 
-  run(context: ProcessedTargetsContext): LineTarget[] {
-    if (context.currentEditor == null) {
+  run(): LineTarget[] {
+    const editor = ide().activeTextEditor;
+    if (editor == null) {
       return [];
     }
-    const editor = context.currentEditor;
     const lineNumber = getLineNumber(
       editor,
       this.mark.lineNumberType,

--- a/packages/cursorless-engine/src/processTargets/marks/getActiveSelections.ts
+++ b/packages/cursorless-engine/src/processTargets/marks/getActiveSelections.ts
@@ -1,0 +1,10 @@
+import type { IDE } from "@cursorless/common";
+
+export function getActiveSelections(ide: IDE) {
+  return (
+    ide.activeTextEditor?.selections.map((selection) => ({
+      selection,
+      editor: ide.activeTextEditor!,
+    })) ?? []
+  );
+}

--- a/packages/cursorless-engine/src/typings/Types.ts
+++ b/packages/cursorless-engine/src/typings/Types.ts
@@ -9,8 +9,6 @@ import type { SyntaxNode } from "web-tree-sitter";
 import { Target } from "./target.types";
 
 export interface ProcessedTargetsContext {
-  currentSelections: SelectionWithEditor[];
-  currentEditor: TextEditor | undefined;
   hatTokenMap: ReadOnlyHatMap;
   thatMark: Target[];
   sourceMark: Target[];


### PR DESCRIPTION
- Depends on https://github.com/cursorless-dev/cursorless/pull/1472

## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet
