### PR TITLE
Remove `getNodeAtLocation` from `ProcessedTargetsContext`

### DIFF
--- a/packages/cursorless-engine/src/core/commandRunner/CommandRunner.ts
+++ b/packages/cursorless-engine/src/core/commandRunner/CommandRunner.ts
@@ -131,9 +131,7 @@ export class CommandRunner {
           ? action.getFinalStages(...actionArgs)
           : [];
 
-      const processedTargetsContext: ProcessedTargetsContext = {
-        getNodeAtLocation: this.treeSitter.getNodeAtLocation,
-      };
+      const processedTargetsContext: ProcessedTargetsContext = {};
 
       if (this.testCaseRecorder.isActive()) {
         const context = {

--- a/packages/cursorless-engine/src/languages/LanguageDefinitions.ts
+++ b/packages/cursorless-engine/src/languages/LanguageDefinitions.ts
@@ -1,3 +1,5 @@
+import { Range, TextDocument } from "@cursorless/common";
+import { SyntaxNode } from "web-tree-sitter";
 import { TreeSitter } from "..";
 import { LanguageDefinition } from "./LanguageDefinition";
 
@@ -49,5 +51,12 @@ export class LanguageDefinitions {
     }
 
     return definition === LANGUAGE_UNDEFINED ? undefined : definition;
+  }
+
+  /**
+   * @deprecated Only for use in legacy containing scope stage
+   */
+  public getNodeAtLocation(document: TextDocument, range: Range): SyntaxNode {
+    return this.treeSitter.getNodeAtLocation(document, range);
   }
 }

--- a/packages/cursorless-engine/src/processTargets/ModifierStageFactoryImpl.ts
+++ b/packages/cursorless-engine/src/processTargets/ModifierStageFactoryImpl.ts
@@ -138,6 +138,7 @@ export class ModifierStageFactoryImpl implements ModifierStageFactory {
       default:
         // Default to containing syntax scope using tree sitter
         return new ContainingSyntaxScopeStage(
+          this.languageDefinitions,
           modifier as SimpleContainingScopeModifier | SimpleEveryScopeModifier,
         );
     }

--- a/packages/cursorless-engine/src/processTargets/modifiers/ItemStage/ItemStage.ts
+++ b/packages/cursorless-engine/src/processTargets/modifiers/ItemStage/ItemStage.ts
@@ -6,7 +6,6 @@ import {
   SimpleScopeTypeType,
   TextEditor,
 } from "@cursorless/common";
-import { LanguageDefinition } from "../../../languages/LanguageDefinition";
 import { LanguageDefinitions } from "../../../languages/LanguageDefinitions";
 import { ProcessedTargetsContext } from "../../../typings/Types";
 import { Target } from "../../../typings/target.types";
@@ -30,31 +29,26 @@ export default class ItemStage implements ModifierStage {
     // First try the language specific implementation of item
     try {
       return new ContainingSyntaxScopeStage(
+        this.languageDefinitions,
         this.modifier as SimpleContainingScopeModifier,
       ).run(context, target);
     } catch (_error) {
       // do nothing
     }
 
-    const languageDefinition = this.languageDefinitions.get(
-      target.editor.document.languageId,
-    );
-
     // Then try the textual implementation
     if (this.modifier.type === "everyScope") {
-      return this.getEveryTarget(languageDefinition, context, target);
+      return this.getEveryTarget(this.languageDefinitions, target);
     }
-    return [this.getSingleTarget(languageDefinition, context, target)];
+    return [this.getSingleTarget(this.languageDefinitions, target)];
   }
 
   private getEveryTarget(
-    languageDefinition: LanguageDefinition | undefined,
-    context: ProcessedTargetsContext,
+    languageDefinitions: LanguageDefinitions,
     target: Target,
   ) {
     const itemInfos = getItemInfosForIterationScope(
-      languageDefinition,
-      context,
+      languageDefinitions,
       target,
     );
 
@@ -73,13 +67,11 @@ export default class ItemStage implements ModifierStage {
   }
 
   private getSingleTarget(
-    languageDefinition: LanguageDefinition | undefined,
-    context: ProcessedTargetsContext,
+    languageDefinitions: LanguageDefinitions,
     target: Target,
   ) {
     const itemInfos = getItemInfosForIterationScope(
-      languageDefinition,
-      context,
+      languageDefinitions,
       target,
     );
 
@@ -144,15 +136,10 @@ function filterItemInfos(target: Target, itemInfos: ItemInfo[]): ItemInfo[] {
 }
 
 function getItemInfosForIterationScope(
-  languageDefinition: LanguageDefinition | undefined,
-  context: ProcessedTargetsContext,
+  languageDefinitions: LanguageDefinitions,
   target: Target,
 ) {
-  const { range, boundary } = getIterationScope(
-    languageDefinition,
-    context,
-    target,
-  );
+  const { range, boundary } = getIterationScope(languageDefinitions, target);
   return getItemsInRange(target.editor, range, boundary);
 }
 

--- a/packages/cursorless-engine/src/processTargets/modifiers/ItemStage/getIterationScope.ts
+++ b/packages/cursorless-engine/src/processTargets/modifiers/ItemStage/getIterationScope.ts
@@ -1,6 +1,5 @@
 import { Range, TextEditor } from "@cursorless/common";
-import { LanguageDefinition } from "../../../languages/LanguageDefinition";
-import { ProcessedTargetsContext } from "../../../typings/Types";
+import { LanguageDefinitions } from "../../../languages/LanguageDefinitions";
 import { Target } from "../../../typings/target.types";
 import { PlainTarget, SurroundingPairTarget } from "../../targets";
 import { fitRangeToLineContent } from "../scopeHandlers";
@@ -14,21 +13,15 @@ import { processSurroundingPair } from "../surroundingPair";
  * @returns The stage iteration scope and optional surrounding pair boundaries
  */
 export function getIterationScope(
-  languageDefinition: LanguageDefinition | undefined,
-  context: ProcessedTargetsContext,
+  languageDefinitions: LanguageDefinitions,
   target: Target,
 ): { range: Range; boundary?: [Range, Range] } {
-  let surroundingTarget = getSurroundingPair(
-    languageDefinition,
-    context,
-    target,
-  );
+  let surroundingTarget = getSurroundingPair(languageDefinitions, target);
 
   // Iteration is necessary in case of nested strings
   while (surroundingTarget != null) {
     const surroundingStringTarget = getStringSurroundingPair(
-      languageDefinition,
-      context,
+      languageDefinitions,
       surroundingTarget,
     );
 
@@ -50,8 +43,7 @@ export function getIterationScope(
     }
 
     surroundingTarget = getParentSurroundingPair(
-      languageDefinition,
-      context,
+      languageDefinitions,
       target.editor,
       surroundingTarget,
     );
@@ -64,8 +56,7 @@ export function getIterationScope(
 }
 
 function getParentSurroundingPair(
-  languageDefinition: LanguageDefinition | undefined,
-  context: ProcessedTargetsContext,
+  languageDefinitions: LanguageDefinitions,
   editor: TextEditor,
   target: SurroundingPairTarget,
 ) {
@@ -77,8 +68,7 @@ function getParentSurroundingPair(
   // Step out of this pair and see if we have a parent
   const position = editor.document.positionAt(startOffset - 1);
   return getSurroundingPair(
-    languageDefinition,
-    context,
+    languageDefinitions,
     new PlainTarget({
       editor,
       contentRange: new Range(position, position),
@@ -88,11 +78,10 @@ function getParentSurroundingPair(
 }
 
 function getSurroundingPair(
-  languageDefinition: LanguageDefinition | undefined,
-  context: ProcessedTargetsContext,
+  languageDefinitions: LanguageDefinitions,
   target: Target,
 ) {
-  return processSurroundingPair(languageDefinition, context, target, {
+  return processSurroundingPair(languageDefinitions, target, {
     type: "surroundingPair",
     delimiter: "collectionBoundary",
     requireStrongContainment: true,
@@ -100,11 +89,10 @@ function getSurroundingPair(
 }
 
 function getStringSurroundingPair(
-  languageDefinition: LanguageDefinition | undefined,
-  context: ProcessedTargetsContext,
+  languageDefinitions: LanguageDefinitions,
   target: Target,
 ) {
-  return processSurroundingPair(languageDefinition, context, target, {
+  return processSurroundingPair(languageDefinitions, target, {
     type: "surroundingPair",
     delimiter: "string",
     requireStrongContainment: true,

--- a/packages/cursorless-engine/src/processTargets/modifiers/SurroundingPairStage.ts
+++ b/packages/cursorless-engine/src/processTargets/modifiers/SurroundingPairStage.ts
@@ -2,7 +2,6 @@ import type {
   ContainingSurroundingPairModifier,
   SurroundingPairModifier,
 } from "@cursorless/common";
-import { LanguageDefinition } from "../../languages/LanguageDefinition";
 import { LanguageDefinitions } from "../../languages/LanguageDefinitions";
 import type { ProcessedTargetsContext } from "../../typings/Types";
 import type { Target } from "../../typings/target.types";
@@ -38,23 +37,20 @@ export default class SurroundingPairStage implements ModifierStage {
     }
 
     return processedSurroundingPairTarget(
-      this.languageDefinitions.get(target.editor.document.languageId),
+      this.languageDefinitions,
       this.modifier,
-      context,
       target,
     );
   }
 }
 
 function processedSurroundingPairTarget(
-  languageDefinition: LanguageDefinition | undefined,
+  languageDefinitions: LanguageDefinitions,
   modifier: ContainingSurroundingPairModifier,
-  context: ProcessedTargetsContext,
   target: Target,
 ): SurroundingPairTarget[] {
   const outputTarget = processSurroundingPair(
-    languageDefinition,
-    context,
+    languageDefinitions,
     target,
     modifier.scopeType,
   );

--- a/packages/cursorless-engine/src/processTargets/modifiers/scopeTypeStages/BoundedNonWhitespaceStage.ts
+++ b/packages/cursorless-engine/src/processTargets/modifiers/scopeTypeStages/BoundedNonWhitespaceStage.ts
@@ -33,16 +33,11 @@ export default class BoundedNonWhitespaceSequenceStage
 
     const paintTargets = paintStage.run(context, target);
 
-    const pairInfo = processSurroundingPair(
-      this.languageDefinitions.get(target.editor.document.languageId),
-      context,
-      target,
-      {
-        type: "surroundingPair",
-        delimiter: "any",
-        requireStrongContainment: true,
-      },
-    );
+    const pairInfo = processSurroundingPair(this.languageDefinitions, target, {
+      type: "surroundingPair",
+      delimiter: "any",
+      requireStrongContainment: true,
+    });
 
     if (pairInfo == null) {
       return paintTargets;

--- a/packages/cursorless-engine/src/processTargets/modifiers/scopeTypeStages/ContainingSyntaxScopeStage.ts
+++ b/packages/cursorless-engine/src/processTargets/modifiers/scopeTypeStages/ContainingSyntaxScopeStage.ts
@@ -1,18 +1,19 @@
-import { NoContainingScopeError, Selection } from "@cursorless/common";
-import type { SyntaxNode } from "web-tree-sitter";
 import type {
   ContainingScopeModifier,
   EveryScopeModifier,
   SimpleScopeType,
 } from "@cursorless/common";
+import { NoContainingScopeError, Selection } from "@cursorless/common";
+import type { SyntaxNode } from "web-tree-sitter";
+import { LanguageDefinitions } from "../../../languages/LanguageDefinitions";
 import { getNodeMatcher } from "../../../languages/getNodeMatcher";
-import type { Target } from "../../../typings/target.types";
 import type {
   NodeMatcher,
   ProcessedTargetsContext,
   SelectionWithEditor,
   SelectionWithEditorWithContext,
 } from "../../../typings/Types";
+import type { Target } from "../../../typings/target.types";
 import { selectionWithEditorFromRange } from "../../../util/selectionUtils";
 import type { ModifierStage } from "../../PipelineStages.types";
 import { ScopeTypeTarget } from "../../targets";
@@ -27,6 +28,7 @@ export interface SimpleEveryScopeModifier extends EveryScopeModifier {
 
 export default class implements ModifierStage {
   constructor(
+    private languageDefinitions: LanguageDefinitions,
     private modifier: SimpleContainingScopeModifier | SimpleEveryScopeModifier,
   ) {}
 
@@ -37,7 +39,7 @@ export default class implements ModifierStage {
       this.modifier.type === "everyScope",
     );
 
-    const node: SyntaxNode | null = context.getNodeAtLocation(
+    const node: SyntaxNode | null = this.languageDefinitions.getNodeAtLocation(
       target.editor.document,
       target.contentRange,
     );

--- a/packages/cursorless-engine/src/processTargets/modifiers/surroundingPair/index.ts
+++ b/packages/cursorless-engine/src/processTargets/modifiers/surroundingPair/index.ts
@@ -4,18 +4,17 @@ import {
   SurroundingPairScopeType,
 } from "@cursorless/common";
 import type { SyntaxNode } from "web-tree-sitter";
-import { LanguageDefinition } from "../../../languages/LanguageDefinition";
+import { LanguageDefinitions } from "../../../languages/LanguageDefinitions";
 import getTextFragmentExtractor, {
   TextFragmentExtractor,
 } from "../../../languages/getTextFragmentExtractor";
-import { ProcessedTargetsContext } from "../../../typings/Types";
 import { Target } from "../../../typings/target.types";
+import { SurroundingPairTarget } from "../../targets";
 import { getContainingScopeTarget } from "../getContainingScopeTarget";
 import { complexDelimiterMap } from "./delimiterMaps";
 import { SurroundingPairInfo } from "./extractSelectionFromSurroundingPairOffsets";
 import { findSurroundingPairParseTreeBased } from "./findSurroundingPairParseTreeBased";
 import { findSurroundingPairTextBased } from "./findSurroundingPairTextBased";
-import { SurroundingPairTarget } from "../../targets";
 
 /**
  * Applies the surrounding pair modifier to the given selection. First looks to
@@ -32,14 +31,12 @@ import { SurroundingPairTarget } from "../../targets";
  * `null` if none was found
  */
 export function processSurroundingPair(
-  languageDefinition: LanguageDefinition | undefined,
-  context: ProcessedTargetsContext,
+  languageDefinitions: LanguageDefinitions,
   target: Target,
   scopeType: SurroundingPairScopeType,
 ): SurroundingPairTarget | null {
   const pairInfo = processSurroundingPairCore(
-    languageDefinition,
-    context,
+    languageDefinitions,
     target,
     scopeType,
   );
@@ -61,12 +58,14 @@ export function processSurroundingPair(
  * {@link SurroundingPairTarget}.
  */
 function processSurroundingPairCore(
-  languageDefinition: LanguageDefinition | undefined,
-  context: ProcessedTargetsContext,
+  languageDefinitions: LanguageDefinitions,
   target: Target,
   scopeType: SurroundingPairScopeType,
 ): SurroundingPairInfo | null {
   const { editor, contentRange: range } = target;
+  const languageDefinition = languageDefinitions.get(
+    target.editor.document.languageId,
+  );
 
   const document = editor.document;
   const delimiters = complexDelimiterMap[
@@ -98,7 +97,7 @@ function processSurroundingPairCore(
   }
 
   try {
-    node = context.getNodeAtLocation(document, range);
+    node = languageDefinitions.getNodeAtLocation(document, range);
 
     textFragmentExtractor = getTextFragmentExtractor(document.languageId);
   } catch (err) {

--- a/packages/cursorless-engine/src/typings/Types.ts
+++ b/packages/cursorless-engine/src/typings/Types.ts
@@ -1,14 +1,8 @@
-import type {
-  Range,
-  Selection,
-  TextDocument,
-  TextEditor,
-} from "@cursorless/common";
+import type { Range, Selection, TextEditor } from "@cursorless/common";
 import type { SyntaxNode } from "web-tree-sitter";
 
-export interface ProcessedTargetsContext {
-  getNodeAtLocation: (document: TextDocument, range: Range) => SyntaxNode;
-}
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface ProcessedTargetsContext {}
 
 export interface SelectionWithEditor {
   selection: Selection;


### PR DESCRIPTION
- Depends on https://github.com/cursorless-dev/cursorless/pull/1475

## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet
