### PR TITLE
Add mutable query capture interface

### DIFF
--- a/packages/cursorless-engine/src/languages/TreeSitterQuery/PredicateOperatorSchemaTypes.ts
+++ b/packages/cursorless-engine/src/languages/TreeSitterQuery/PredicateOperatorSchemaTypes.ts
@@ -1,9 +1,9 @@
-import { SyntaxNode } from "web-tree-sitter";
 import z from "zod";
 import {
   SchemaInputType,
   SchemaOutputType,
 } from "./operatorArgumentSchemaTypes";
+import { MutableQueryCapture } from "./QueryCapture";
 
 /**
  * A schema used to validate a list of operands for a given predicate operator.
@@ -38,7 +38,7 @@ export type InferSchemaType<T extends HasSchema> = T["schema"];
 type PredicateParameterType<T extends SchemaOutputType> = T extends {
   type: "capture";
 }
-  ? SyntaxNode
+  ? MutableQueryCapture
   : T extends { value: infer V }
   ? V
   : never;

--- a/packages/cursorless-engine/src/languages/TreeSitterQuery/QueryCapture.ts
+++ b/packages/cursorless-engine/src/languages/TreeSitterQuery/QueryCapture.ts
@@ -1,0 +1,57 @@
+import { Range } from "@cursorless/common";
+import { SyntaxNode } from "web-tree-sitter";
+
+/**
+ * A capture of a query pattern against a syntax tree.  Often corresponds to a
+ * node within the syntax tree, but can also be a range within a node or be modified
+ * by query predicate operators.
+ */
+export interface QueryCapture {
+  /**
+   * The name of the capture.  Eg for a capture labeled `@foo`, the name is
+   * `foo`.
+   */
+  readonly name: string;
+
+  /** The range of the capture. */
+  readonly range: Range;
+}
+
+/**
+ * A match of a query pattern against a syntax tree.
+ */
+export interface QueryMatch {
+  /**
+   * The captures of the pattern that was matched.
+   */
+  readonly captures: QueryCapture[];
+}
+
+/**
+ * A capture of a query pattern against a syntax tree. This type is used
+ * internally by the query engine to allow operators to modify the capture.
+ */
+export interface MutableQueryCapture extends QueryCapture {
+  /**
+   * The tree-sitter node that was captured. Note that the range may have already
+   * been altered by a prior operator, so please use {@link range} instead of
+   * trying to retrieve the range from the node.
+   */
+  readonly node: SyntaxNode;
+
+  range: Range;
+}
+
+/**
+ * A match of a query pattern against a syntax tree that can be mutated. This
+ * type is used internally by the query engine to allow operators to modify the
+ * match.
+ */
+export interface MutableQueryMatch extends QueryMatch {
+  /**
+   * The index of the pattern that was matched.
+   */
+  readonly patternIdx: number;
+
+  readonly captures: MutableQueryCapture[];
+}

--- a/packages/cursorless-engine/src/languages/TreeSitterQuery/parsePredicates.ts
+++ b/packages/cursorless-engine/src/languages/TreeSitterQuery/parsePredicates.ts
@@ -1,4 +1,5 @@
-import { PredicateResult, QueryMatch } from "web-tree-sitter";
+import { PredicateResult } from "web-tree-sitter";
+import { MutableQueryMatch } from "./QueryCapture";
 import { queryPredicateOperators } from "./queryPredicateOperators";
 
 /**
@@ -15,11 +16,11 @@ import { queryPredicateOperators } from "./queryPredicateOperators";
  */
 export function parsePredicates(predicateDescriptors: PredicateResult[][]) {
   const errors: PredicateError[] = [];
-  const predicates: ((match: QueryMatch) => boolean)[][] = [];
+  const predicates: ((match: MutableQueryMatch) => boolean)[][] = [];
 
   predicateDescriptors.forEach((patternPredicateDescriptors, patternIdx) => {
     /** The predicates for a given pattern */
-    const patternPredicates: ((match: QueryMatch) => boolean)[] = [];
+    const patternPredicates: ((match: MutableQueryMatch) => boolean)[] = [];
 
     patternPredicateDescriptors.forEach((predicateDescriptor, predicateIdx) => {
       const operator = queryPredicateOperators.find(

--- a/packages/cursorless-engine/src/languages/TreeSitterQuery/queryPredicateOperators.ts
+++ b/packages/cursorless-engine/src/languages/TreeSitterQuery/queryPredicateOperators.ts
@@ -1,8 +1,8 @@
-import { SyntaxNode } from "web-tree-sitter";
 import z from "zod";
+import { HasSchema } from "./PredicateOperatorSchemaTypes";
+import { MutableQueryCapture } from "./QueryCapture";
 import { QueryPredicateOperator } from "./QueryPredicateOperator";
 import { q } from "./operatorArgumentSchemaTypes";
-import { HasSchema } from "./PredicateOperatorSchemaTypes";
 
 /**
  * A predicate operator that returns true if the node is not of the given type.
@@ -13,7 +13,7 @@ import { HasSchema } from "./PredicateOperatorSchemaTypes";
 class NotType extends QueryPredicateOperator<NotType> {
   name = "not-type?" as const;
   schema = z.tuple([q.node, q.string]).rest(q.string);
-  accept(node: SyntaxNode, ...types: string[]) {
+  run({ node }: MutableQueryCapture, ...types: string[]) {
     return !types.includes(node.type);
   }
 }
@@ -27,7 +27,7 @@ class NotType extends QueryPredicateOperator<NotType> {
 class NotParentType extends QueryPredicateOperator<NotParentType> {
   name = "not-parent-type?" as const;
   schema = z.tuple([q.node, q.string]).rest(q.string);
-  accept(node: SyntaxNode, ...types: string[]) {
+  run({ node }: MutableQueryCapture, ...types: string[]) {
     return node.parent == null || !types.includes(node.parent.type);
   }
 }
@@ -40,7 +40,7 @@ class NotParentType extends QueryPredicateOperator<NotParentType> {
 class IsNthChild extends QueryPredicateOperator<IsNthChild> {
   name = "is-nth-child?" as const;
   schema = z.tuple([q.node, q.integer]);
-  accept(node: SyntaxNode, n: number) {
+  run({ node }: MutableQueryCapture, n: number) {
     return node.parent?.children.indexOf(node) === n;
   }
 }

--- a/packages/cursorless-engine/src/processTargets/modifiers/scopeHandlers/TreeSitterScopeHandler/BaseTreeSitterScopeHandler.ts
+++ b/packages/cursorless-engine/src/processTargets/modifiers/scopeHandlers/TreeSitterScopeHandler/BaseTreeSitterScopeHandler.ts
@@ -4,8 +4,8 @@ import {
   TextDocument,
   TextEditor,
 } from "@cursorless/common";
-import { QueryMatch } from "web-tree-sitter";
 import { TreeSitterQuery } from "../../../../languages/TreeSitterQuery";
+import { QueryMatch } from "../../../../languages/TreeSitterQuery/QueryCapture";
 import BaseScopeHandler from "../BaseScopeHandler";
 import { compareTargetScopes } from "../compareTargetScopes";
 import { TargetScope } from "../scope.types";

--- a/packages/cursorless-engine/src/processTargets/modifiers/scopeHandlers/TreeSitterScopeHandler/TreeSitterIterationScopeHandler.ts
+++ b/packages/cursorless-engine/src/processTargets/modifiers/scopeHandlers/TreeSitterScopeHandler/TreeSitterIterationScopeHandler.ts
@@ -1,10 +1,10 @@
 import { ScopeType, SimpleScopeType, TextEditor } from "@cursorless/common";
-import { QueryMatch } from "web-tree-sitter";
 import { TreeSitterQuery } from "../../../../languages/TreeSitterQuery";
 import { PlainTarget } from "../../../targets";
 import { TargetScope } from "../scope.types";
 import { BaseTreeSitterScopeHandler } from "./BaseTreeSitterScopeHandler";
 import { getCaptureRangeByName, getRelatedRange } from "./captureUtils";
+import { QueryMatch } from "../../../../languages/TreeSitterQuery/QueryCapture";
 
 /** Scope handler to be used for iteration scopes of tree-sitter scope types */
 export class TreeSitterIterationScopeHandler extends BaseTreeSitterScopeHandler {

--- a/packages/cursorless-engine/src/processTargets/modifiers/scopeHandlers/TreeSitterScopeHandler/TreeSitterScopeHandler.ts
+++ b/packages/cursorless-engine/src/processTargets/modifiers/scopeHandlers/TreeSitterScopeHandler/TreeSitterScopeHandler.ts
@@ -1,7 +1,6 @@
 import { SimpleScopeType, TextEditor } from "@cursorless/common";
-
-import { QueryMatch } from "web-tree-sitter";
 import { TreeSitterQuery } from "../../../../languages/TreeSitterQuery";
+import { QueryMatch } from "../../../../languages/TreeSitterQuery/QueryCapture";
 import ScopeTypeTarget from "../../../targets/ScopeTypeTarget";
 import { TargetScope } from "../scope.types";
 import { CustomScopeType } from "../scopeHandler.types";

--- a/packages/cursorless-engine/src/processTargets/modifiers/scopeHandlers/TreeSitterScopeHandler/TreeSitterTextFragmentScopeHandler.ts
+++ b/packages/cursorless-engine/src/processTargets/modifiers/scopeHandlers/TreeSitterScopeHandler/TreeSitterTextFragmentScopeHandler.ts
@@ -1,6 +1,6 @@
 import { ScopeType, TextEditor } from "@cursorless/common";
-import { QueryMatch } from "web-tree-sitter";
 import { TreeSitterQuery } from "../../../../languages/TreeSitterQuery";
+import { QueryMatch } from "../../../../languages/TreeSitterQuery/QueryCapture";
 import { TEXT_FRAGMENT_CAPTURE_NAME } from "../../../../languages/captureNames";
 import { PlainTarget } from "../../../targets";
 import { TargetScope } from "../scope.types";

--- a/packages/cursorless-engine/src/processTargets/modifiers/scopeHandlers/TreeSitterScopeHandler/captureUtils.ts
+++ b/packages/cursorless-engine/src/processTargets/modifiers/scopeHandlers/TreeSitterScopeHandler/captureUtils.ts
@@ -1,5 +1,4 @@
-import { QueryMatch } from "web-tree-sitter";
-import { getNodeRange } from "../../../../util/nodeSelectors";
+import { QueryMatch } from "../../../../languages/TreeSitterQuery/QueryCapture";
 
 /**
  * Gets the range of a node that is related to the scope.  For example, if the
@@ -32,9 +31,7 @@ export function getRelatedRange(
  * @returns A range or undefined if no matching capture was found
  */
 export function getCaptureRangeByName(match: QueryMatch, ...names: string[]) {
-  const relatedNode = match.captures.find((capture) =>
+  return match.captures.find((capture) =>
     names.some((name) => capture.name === name),
-  )?.node;
-
-  return relatedNode == null ? undefined : getNodeRange(relatedNode);
+  )?.range;
 }


### PR DESCRIPTION
This solution is simple and fairly clean, but there are a couple things I don't like about it:

I would prefer to have more separation between predicate operators, which just return `true` or `false`, and "mutator" operators that can alter the capture itself.  I started down that road, but decided it wasn't worth the complexity to create a whole other set of types for mutators

I don't love the idea of mutating your parameters; I prefer treating parameters as immutable and just returning an object indicating what should happen.  But that also would have made things a fair amount more complicated, and I don't imagine there will be a lot of these operators, so I don't think we need to come up with an airtight type system here.

## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet
