### PR TITLE
Support for `@foo.start` and `@foo.end`

### DIFF
--- a/packages/cursorless-engine/src/languages/TreeSitterQuery/checkCaptureStartEnd.test.ts
+++ b/packages/cursorless-engine/src/languages/TreeSitterQuery/checkCaptureStartEnd.test.ts
@@ -1,0 +1,196 @@
+import { Messages, Range } from "@cursorless/common";
+import { QueryCapture } from "./QueryCapture";
+import { checkCaptureStartEnd } from "./checkCaptureStartEnd";
+import assert = require("assert");
+
+interface TestCase {
+  name: string;
+  captures: QueryCapture[];
+  isValid: boolean;
+  expectedErrorMessageIds: string[];
+}
+
+const testCases: TestCase[] = [
+  {
+    name: "should return true for valid capture",
+    captures: [
+      {
+        name: "@foo",
+        range: new Range(0, 0, 0, 0),
+      },
+    ],
+    isValid: true,
+    expectedErrorMessageIds: [],
+  },
+
+  {
+    name: "should return true for valid capture with start only",
+    captures: [
+      {
+        name: "@foo.start",
+        range: new Range(0, 0, 0, 0),
+      },
+    ],
+    isValid: true,
+    expectedErrorMessageIds: [],
+  },
+
+  {
+    name: "should return true for valid capture with end only",
+    captures: [
+      {
+        name: "@foo.end",
+        range: new Range(0, 0, 0, 0),
+      },
+    ],
+    isValid: true,
+    expectedErrorMessageIds: [],
+  },
+
+  {
+    name: "should return true for valid capture with start and end",
+    captures: [
+      {
+        name: "@foo.start",
+        range: new Range(0, 0, 0, 1),
+      },
+      {
+        name: "@foo.end",
+        range: new Range(0, 1, 0, 2),
+      },
+    ],
+    isValid: true,
+    expectedErrorMessageIds: [],
+  },
+
+  {
+    name: "should show error for capture with start and end in reverse order",
+    captures: [
+      {
+        name: "@foo.start",
+        range: new Range(0, 1, 0, 2),
+      },
+      {
+        name: "@foo.end",
+        range: new Range(0, 0, 0, 1),
+      },
+    ],
+    isValid: false,
+    expectedErrorMessageIds: ["TreeSitterQuery.checkCaptures.badOrder"],
+  },
+
+  {
+    name: "should show error for capture with start containing end",
+    captures: [
+      {
+        name: "@foo.start",
+        range: new Range(0, 0, 0, 2),
+      },
+      {
+        name: "@foo.end",
+        range: new Range(0, 1, 0, 2),
+      },
+    ],
+    isValid: false,
+    expectedErrorMessageIds: ["TreeSitterQuery.checkCaptures.badOrder"],
+  },
+
+  {
+    name: "should show error for capture with regular and start",
+    captures: [
+      {
+        name: "@foo",
+        range: new Range(0, 0, 0, 0),
+      },
+      {
+        name: "@foo.start",
+        range: new Range(0, 1, 0, 2),
+      },
+    ],
+    isValid: false,
+    expectedErrorMessageIds: [
+      "TreeSitterQuery.checkCaptures.mixRegularStartEnd",
+    ],
+  },
+
+  {
+    name: "should show error for capture with multiple regular",
+    captures: [
+      {
+        name: "@foo",
+        range: new Range(0, 0, 0, 0),
+      },
+      {
+        name: "@foo",
+        range: new Range(0, 1, 0, 2),
+      },
+    ],
+    isValid: false,
+    expectedErrorMessageIds: ["TreeSitterQuery.checkCaptures.duplicate"],
+  },
+
+  {
+    name: "should show error for capture with multiple start",
+    captures: [
+      {
+        name: "@foo.start",
+        range: new Range(0, 0, 0, 0),
+      },
+      {
+        name: "@foo.start",
+        range: new Range(0, 1, 0, 2),
+      },
+      {
+        name: "@foo.end",
+        range: new Range(0, 2, 0, 3),
+      },
+    ],
+    isValid: false,
+    expectedErrorMessageIds: ["TreeSitterQuery.checkCaptures.duplicate"],
+  },
+
+  {
+    name: "should show multiple errors",
+    captures: [
+      {
+        name: "@foo.start",
+        range: new Range(0, 0, 0, 0),
+      },
+      {
+        name: "@foo.start",
+        range: new Range(0, 1, 0, 2),
+      },
+      {
+        name: "@foo",
+        range: new Range(0, 2, 0, 3),
+      },
+      {
+        name: "@foo.end",
+        range: new Range(0, 2, 0, 3),
+      },
+    ],
+    isValid: false,
+    expectedErrorMessageIds: [
+      "TreeSitterQuery.checkCaptures.mixRegularStartEnd",
+      "TreeSitterQuery.checkCaptures.duplicate",
+    ],
+  },
+];
+
+suite("checkCaptureStartEnd", () => {
+  for (const testCase of testCases) {
+    test(testCase.name, () => {
+      const actualErrorIds: string[] = [];
+      const messages: Messages = {
+        async showMessage(_type, id, _message) {
+          actualErrorIds.push(id);
+          return undefined;
+        },
+      };
+
+      const result = checkCaptureStartEnd(testCase.captures, messages);
+      assert(result === testCase.isValid);
+      assert.deepStrictEqual(actualErrorIds, testCase.expectedErrorMessageIds);
+    });
+  }
+});

--- a/packages/cursorless-engine/src/languages/TreeSitterQuery/checkCaptureStartEnd.ts
+++ b/packages/cursorless-engine/src/languages/TreeSitterQuery/checkCaptureStartEnd.ts
@@ -1,0 +1,88 @@
+import { Messages, showError } from "@cursorless/common";
+import { QueryCapture } from "./QueryCapture";
+
+/**
+ * Checks the captures for a single name to ensure that they are valid.  Detects
+ * errors like start appearing before end, the same capture appearing twice, etc.
+ * @param captures A list of captures with the same name
+ * @param messages The messages object for displaying messages to the user
+ * @returns `true` if the captures are valid
+ */
+export function checkCaptureStartEnd(
+  captures: QueryCapture[],
+  messages: Messages,
+): boolean {
+  if (captures.length === 1) {
+    // Could be one of the following:
+    //
+    // - `["@foo"]`
+    // - `["@foo.start"]
+    // - `["@foo.end"]
+    //
+    // These are all considered fine, as the latter two are assumed to mean that
+    // the other endpoint wasn't matched, so we just use the range of the endpoint
+    // that did match
+    return true;
+  }
+
+  let shownError = false;
+
+  if (captures.length === 2) {
+    const startRange = captures.find(({ name }) =>
+      name.endsWith(".start"),
+    )?.range;
+    const endRange = captures.find(({ name }) => name.endsWith(".end"))?.range;
+    if (startRange != null && endRange != null) {
+      if (startRange.end.isBeforeOrEqual(endRange.start)) {
+        // Found just a start and endpoint in the right order, so we're good
+        return true;
+      }
+
+      showError(
+        messages,
+        "TreeSitterQuery.checkCaptures.badOrder",
+        `Start capture must be before end capture: ${captures}`,
+      );
+      shownError = true;
+    }
+  }
+
+  const startCount = captures.filter(({ name }) =>
+    name.endsWith(".start"),
+  ).length;
+  const endCount = captures.filter(({ name }) => name.endsWith(".end")).length;
+  const regularCount = captures.length - startCount - endCount;
+
+  if (regularCount > 0 && (startCount > 0 || endCount > 0)) {
+    // Found a mix of regular captures and start/end captures, which is not
+    // allowed
+    showError(
+      messages,
+      "TreeSitterQuery.checkCaptures.mixRegularStartEnd",
+      `Please do not mix regular captures and start/end captures: ${captures}`,
+    );
+    shownError = true;
+  }
+
+  if (regularCount > 1 || startCount > 1 || endCount > 1) {
+    // Found duplicate captures
+    showError(
+      messages,
+      "TreeSitterQuery.checkCaptures.duplicate",
+      `A capture with the same name may only appear once in a single pattern: ${captures}`,
+    );
+    shownError = true;
+  }
+
+  if (!shownError) {
+    // I don't think it's possible to get here, but just in case, show a generic
+    // error message
+    showError(
+      messages,
+      "TreeSitterQuery.checkCaptures.unexpected",
+      `Unexpected captures: ${captures}`,
+    );
+  }
+
+  return false;
+}


### PR DESCRIPTION
- Fixes #1479

## Checklist

- [x] Remove `.start` and `.end` when computing capture names in https://github.com/cursorless-dev/cursorless/blob/main/packages/cursorless-engine/src/languages/TreeSitterQuery/TreeSitterQuery.ts#L73-L75
- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet
