### PR TITLE
Clean up legacy types

### DIFF
--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -73,6 +73,7 @@ export * from "./types/command/legacy/CommandV4.types";
 export * from "./types/command/legacy/targetDescriptorV2.types";
 export * from "./types/command/CommandV5.types";
 export * from "./types/command/legacy/PartialTargetDescriptorV3.types";
+export * from "./types/command/legacy/PartialTargetDescriptorV4.types";
 export * from "./types/CommandServerApi";
 export * from "./util/itertools";
 export * from "./extensionDependencies";

--- a/packages/common/src/types/command/legacy/CommandV2.types.ts
+++ b/packages/common/src/types/command/legacy/CommandV2.types.ts
@@ -1,6 +1,6 @@
 import type { PartialTargetDescriptorV2 } from "./targetDescriptorV2.types";
 
-type ActionType =
+export type ActionTypeV2 =
   | "callAsFunction"
   | "clearAndSetSelection"
   | "copyToClipboard"
@@ -58,7 +58,7 @@ interface ActionCommand {
   /**
    * The action to run
    */
-  name: ActionType;
+  name: ActionTypeV2;
 
   /**
    * A list of arguments expected by the given action.

--- a/packages/common/src/types/command/legacy/PartialTargetDescriptorV4.types.ts
+++ b/packages/common/src/types/command/legacy/PartialTargetDescriptorV4.types.ts
@@ -253,7 +253,7 @@ interface PositionModifier {
   position: TargetPosition;
 }
 
-interface PartialPrimitiveTargetDescriptor {
+export interface PartialPrimitiveTargetDescriptorV4 {
   type: "primitive";
   mark?: Mark;
   modifiers?: Modifier[];
@@ -326,10 +326,10 @@ type Modifier =
 // vertical puts a selection on each line vertically between the two targets
 type RangeType = "continuous" | "vertical";
 
-interface PartialRangeTargetDescriptor {
+export interface PartialRangeTargetDescriptorV4 {
   type: "range";
-  anchor: PartialPrimitiveTargetDescriptor | ImplicitTargetDescriptor;
-  active: PartialPrimitiveTargetDescriptor;
+  anchor: PartialPrimitiveTargetDescriptorV4 | ImplicitTargetDescriptor;
+  active: PartialPrimitiveTargetDescriptorV4;
   excludeAnchor: boolean;
   excludeActive: boolean;
   rangeType?: RangeType;
@@ -337,7 +337,10 @@ interface PartialRangeTargetDescriptor {
 
 interface PartialListTargetDescriptor {
   type: "list";
-  elements: (PartialPrimitiveTargetDescriptor | PartialRangeTargetDescriptor)[];
+  elements: (
+    | PartialPrimitiveTargetDescriptorV4
+    | PartialRangeTargetDescriptorV4
+  )[];
 }
 
 interface ImplicitTargetDescriptor {
@@ -345,7 +348,7 @@ interface ImplicitTargetDescriptor {
 }
 
 export type PartialTargetDescriptorV4 =
-  | PartialPrimitiveTargetDescriptor
-  | PartialRangeTargetDescriptor
+  | PartialPrimitiveTargetDescriptorV4
+  | PartialRangeTargetDescriptorV4
   | PartialListTargetDescriptor
   | ImplicitTargetDescriptor;

--- a/packages/cursorless-engine/src/core/commandVersionUpgrades/upgradeV1ToV2/upgradeV1ToV2.ts
+++ b/packages/cursorless-engine/src/core/commandVersionUpgrades/upgradeV1ToV2/upgradeV1ToV2.ts
@@ -1,4 +1,4 @@
-import { ActionType } from "@cursorless/common";
+import { ActionType, ActionTypeV2 } from "@cursorless/common";
 import { CommandV2 } from "@cursorless/common";
 import {
   ModifierV2,
@@ -16,7 +16,7 @@ import {
 import { upgradeStrictHere } from "./upgradeStrictHere";
 
 export function upgradeV1ToV2(command: CommandV1): CommandV2 {
-  const actionName = command.action as ActionType;
+  const actionName = command.action as ActionTypeV2;
   return {
     spokenForm: command.spokenForm,
     action: {

--- a/packages/cursorless-engine/src/core/commandVersionUpgrades/upgradeV3ToV4/upgradeV3ToV4.ts
+++ b/packages/cursorless-engine/src/core/commandVersionUpgrades/upgradeV3ToV4/upgradeV3ToV4.ts
@@ -2,11 +2,11 @@ import {
   CommandV3,
   CommandV4,
   ImplicitTargetDescriptor,
-  PartialPrimitiveTargetDescriptor,
   PartialPrimitiveTargetDescriptorV3,
-  PartialRangeTargetDescriptor,
-  PartialTargetDescriptor,
+  PartialPrimitiveTargetDescriptorV4,
+  PartialRangeTargetDescriptorV4,
   PartialTargetDescriptorV3,
+  PartialTargetDescriptorV4,
 } from "@cursorless/common";
 
 export function upgradeV3ToV4(command: CommandV3): CommandV4 {
@@ -19,7 +19,7 @@ export function upgradeV3ToV4(command: CommandV3): CommandV4 {
 
 function upgradeTarget(
   target: PartialTargetDescriptorV3,
-): PartialTargetDescriptor {
+): PartialTargetDescriptorV4 {
   switch (target.type) {
     case "primitive":
       return upgradePrimitiveTarget(target);
@@ -36,8 +36,8 @@ function upgradeTarget(
       return {
         ...rest,
         elements: elements.map(upgradeTarget) as (
-          | PartialPrimitiveTargetDescriptor
-          | PartialRangeTargetDescriptor
+          | PartialPrimitiveTargetDescriptorV4
+          | PartialRangeTargetDescriptorV4
         )[],
       };
     }
@@ -46,7 +46,7 @@ function upgradeTarget(
 
 function upgradePrimitiveTarget(
   target: PartialPrimitiveTargetDescriptorV3,
-): PartialPrimitiveTargetDescriptor | ImplicitTargetDescriptor {
+): PartialPrimitiveTargetDescriptorV4 | ImplicitTargetDescriptor {
   if ((target.mark == null && target.modifiers == null) || target.isImplicit) {
     return { type: "implicit" };
   }

--- a/packages/cursorless-vscode-e2e/src/suite/testCaseRecorder.test.ts
+++ b/packages/cursorless-vscode-e2e/src/suite/testCaseRecorder.test.ts
@@ -70,7 +70,7 @@ async function testCaseRecorderGracefulError() {
 
     try {
       await runCursorlessCommand({
-        version: 4,
+        version: 5,
         action: { name: "badActionName" as ActionType },
         targets: [
           {


### PR DESCRIPTION
## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet
