### PR TITLE
Support `"from"` action to set instance reference target

### DIFF
--- a/cursorless-talon/src/actions/actions.py
+++ b/cursorless-talon/src/actions/actions.py
@@ -13,9 +13,13 @@ from .actions_simple import (
 mod = Module()
 
 
+mod.list("cursorless_experimental_action", "Experimental actions")
+
+
 @mod.capture(
     rule=(
         "{user.cursorless_simple_action} |"
+        "{user.cursorless_experimental_action} |"
         "{user.cursorless_callback_action} |"
         "{user.cursorless_custom_action}"
     )
@@ -90,11 +94,19 @@ default_values = {
 }
 
 
-ACTION_LIST_NAMES = default_values.keys()
+ACTION_LIST_NAMES = list(default_values.keys()) + ["experimental_action"]
 
 
 def on_ready() -> None:
     init_csv_and_watch_changes("actions", default_values)
+    init_csv_and_watch_changes(
+        "experimental/experimental_actions",
+        {
+            "experimental_action": {
+                "-from": "experimental.setInstanceReference",
+            }
+        },
+    )
 
 
 app.register("ready", on_ready)

--- a/cursorless-talon/src/actions/actions_simple.py
+++ b/cursorless-talon/src/actions/actions_simple.py
@@ -22,7 +22,6 @@ simple_action_defaults = {
     "float": "insertEmptyLineAfter",
     "fold": "foldRegion",
     "follow": "followLink",
-    "-from": "experimentalSetInstanceReference",
     "give": "deselect",
     "highlight": "highlight",
     "hover": "showHover",

--- a/cursorless-talon/src/actions/actions_simple.py
+++ b/cursorless-talon/src/actions/actions_simple.py
@@ -22,6 +22,7 @@ simple_action_defaults = {
     "float": "insertEmptyLineAfter",
     "fold": "foldRegion",
     "follow": "followLink",
+    "from": "setInstanceReference",
     "give": "deselect",
     "highlight": "highlight",
     "hover": "showHover",

--- a/cursorless-talon/src/actions/actions_simple.py
+++ b/cursorless-talon/src/actions/actions_simple.py
@@ -22,7 +22,7 @@ simple_action_defaults = {
     "float": "insertEmptyLineAfter",
     "fold": "foldRegion",
     "follow": "followLink",
-    "from": "setInstanceReference",
+    "-from": "experimentalSetInstanceReference",
     "give": "deselect",
     "highlight": "highlight",
     "hover": "showHover",

--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -338,7 +338,7 @@ We have experimental support for prefixing a command with `"from <target>"` to n
 - `"from funk take every instance air"`: selects all instances of the token with a hat over the letter `a` in the current function
 - `"from air take next instance bat"`: selects the next instance of the token with a hat over the letter `b` starting from the token with a hat over the letter `a`
 
-Note that the `"from"` modifier is not enabled by default; you must remove the `-` at the start of the line starting with `-from` in your actions [settings csv](./customization.md). Note also that this feature is considered experimental and may change in the future.
+Note that the `"from"` modifier is not enabled by default; you must remove the `-` at the start of the line starting with `-from` in your `experimental/experimental_actions.csv` [settings csv](./customization.md). Note also that this feature is considered experimental and may change in the future.
 
 ##### Surrounding pair
 

--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -331,6 +331,15 @@ If your cursor is touching a token, you can say `"take every instance"` to selec
 
 Pro tip: if you say eg `"take five instances air"`, and it turns out you need more, you can say eg `"take that and next two instances that"` to select the next two instances after the last instance you selected.
 
+###### Experimental: `"from"`
+
+We have experimental support for prefixing a command with `"from <target>"` to narrow the range within which `"every instance"` searches, or to set the start point from which `"next instance"` searches. For example:
+
+- `"from funk take every instance air"`: selects all instances of the token with a hat over the letter `a` in the current function
+- `"from air take next instance bat"`: selects the next instance of the token with a hat over the letter `b` starting from the token with a hat over the letter `a`
+
+Note that the `"from"` modifier is not enabled by default; you must remove the `-` at the start of the line starting with `-from` in your actions [settings csv](./customization.md). Note also that this feature is considered experimental and may change in the future.
+
 ##### Surrounding pair
 
 Cursorless has support for expanding the selection to the nearest containing paired delimiter, eg the surrounding parentheses, curly brackets, etc.

--- a/packages/common/src/testUtil/TestCaseSnapshot.ts
+++ b/packages/common/src/testUtil/TestCaseSnapshot.ts
@@ -15,6 +15,7 @@ export type TestCaseSnapshot = {
   marks?: SerializedMarks;
   thatMark?: TargetPlainObject[];
   sourceMark?: TargetPlainObject[];
+  instanceReferenceMark?: TargetPlainObject[];
   timeOffsetSeconds?: number;
 
   /**

--- a/packages/common/src/types/command/ActionCommand.ts
+++ b/packages/common/src/types/command/ActionCommand.ts
@@ -34,6 +34,7 @@ export const actionNames = [
   "revealTypeDefinition",
   "reverseTargets",
   "rewrapWithPairedDelimiter",
+  "setInstanceReference",
   "scrollToBottom",
   "scrollToCenter",
   "scrollToTop",

--- a/packages/common/src/types/command/ActionCommand.ts
+++ b/packages/common/src/types/command/ActionCommand.ts
@@ -34,7 +34,7 @@ export const actionNames = [
   "revealTypeDefinition",
   "reverseTargets",
   "rewrapWithPairedDelimiter",
-  "experimentalSetInstanceReference",
+  "experimental.setInstanceReference",
   "scrollToBottom",
   "scrollToCenter",
   "scrollToTop",

--- a/packages/common/src/types/command/ActionCommand.ts
+++ b/packages/common/src/types/command/ActionCommand.ts
@@ -34,7 +34,7 @@ export const actionNames = [
   "revealTypeDefinition",
   "reverseTargets",
   "rewrapWithPairedDelimiter",
-  "setInstanceReference",
+  "experimentalSetInstanceReference",
   "scrollToBottom",
   "scrollToCenter",
   "scrollToTop",

--- a/packages/cursorless-engine/src/actions/Actions.ts
+++ b/packages/cursorless-engine/src/actions/Actions.ts
@@ -126,7 +126,7 @@ export class Actions implements ActionRecord {
   scrollToBottom = new ScrollToBottom();
   scrollToCenter = new ScrollToCenter();
   scrollToTop = new ScrollToTop();
-  experimentalSetInstanceReference = new SetInstanceReference();
+  ["experimental.setInstanceReference"] = new SetInstanceReference();
   setSelection = new SetSelection();
   setSelectionAfter = new SetSelectionAfter();
   setSelectionBefore = new SetSelectionBefore();

--- a/packages/cursorless-engine/src/actions/Actions.ts
+++ b/packages/cursorless-engine/src/actions/Actions.ts
@@ -126,7 +126,7 @@ export class Actions implements ActionRecord {
   scrollToBottom = new ScrollToBottom();
   scrollToCenter = new ScrollToCenter();
   scrollToTop = new ScrollToTop();
-  setInstanceReference = new SetInstanceReference();
+  experimentalSetInstanceReference = new SetInstanceReference();
   setSelection = new SetSelection();
   setSelectionAfter = new SetSelectionAfter();
   setSelectionBefore = new SetSelectionBefore();

--- a/packages/cursorless-engine/src/actions/Actions.ts
+++ b/packages/cursorless-engine/src/actions/Actions.ts
@@ -28,6 +28,7 @@ import Remove from "./Remove";
 import Replace from "./Replace";
 import Rewrap from "./Rewrap";
 import { ScrollToBottom, ScrollToCenter, ScrollToTop } from "./Scroll";
+import { SetInstanceReference } from "./SetInstanceReference";
 import {
   SetSelection,
   SetSelectionAfter,
@@ -125,6 +126,7 @@ export class Actions implements ActionRecord {
   scrollToBottom = new ScrollToBottom();
   scrollToCenter = new ScrollToCenter();
   scrollToTop = new ScrollToTop();
+  setInstanceReference = new SetInstanceReference();
   setSelection = new SetSelection();
   setSelectionAfter = new SetSelectionAfter();
   setSelectionBefore = new SetSelectionBefore();

--- a/packages/cursorless-engine/src/actions/SetInstanceReference.ts
+++ b/packages/cursorless-engine/src/actions/SetInstanceReference.ts
@@ -1,0 +1,15 @@
+import { Target } from "../typings/target.types";
+import { Action, ActionReturnValue } from "./actions.types";
+
+export class SetInstanceReference implements Action {
+  constructor() {
+    this.run = this.run.bind(this);
+  }
+
+  async run([targets]: [Target[]]): Promise<ActionReturnValue> {
+    return {
+      thatTargets: targets,
+      instanceReferenceTargets: targets,
+    };
+  }
+}

--- a/packages/cursorless-engine/src/actions/actions.types.ts
+++ b/packages/cursorless-engine/src/actions/actions.types.ts
@@ -38,6 +38,12 @@ export interface ActionReturnValue {
    * Mutually exclusive with {@link sourceSelections}
    */
   sourceTargets?: Target[];
+
+  /**
+   * A list of targets that will be used by the "instance" modifier in the next command
+   * to determine either the range for "every", or the start point for "next"
+   */
+  instanceReferenceTargets?: Target[];
 }
 
 export interface Action {

--- a/packages/cursorless-engine/src/core/StoredTargets.ts
+++ b/packages/cursorless-engine/src/core/StoredTargets.ts
@@ -1,6 +1,6 @@
 import { Target } from "../typings/target.types";
 
-export type StoredTargetKey = "that" | "source";
+export type StoredTargetKey = "that" | "source" | "instanceReference";
 
 /**
  * Used to store targets between commands.  This is used by marks like `that`

--- a/packages/cursorless-engine/src/core/commandRunner/CommandRunnerImpl.ts
+++ b/packages/cursorless-engine/src/core/commandRunner/CommandRunnerImpl.ts
@@ -63,6 +63,7 @@ export class CommandRunnerImpl implements CommandRunner {
       thatTargets: newThatTargets,
       sourceSelections: newSourceSelections,
       sourceTargets: newSourceTargets,
+      instanceReferenceTargets: newInstanceReferenceTargets,
     } = await action.run(targets, ...actionArgs);
 
     this.storedTargets.set(
@@ -73,6 +74,7 @@ export class CommandRunnerImpl implements CommandRunner {
       "source",
       constructStoredTarget(newSourceTargets, newSourceSelections),
     );
+    this.storedTargets.set("instanceReference", newInstanceReferenceTargets);
 
     return returnValue;
   }

--- a/packages/cursorless-engine/src/processTargets/ModifierStageFactoryImpl.ts
+++ b/packages/cursorless-engine/src/processTargets/ModifierStageFactoryImpl.ts
@@ -42,10 +42,12 @@ import {
   NonWhitespaceSequenceStage,
   UrlStage,
 } from "./modifiers/scopeTypeStages/RegexStage";
+import { StoredTargetMap } from "..";
 
 export class ModifierStageFactoryImpl implements ModifierStageFactory {
   constructor(
     private languageDefinitions: LanguageDefinitions,
+    private storedTargets: StoredTargetMap,
     private scopeHandlerFactory: ScopeHandlerFactory,
   ) {
     this.create = this.create.bind(this);
@@ -77,19 +79,19 @@ export class ModifierStageFactoryImpl implements ModifierStageFactory {
         );
       case "everyScope":
         if (modifier.scopeType.type === "instance") {
-          return new InstanceStage(this, modifier);
+          return new InstanceStage(this, this.storedTargets, modifier);
         }
 
         return new EveryScopeStage(this, this.scopeHandlerFactory, modifier);
       case "ordinalScope":
         if (modifier.scopeType.type === "instance") {
-          return new InstanceStage(this, modifier);
+          return new InstanceStage(this, this.storedTargets, modifier);
         }
 
         return new OrdinalScopeStage(this, modifier);
       case "relativeScope":
         if (modifier.scopeType.type === "instance") {
-          return new InstanceStage(this, modifier);
+          return new InstanceStage(this, this.storedTargets, modifier);
         }
 
         return new RelativeScopeStage(this, this.scopeHandlerFactory, modifier);

--- a/packages/cursorless-engine/src/runCommand.ts
+++ b/packages/cursorless-engine/src/runCommand.ts
@@ -75,6 +75,7 @@ function createCommandRunner(
 ): CommandRunner {
   const modifierStageFactory = new ModifierStageFactoryImpl(
     languageDefinitions,
+    storedTargets,
     new ScopeHandlerFactoryImpl(languageDefinitions),
   );
 

--- a/packages/cursorless-engine/src/testCaseRecorder/TestCase.ts
+++ b/packages/cursorless-engine/src/testCaseRecorder/TestCase.ts
@@ -103,7 +103,7 @@ export class TestCase {
       "scrollToTop",
     ];
 
-    const excludableFields = {
+    const excludedFields = {
       clipboard: !clipboardActions.includes(this.command.action.name),
       thatMark:
         (!isInitialSnapshot && !this.captureFinalThatMark) ||
@@ -120,9 +120,7 @@ export class TestCase {
       visibleRanges: !visibleRangeActions.includes(this.command.action.name),
     };
 
-    return Object.keys(excludableFields).filter(
-      (field) => excludableFields[field],
-    );
+    return Object.keys(excludedFields).filter((field) => excludedFields[field]);
   }
 
   toYaml() {

--- a/packages/cursorless-engine/src/testUtil/plainObjectToTarget.ts
+++ b/packages/cursorless-engine/src/testUtil/plainObjectToTarget.ts
@@ -3,7 +3,7 @@ import {
   TargetPlainObject,
   TextEditor,
 } from "@cursorless/common";
-import { UntypedTarget } from "../processTargets/targets";
+import { LineTarget, UntypedTarget } from "../processTargets/targets";
 import { Target } from "../typings/target.types";
 
 /**
@@ -30,6 +30,12 @@ export function plainObjectToTarget(
         isReversed: plainObject.isReversed,
         contentRange: plainObjectToRange(plainObject.contentRange),
         hasExplicitRange: plainObject.hasExplicitRange,
+      });
+    case "LineTarget":
+      return new LineTarget({
+        editor,
+        isReversed: plainObject.isReversed,
+        contentRange: plainObjectToRange(plainObject.contentRange),
       });
     default:
       throw Error(`Unsupported target type ${plainObject.type}`);

--- a/packages/cursorless-engine/src/testUtil/takeSnapshot.ts
+++ b/packages/cursorless-engine/src/testUtil/takeSnapshot.ts
@@ -56,6 +56,15 @@ export async function takeSnapshot(
     snapshot.sourceMark = sourceMarkTargets.map(targetToPlainObject);
   }
 
+  const instanceReferenceMarkTargets = storedTargets?.get("instanceReference");
+  if (
+    instanceReferenceMarkTargets != null &&
+    !excludeFields.includes("instanceReferenceMark")
+  ) {
+    snapshot.instanceReferenceMark =
+      instanceReferenceMarkTargets.map(targetToPlainObject);
+  }
+
   if (extraFields.includes("timeOffsetSeconds")) {
     const startTimestamp = extraContext?.startTimestamp;
 

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/modifiers/instance/clearEveryInstanceAir2.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/modifiers/instance/clearEveryInstanceAir2.yml
@@ -1,0 +1,39 @@
+languageId: plaintext
+command:
+  version: 5
+  spokenForm: clear every instance air
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: everyScope
+          scopeType: {type: instance}
+      mark: {type: decoratedSymbol, symbolColor: default, character: a}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    aaa bbb ccc aaa bbb
+    aaa ddd eee aaa fff
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  marks:
+    default.a:
+      start: {line: 0, character: 0}
+      end: {line: 0, character: 3}
+  instanceReferenceMark:
+    - type: LineTarget
+      contentRange:
+        start: {line: 0, character: 0}
+        end: {line: 0, character: 19}
+      isReversed: false
+      hasExplicitRange: true
+finalState:
+  documentContents: |2-
+     bbb ccc  bbb
+    aaa ddd eee aaa fff
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+    - anchor: {line: 0, character: 9}
+      active: {line: 0, character: 9}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/modifiers/instance/clearEveryInstanceAir3.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/modifiers/instance/clearEveryInstanceAir3.yml
@@ -1,0 +1,53 @@
+languageId: plaintext
+command:
+  version: 5
+  spokenForm: clear every instance air
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: everyScope
+          scopeType: {type: instance}
+      mark: {type: decoratedSymbol, symbolColor: default, character: a}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |
+    hhh bbb aaa ccc aaa
+    eee bbb aaa ccc aaa
+    fff bbb aaa ccc aaa
+    ggg bbb aaa ccc aaa
+  selections:
+    - anchor: {line: 4, character: 0}
+      active: {line: 4, character: 0}
+  marks:
+    default.a:
+      start: {line: 3, character: 8}
+      end: {line: 3, character: 11}
+  instanceReferenceMark:
+    - type: LineTarget
+      contentRange:
+        start: {line: 0, character: 0}
+        end: {line: 0, character: 19}
+      isReversed: false
+      hasExplicitRange: true
+    - type: LineTarget
+      contentRange:
+        start: {line: 2, character: 0}
+        end: {line: 2, character: 19}
+      isReversed: false
+      hasExplicitRange: true
+finalState:
+  documentContents: |
+    hhh bbb  ccc 
+    eee bbb aaa ccc aaa
+    fff bbb  ccc 
+    ggg bbb aaa ccc aaa
+  selections:
+    - anchor: {line: 0, character: 8}
+      active: {line: 0, character: 8}
+    - anchor: {line: 0, character: 13}
+      active: {line: 0, character: 13}
+    - anchor: {line: 2, character: 8}
+      active: {line: 2, character: 8}
+    - anchor: {line: 2, character: 13}
+      active: {line: 2, character: 13}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/modifiers/instance/clearFirstTwoInstancesAir2.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/modifiers/instance/clearFirstTwoInstancesAir2.yml
@@ -1,0 +1,55 @@
+languageId: plaintext
+command:
+  version: 5
+  spokenForm: clear first two instances air
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: ordinalScope
+          scopeType: {type: instance}
+          start: 0
+          length: 2
+      mark: {type: decoratedSymbol, symbolColor: default, character: a}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |
+    bbb aaa ccc aaa ddd aaa
+    eee aaa ccc aaa ddd aaa
+    fff aaa ccc aaa ddd aaa
+    ggg aaa ccc aaa ddd aaa
+  selections:
+    - anchor: {line: 4, character: 0}
+      active: {line: 4, character: 0}
+  marks:
+    default.a:
+      start: {line: 3, character: 4}
+      end: {line: 3, character: 7}
+  instanceReferenceMark:
+    - type: LineTarget
+      contentRange:
+        start: {line: 0, character: 0}
+        end: {line: 0, character: 23}
+      isReversed: false
+      hasExplicitRange: true
+    - type: LineTarget
+      contentRange:
+        start: {line: 2, character: 0}
+        end: {line: 2, character: 23}
+      isReversed: false
+      hasExplicitRange: true
+finalState:
+  documentContents: |
+    bbb  ccc  ddd aaa
+    eee aaa ccc aaa ddd aaa
+    fff  ccc  ddd aaa
+    ggg aaa ccc aaa ddd aaa
+  selections:
+    - anchor: {line: 0, character: 4}
+      active: {line: 0, character: 4}
+    - anchor: {line: 0, character: 9}
+      active: {line: 0, character: 9}
+    - anchor: {line: 2, character: 4}
+      active: {line: 2, character: 4}
+    - anchor: {line: 2, character: 9}
+      active: {line: 2, character: 9}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/modifiers/instance/clearNextInstanceAir2.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/modifiers/instance/clearNextInstanceAir2.yml
@@ -1,0 +1,38 @@
+languageId: plaintext
+command:
+  version: 5
+  spokenForm: clear next instance air
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: relativeScope
+          scopeType: {type: instance}
+          offset: 1
+          length: 1
+          direction: forward
+      mark: {type: decoratedSymbol, symbolColor: default, character: a}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |
+    aaa bbb ccc aaa ddd aaa
+  selections:
+    - anchor: {line: 1, character: 0}
+      active: {line: 1, character: 0}
+  marks:
+    default.a:
+      start: {line: 0, character: 0}
+      end: {line: 0, character: 3}
+  instanceReferenceMark:
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 16}
+        end: {line: 0, character: 19}
+      isReversed: false
+      hasExplicitRange: false
+finalState:
+  documentContents: |
+    aaa bbb ccc aaa ddd 
+  selections:
+    - anchor: {line: 0, character: 20}
+      active: {line: 0, character: 20}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/modifiers/instance/clearNextInstanceAir3.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/modifiers/instance/clearNextInstanceAir3.yml
@@ -1,0 +1,46 @@
+languageId: plaintext
+command:
+  version: 5
+  spokenForm: clear next instance air
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: relativeScope
+          scopeType: {type: instance}
+          offset: 1
+          length: 1
+          direction: forward
+      mark: {type: decoratedSymbol, symbolColor: default, character: a}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |
+    aaa bbb aaa ccc aaa ddd aaa
+  selections:
+    - anchor: {line: 1, character: 0}
+      active: {line: 1, character: 0}
+  marks:
+    default.a:
+      start: {line: 0, character: 0}
+      end: {line: 0, character: 3}
+  instanceReferenceMark:
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 12}
+        end: {line: 0, character: 15}
+      isReversed: false
+      hasExplicitRange: false
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 20}
+        end: {line: 0, character: 23}
+      isReversed: false
+      hasExplicitRange: false
+finalState:
+  documentContents: |
+    aaa bbb aaa ccc  ddd 
+  selections:
+    - anchor: {line: 0, character: 16}
+      active: {line: 0, character: 16}
+    - anchor: {line: 0, character: 21}
+      active: {line: 0, character: 21}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/modifiers/instance/fromDrum.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/modifiers/instance/fromDrum.yml
@@ -2,7 +2,7 @@ languageId: plaintext
 command:
   version: 5
   spokenForm: from drum
-  action: {name: setInstanceReference}
+  action: {name: experimentalSetInstanceReference}
   targets:
     - type: primitive
       mark: {type: decoratedSymbol, symbolColor: default, character: d}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/modifiers/instance/fromDrum.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/modifiers/instance/fromDrum.yml
@@ -2,7 +2,7 @@ languageId: plaintext
 command:
   version: 5
   spokenForm: from drum
-  action: {name: experimentalSetInstanceReference}
+  action: {name: experimental.setInstanceReference}
   targets:
     - type: primitive
       mark: {type: decoratedSymbol, symbolColor: default, character: d}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/modifiers/instance/fromDrum.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/modifiers/instance/fromDrum.yml
@@ -1,0 +1,32 @@
+languageId: plaintext
+command:
+  version: 5
+  spokenForm: from drum
+  action: {name: setInstanceReference}
+  targets:
+    - type: primitive
+      mark: {type: decoratedSymbol, symbolColor: default, character: d}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |
+    aaa bbb ccc aaa ddd aaa
+  selections:
+    - anchor: {line: 1, character: 0}
+      active: {line: 1, character: 0}
+  marks:
+    default.d:
+      start: {line: 0, character: 16}
+      end: {line: 0, character: 19}
+finalState:
+  documentContents: |
+    aaa bbb ccc aaa ddd aaa
+  selections:
+    - anchor: {line: 1, character: 0}
+      active: {line: 1, character: 0}
+  instanceReferenceMark:
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 16}
+        end: {line: 0, character: 19}
+      isReversed: false
+      hasExplicitRange: false

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/modifiers/instance/fromLine.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/modifiers/instance/fromLine.yml
@@ -2,7 +2,7 @@ languageId: plaintext
 command:
   version: 5
   spokenForm: from line
-  action: {name: experimentalSetInstanceReference}
+  action: {name: experimental.setInstanceReference}
   targets:
     - type: primitive
       modifiers:

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/modifiers/instance/fromLine.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/modifiers/instance/fromLine.yml
@@ -2,7 +2,7 @@ languageId: plaintext
 command:
   version: 5
   spokenForm: from line
-  action: {name: setInstanceReference}
+  action: {name: experimentalSetInstanceReference}
   targets:
     - type: primitive
       modifiers:

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/modifiers/instance/fromLine.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/modifiers/instance/fromLine.yml
@@ -1,0 +1,33 @@
+languageId: plaintext
+command:
+  version: 5
+  spokenForm: from line
+  action: {name: setInstanceReference}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: line}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    aaa bbb ccc aaa bbb
+    aaa ddd eee aaa fff
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  marks: {}
+finalState:
+  documentContents: |-
+    aaa bbb ccc aaa bbb
+    aaa ddd eee aaa fff
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  instanceReferenceMark:
+    - type: LineTarget
+      contentRange:
+        start: {line: 0, character: 0}
+        end: {line: 0, character: 19}
+      isReversed: false
+      hasExplicitRange: true

--- a/packages/cursorless-vscode-e2e/src/suite/recorded.test.ts
+++ b/packages/cursorless-vscode-e2e/src/suite/recorded.test.ts
@@ -97,6 +97,14 @@ async function runTest(file: string, spyIde: SpyIDE) {
     setStoredTarget(editor, "source", fixture.initialState.sourceMark);
   }
 
+  if (fixture.initialState.instanceReferenceMark) {
+    setStoredTarget(
+      editor,
+      "instanceReference",
+      fixture.initialState.instanceReferenceMark,
+    );
+  }
+
   if (fixture.initialState.clipboard) {
     vscode.env.clipboard.writeText(fixture.initialState.clipboard);
     // FIXME https://github.com/cursorless-dev/cursorless/issues/559
@@ -166,6 +174,10 @@ async function runTest(file: string, spyIde: SpyIDE) {
 
   if (fixture.finalState?.sourceMark == null) {
     excludeFields.push("sourceMark");
+  }
+
+  if (fixture.finalState?.instanceReferenceMark == null) {
+    excludeFields.push("instanceReferenceMark");
   }
 
   // TODO Visible ranges are not asserted, see:


### PR DESCRIPTION
## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet
