### PR TITLE
Support `#start-position!` and `#end-position!` predicates

### DIFF
--- a/packages/cursorless-engine/src/languages/TreeSitterQuery/queryPredicateOperators.ts
+++ b/packages/cursorless-engine/src/languages/TreeSitterQuery/queryPredicateOperators.ts
@@ -1,3 +1,4 @@
+import { Range } from "@cursorless/common";
 import z from "zod";
 import { HasSchema } from "./PredicateOperatorSchemaTypes";
 import { MutableQueryCapture } from "./QueryCapture";
@@ -45,8 +46,44 @@ class IsNthChild extends QueryPredicateOperator<IsNthChild> {
   }
 }
 
+/**
+ * A predicate operator that modifies the range of the match to be a zero-width
+ * range at the start of the node.  For example, `(#start! @foo)` will modify
+ * the range of the `@foo` capture to be a zero-width range at the start of the
+ * `@foo` node.
+ */
+class Start extends QueryPredicateOperator<Start> {
+  name = "start!" as const;
+  schema = z.tuple([q.node]);
+
+  run(nodeInfo: MutableQueryCapture) {
+    nodeInfo.range = new Range(nodeInfo.range.start, nodeInfo.range.start);
+
+    return true;
+  }
+}
+
+/**
+ * A predicate operator that modifies the range of the match to be a zero-width
+ * range at the end of the node.  For example, `(#end! @foo)` will modify
+ * the range of the `@foo` capture to be a zero-width range at the end of the
+ * `@foo` node.
+ */
+class End extends QueryPredicateOperator<End> {
+  name = "end!" as const;
+  schema = z.tuple([q.node]);
+
+  run(nodeInfo: MutableQueryCapture) {
+    nodeInfo.range = new Range(nodeInfo.range.end, nodeInfo.range.end);
+
+    return true;
+  }
+}
+
 export const queryPredicateOperators: QueryPredicateOperator<HasSchema>[] = [
   new NotType(),
   new NotParentType(),
   new IsNthChild(),
+  new Start(),
+  new End(),
 ];

--- a/packages/cursorless-engine/src/languages/TreeSitterQuery/queryPredicateOperators.ts
+++ b/packages/cursorless-engine/src/languages/TreeSitterQuery/queryPredicateOperators.ts
@@ -48,12 +48,12 @@ class IsNthChild extends QueryPredicateOperator<IsNthChild> {
 
 /**
  * A predicate operator that modifies the range of the match to be a zero-width
- * range at the start of the node.  For example, `(#start! @foo)` will modify
- * the range of the `@foo` capture to be a zero-width range at the start of the
- * `@foo` node.
+ * range at the start of the node.  For example, `(#start-position! @foo)` will
+ * modify the range of the `@foo` capture to be a zero-width range at the start
+ * of the `@foo` node.
  */
-class Start extends QueryPredicateOperator<Start> {
-  name = "start!" as const;
+class StartPosition extends QueryPredicateOperator<StartPosition> {
+  name = "start-position!" as const;
   schema = z.tuple([q.node]);
 
   run(nodeInfo: MutableQueryCapture) {
@@ -65,12 +65,12 @@ class Start extends QueryPredicateOperator<Start> {
 
 /**
  * A predicate operator that modifies the range of the match to be a zero-width
- * range at the end of the node.  For example, `(#end! @foo)` will modify
- * the range of the `@foo` capture to be a zero-width range at the end of the
- * `@foo` node.
+ * range at the end of the node.  For example, `(#end-position! @foo)` will
+ * modify the range of the `@foo` capture to be a zero-width range at the end of
+ * the `@foo` node.
  */
-class End extends QueryPredicateOperator<End> {
-  name = "end!" as const;
+class EndPosition extends QueryPredicateOperator<EndPosition> {
+  name = "end-position!" as const;
   schema = z.tuple([q.node]);
 
   run(nodeInfo: MutableQueryCapture) {
@@ -84,6 +84,6 @@ export const queryPredicateOperators: QueryPredicateOperator<HasSchema>[] = [
   new NotType(),
   new NotParentType(),
   new IsNthChild(),
-  new Start(),
-  new End(),
+  new StartPosition(),
+  new EndPosition(),
 ];


### PR DESCRIPTION
- Fixes https://github.com/cursorless-dev/cursorless/issues/1482
- Depends on https://github.com/cursorless-dev/cursorless/pull/1501

## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet
