### PR TITLE
Support `#child-range!` predicate

### DIFF
--- a/packages/cursorless-engine/src/languages/TreeSitterQuery/operatorArgumentSchemaTypes.ts
+++ b/packages/cursorless-engine/src/languages/TreeSitterQuery/operatorArgumentSchemaTypes.ts
@@ -35,6 +35,27 @@ export const q = {
     }
     return { type: "integer", value: parsedValue } as const;
   }),
+
+  /** Expect a boolean */
+  boolean: string.transform((val, ctx) => {
+    if (val.value === "true") {
+      return { type: "boolean" as const, value: true };
+    }
+
+    if (val.value === "false") {
+      return { type: "boolean" as const, value: false };
+    }
+
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "Expected true or false",
+    });
+
+    // This is a special symbol you can use to return early from the transform
+    // function. It has type `never` so it does not affect the inferred return
+    // type.
+    return z.NEVER;
+  }),
 } as const;
 
 export type SchemaTypes = (typeof q)[keyof typeof q];

--- a/packages/cursorless-engine/src/languages/TreeSitterQuery/queryPredicateOperators.ts
+++ b/packages/cursorless-engine/src/languages/TreeSitterQuery/queryPredicateOperators.ts
@@ -80,10 +80,66 @@ class EndPosition extends QueryPredicateOperator<EndPosition> {
   }
 }
 
+class ChildRange extends QueryPredicateOperator<ChildRange> {
+  name = "child-range!" as const;
+  schema = z.union([
+    z.tuple([q.node, q.integer]),
+    z.tuple([q.node, q.integer, q.integer]),
+    z.tuple([q.node, q.integer, q.integer, q.boolean]),
+    z.tuple([q.node, q.integer, q.integer, q.boolean, q.boolean]),
+  ]);
+
+  run(nodeInfo: MutableQueryCapture, startIndex: number): boolean;
+  run(
+    nodeInfo: MutableQueryCapture,
+    startIndex: number,
+    endIndex: number,
+  ): boolean;
+  run(
+    nodeInfo: MutableQueryCapture,
+    startIndex: number,
+    endIndex: number,
+    excludeStart: boolean,
+  ): boolean;
+  run(
+    nodeInfo: MutableQueryCapture,
+    startIndex: number,
+    endIndex: number,
+    excludeStart: boolean,
+    excludeEnd: boolean,
+  ): boolean;
+  run(
+    nodeInfo: MutableQueryCapture,
+    startIndex: number,
+    endIndex?: number,
+    excludeStart?: boolean,
+    excludeEnd?: boolean,
+  ) {
+    const {
+      node: { children },
+    } = nodeInfo;
+
+    startIndex = startIndex < 0 ? children.length + startIndex : startIndex;
+    endIndex = endIndex == null ? -1 : endIndex;
+    endIndex = endIndex < 0 ? children.length + endIndex : endIndex;
+
+    const start = children[startIndex];
+    const end = children[endIndex];
+
+    nodeInfo.range = makeRangeFromPositions(
+      excludeStart ? start.endPosition : start.startPosition,
+      excludeEnd ? end.startPosition : end.endPosition,
+    );
+
+    return true;
+  }
+}
+
 export const queryPredicateOperators: QueryPredicateOperator<HasSchema>[] = [
   new NotType(),
   new NotParentType(),
   new IsNthChild(),
   new StartPosition(),
   new EndPosition(),
+  new ChildRange(),
 ];

--- a/packages/cursorless-engine/src/languages/TreeSitterQuery/queryPredicateOperators.ts
+++ b/packages/cursorless-engine/src/languages/TreeSitterQuery/queryPredicateOperators.ts
@@ -1,6 +1,6 @@
 import { Range } from "@cursorless/common";
 import z from "zod";
-import { HasSchema } from "./PredicateOperatorSchemaTypes";
+import { makeRangeFromPositions } from "../../util/nodeSelectors";
 import { MutableQueryCapture } from "./QueryCapture";
 import { QueryPredicateOperator } from "./QueryPredicateOperator";
 import { q } from "./operatorArgumentSchemaTypes";
@@ -89,25 +89,6 @@ class ChildRange extends QueryPredicateOperator<ChildRange> {
     z.tuple([q.node, q.integer, q.integer, q.boolean, q.boolean]),
   ]);
 
-  run(nodeInfo: MutableQueryCapture, startIndex: number): boolean;
-  run(
-    nodeInfo: MutableQueryCapture,
-    startIndex: number,
-    endIndex: number,
-  ): boolean;
-  run(
-    nodeInfo: MutableQueryCapture,
-    startIndex: number,
-    endIndex: number,
-    excludeStart: boolean,
-  ): boolean;
-  run(
-    nodeInfo: MutableQueryCapture,
-    startIndex: number,
-    endIndex: number,
-    excludeStart: boolean,
-    excludeEnd: boolean,
-  ): boolean;
   run(
     nodeInfo: MutableQueryCapture,
     startIndex: number,
@@ -135,7 +116,7 @@ class ChildRange extends QueryPredicateOperator<ChildRange> {
   }
 }
 
-export const queryPredicateOperators: QueryPredicateOperator<HasSchema>[] = [
+export const queryPredicateOperators = [
   new NotType(),
   new NotParentType(),
   new IsNthChild(),


### PR DESCRIPTION
- Depends on https://github.com/cursorless-dev/cursorless/pull/1505
- Fixes #1480

## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet
