### PR TITLE
Fix `"instance first three chars"`

### DIFF
--- a/packages/cursorless-engine/src/processTargets/targets/PlainTarget.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/PlainTarget.ts
@@ -20,5 +20,10 @@ export default class PlainTarget extends BaseTarget {
   getTrailingDelimiterTarget = () => undefined;
   getRemovalRange = () => this.contentRange;
 
-  protected getCloneParameters = () => this.state;
+  protected getCloneParameters() {
+    return {
+      ...this.state,
+      isToken: this.isToken,
+    };
+  }
 }

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/modifiers/instance/clearTwoInstancesFirstThreeCarsAir.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/modifiers/instance/clearTwoInstancesFirstThreeCarsAir.yml
@@ -1,0 +1,37 @@
+languageId: plaintext
+command:
+  version: 5
+  spokenForm: clear two instances first three cars air
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: relativeScope
+          scopeType: {type: instance}
+          offset: 0
+          length: 2
+          direction: forward
+        - type: ordinalScope
+          scopeType: {type: character}
+          start: 0
+          length: 3
+      mark: {type: decoratedSymbol, symbolColor: default, character: a}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |
+    aaabbb aaaccc
+  selections:
+    - anchor: {line: 1, character: 0}
+      active: {line: 1, character: 0}
+  marks:
+    default.a:
+      start: {line: 0, character: 0}
+      end: {line: 0, character: 6}
+finalState:
+  documentContents: |
+    bbb ccc
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+    - anchor: {line: 0, character: 4}
+      active: {line: 0, character: 4}


### PR DESCRIPTION
The problem was that constructing a character range inadvertently resulted in a target with `isToken = true`, because when we clone the anchor target to create the new range target, we forgot to include the `isToken = false`.

## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet
