### PR TITLE
Support `#allow-multiple!` predicate to enable multiple content ranges

### DIFF
--- a/packages/cursorless-engine/src/languages/TreeSitterQuery/QueryCapture.ts
+++ b/packages/cursorless-engine/src/languages/TreeSitterQuery/QueryCapture.ts
@@ -15,6 +15,12 @@ export interface QueryCapture {
 
   /** The range of the capture. */
   readonly range: Range;
+
+  /** Whether it is ok for the same capture to appear multiple times with the
+   * same domain. If set to `true`, then the scope handler should merge all
+   * captures with the same name and domain into a single scope with multiple
+   * content ranges. */
+  readonly allowMultiple: boolean;
 }
 
 /**
@@ -40,6 +46,7 @@ export interface MutableQueryCapture extends QueryCapture {
   readonly node: SyntaxNode;
 
   range: Range;
+  allowMultiple: boolean;
 }
 
 /**

--- a/packages/cursorless-engine/src/languages/TreeSitterQuery/TreeSitterQuery.ts
+++ b/packages/cursorless-engine/src/languages/TreeSitterQuery/TreeSitterQuery.ts
@@ -78,6 +78,7 @@ export class TreeSitterQuery {
             name,
             node,
             range: getNodeRange(node),
+            allowMultiple: false,
           })),
         }),
       )
@@ -108,6 +109,9 @@ export class TreeSitterQuery {
             range: captures
               .map(({ range }) => range)
               .reduce((accumulator, range) => range.union(accumulator)),
+            allowMultiple: captures
+              .map((capture) => capture.allowMultiple)
+              .some(Boolean),
           };
         });
 

--- a/packages/cursorless-engine/src/languages/TreeSitterQuery/TreeSitterQuery.ts
+++ b/packages/cursorless-engine/src/languages/TreeSitterQuery/TreeSitterQuery.ts
@@ -109,9 +109,7 @@ export class TreeSitterQuery {
             range: captures
               .map(({ range }) => range)
               .reduce((accumulator, range) => range.union(accumulator)),
-            allowMultiple: captures
-              .map((capture) => capture.allowMultiple)
-              .some(Boolean),
+            allowMultiple: captures.some((capture) => capture.allowMultiple),
           };
         });
 

--- a/packages/cursorless-engine/src/languages/TreeSitterQuery/checkCaptureStartEnd.test.ts
+++ b/packages/cursorless-engine/src/languages/TreeSitterQuery/checkCaptureStartEnd.test.ts
@@ -5,7 +5,7 @@ import assert = require("assert");
 
 interface TestCase {
   name: string;
-  captures: QueryCapture[];
+  captures: Omit<QueryCapture, "allowMultiple">[];
   isValid: boolean;
   expectedErrorMessageIds: string[];
 }
@@ -188,7 +188,13 @@ suite("checkCaptureStartEnd", () => {
         },
       };
 
-      const result = checkCaptureStartEnd(testCase.captures, messages);
+      const result = checkCaptureStartEnd(
+        testCase.captures.map((capture) => ({
+          ...capture,
+          allowMultiple: false,
+        })),
+        messages,
+      );
       assert(result === testCase.isValid);
       assert.deepStrictEqual(actualErrorIds, testCase.expectedErrorMessageIds);
     });

--- a/packages/cursorless-engine/src/languages/TreeSitterQuery/queryPredicateOperators.ts
+++ b/packages/cursorless-engine/src/languages/TreeSitterQuery/queryPredicateOperators.ts
@@ -116,6 +116,17 @@ class ChildRange extends QueryPredicateOperator<ChildRange> {
   }
 }
 
+class AllowMultiple extends QueryPredicateOperator<AllowMultiple> {
+  name = "allow-multiple!" as const;
+  schema = z.tuple([q.node]);
+
+  run(nodeInfo: MutableQueryCapture) {
+    nodeInfo.allowMultiple = true;
+
+    return true;
+  }
+}
+
 export const queryPredicateOperators = [
   new NotType(),
   new NotParentType(),
@@ -123,4 +134,5 @@ export const queryPredicateOperators = [
   new StartPosition(),
   new EndPosition(),
   new ChildRange(),
+  new AllowMultiple(),
 ];

--- a/packages/cursorless-engine/src/processTargets/modifiers/scopeHandlers/TreeSitterScopeHandler/TreeSitterIterationScopeHandler.ts
+++ b/packages/cursorless-engine/src/processTargets/modifiers/scopeHandlers/TreeSitterScopeHandler/TreeSitterIterationScopeHandler.ts
@@ -1,10 +1,12 @@
 import { ScopeType, SimpleScopeType, TextEditor } from "@cursorless/common";
 import { TreeSitterQuery } from "../../../../languages/TreeSitterQuery";
-import { PlainTarget } from "../../../targets";
-import { TargetScope } from "../scope.types";
-import { BaseTreeSitterScopeHandler } from "./BaseTreeSitterScopeHandler";
-import { getCaptureRangeByName, getRelatedRange } from "./captureUtils";
 import { QueryMatch } from "../../../../languages/TreeSitterQuery/QueryCapture";
+import { PlainTarget } from "../../../targets";
+import {
+  BaseTreeSitterScopeHandler,
+  ExtendedTargetScope,
+} from "./BaseTreeSitterScopeHandler";
+import { getRelatedCapture, getRelatedRange } from "./captureUtils";
 
 /** Scope handler to be used for iteration scopes of tree-sitter scope types */
 export class TreeSitterIterationScopeHandler extends BaseTreeSitterScopeHandler {
@@ -30,26 +32,26 @@ export class TreeSitterIterationScopeHandler extends BaseTreeSitterScopeHandler 
   protected matchToScope(
     editor: TextEditor,
     match: QueryMatch,
-  ): TargetScope | undefined {
+  ): ExtendedTargetScope | undefined {
     const scopeTypeType = this.iterateeScopeType.type;
 
-    const contentRange = getRelatedRange(match, scopeTypeType, "iteration")!;
+    const capture = getRelatedCapture(match, scopeTypeType, "iteration", false);
 
-    if (contentRange == null) {
+    if (capture == null) {
       // This capture was for some unrelated scope type
       return undefined;
     }
 
+    const { range: contentRange, allowMultiple } = capture;
+
     const domain =
-      getCaptureRangeByName(
-        match,
-        `${scopeTypeType}.iteration.domain`,
-        `_.iteration.domain`,
-      ) ?? contentRange;
+      getRelatedRange(match, scopeTypeType, "iteration.domain", false) ??
+      contentRange;
 
     return {
       editor,
       domain,
+      allowMultiple,
       getTargets: (isReversed) => [
         new PlainTarget({
           editor,

--- a/packages/cursorless-engine/src/processTargets/modifiers/scopeHandlers/TreeSitterScopeHandler/captureUtils.ts
+++ b/packages/cursorless-engine/src/processTargets/modifiers/scopeHandlers/TreeSitterScopeHandler/captureUtils.ts
@@ -1,25 +1,63 @@
 import { QueryMatch } from "../../../../languages/TreeSitterQuery/QueryCapture";
 
 /**
+ * Gets a capture that is related to the scope.  For example, if the scope is
+ * "class name", the `domain` node would be the containing class.
+ *
+ * @param match The match to get the range from
+ * @param scopeTypeType The type of the scope
+ * @param relationship The relationship to get the range for, eg "domain", or
+ * "removal"
+ * @param matchHasScopeType Set to `true` if this match is known to have a
+ * capture for the given scope type
+ * @returns A capture or undefined if no capture was found
+ */
+export function getRelatedCapture(
+  match: QueryMatch,
+  scopeTypeType: string,
+  relationship: string,
+  matchHasScopeType: boolean,
+) {
+  if (matchHasScopeType) {
+    return findCaptureByName(
+      match,
+      `${scopeTypeType}.${relationship}`,
+      `_.${relationship}`,
+    );
+  }
+
+  return (
+    findCaptureByName(match, `${scopeTypeType}.${relationship}`) ??
+    (findCaptureByName(match, scopeTypeType) != null
+      ? findCaptureByName(match, `_.${relationship}`)
+      : undefined)
+  );
+}
+
+/**
  * Gets the range of a node that is related to the scope.  For example, if the
  * scope is "class name", the `domain` node would be the containing class.
  *
  * @param match The match to get the range from
  * @param scopeTypeType The type of the scope
- * @param relationship The relationship to get the range for, eg "domain", or "removal"
+ * @param relationship The relationship to get the range for, eg "domain", or
+ * "removal"
+ * @param matchHasScopeType Set to `true` if this match is known to have a
+ * capture for the given scope type
  * @returns A range or undefined if no range was found
  */
-
 export function getRelatedRange(
   match: QueryMatch,
   scopeTypeType: string,
   relationship: string,
+  matchHasScopeType: boolean,
 ) {
-  return getCaptureRangeByName(
+  return getRelatedCapture(
     match,
-    `${scopeTypeType}.${relationship}`,
-    `_.${relationship}`,
-  );
+    scopeTypeType,
+    relationship,
+    matchHasScopeType,
+  )?.range;
 }
 
 /**
@@ -30,8 +68,20 @@ export function getRelatedRange(
  * @param names The possible names of the capture to get the range for
  * @returns A range or undefined if no matching capture was found
  */
-export function getCaptureRangeByName(match: QueryMatch, ...names: string[]) {
+export function findCaptureRangeByName(match: QueryMatch, ...names: string[]) {
+  return findCaptureByName(match, ...names)?.range;
+}
+
+/**
+ * Looks in the captures of a match for a capture with one of the given names, and
+ * returns that capture, or undefined if no matching capture was found
+ *
+ * @param match The match to get the range from
+ * @param names The possible names of the capture to get the range for
+ * @returns A range or undefined if no matching capture was found
+ */
+export function findCaptureByName(match: QueryMatch, ...names: string[]) {
   return match.captures.find((capture) =>
     names.some((name) => capture.name === name),
-  )?.range;
+  );
 }


### PR DESCRIPTION
- Depends on https://github.com/cursorless-dev/cursorless/pull/1509
- Fixes #1481

## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet
