### PR TITLE
Make it clearer that we're not waiting for inference warning

### DIFF
--- a/packages/cursorless-engine/src/core/commandVersionUpgrades/canonicalizeAndValidateCommand.ts
+++ b/packages/cursorless-engine/src/core/commandVersionUpgrades/canonicalizeAndValidateCommand.ts
@@ -119,7 +119,7 @@ function usesScopeType(
   );
 }
 
-export async function checkForOldInference(
+export function checkForOldInference(
   partialTargets: PartialTargetDescriptor[],
 ) {
   const hasOldInference = partialTargets.some((target) => {
@@ -136,16 +136,16 @@ export async function checkForOldInference(
     const hideInferenceWarning = globalState.get("hideInferenceWarning");
 
     if (!hideInferenceWarning) {
-      const pressed = await showWarning(
+      showWarning(
         messages,
         "deprecatedPositionInference",
         'The "past start of" / "past end of" form has changed behavior.  For the old behavior, update cursorless-talon (https://www.cursorless.org/docs/user/updating/), and then you can now say "past start of its" / "past end of its". For example, "take air past end of its line".  You may also consider using "head" / "tail" instead; see https://www.cursorless.org/docs/#head-and-tail',
         "Don't show again",
-      );
-
-      if (pressed) {
-        globalState.set("hideInferenceWarning", true);
-      }
+      ).then((pressed) => {
+        if (pressed) {
+          globalState.set("hideInferenceWarning", true);
+        }
+      });
     }
   }
 }


### PR DESCRIPTION
`checkForOldInference` was returning a promise, but we weren't awaiting it, which is a smell imo.  This PR makes it clear that we don't wait for the user to respond to the inference warning

## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet
