### PR TITLE
Fix `"forward"` in cheatsheet

### DIFF
--- a/cursorless-talon/src/cheatsheet/sections/modifiers.py
+++ b/cursorless-talon/src/cheatsheet/sections/modifiers.py
@@ -26,6 +26,7 @@ def get_modifiers():
         "previous",
         "next",
         "backward",
+        "forward",
     ]
     simple_modifiers = {
         key: value
@@ -124,6 +125,10 @@ def get_modifiers():
                 {
                     "spokenForm": f"<scope> {complex_modifiers['backward']}",
                     "description": "single instance of <scope> including target, going backwards",
+                },
+                {
+                    "spokenForm": f"<scope> {complex_modifiers['forward']}",
+                    "description": "single instance of <scope> including target, going forwards",
                 },
                 {
                     "spokenForm": f"<number> <scope>s {complex_modifiers['backward']}",

--- a/packages/cheatsheet/src/lib/sampleSpokenFormInfos/defaults.json
+++ b/packages/cheatsheet/src/lib/sampleSpokenFormInfos/defaults.json
@@ -709,6 +709,16 @@
           ]
         },
         {
+          "id": "inferPreviousMark",
+          "type": "modifier",
+          "variations": [
+            {
+              "spokenForm": "its",
+              "description": "Infer previous mark"
+            }
+          ]
+        },
+        {
           "id": "interiorOnly",
           "type": "modifier",
           "variations": [
@@ -793,6 +803,14 @@
             {
               "spokenForm": "previous <number> <scope>s",
               "description": "previous <number> instances of <scope>"
+            },
+            {
+              "spokenForm": "<scope> backward",
+              "description": "single instance of <scope> including target, going backwards"
+            },
+            {
+              "spokenForm": "<scope> forward",
+              "description": "single instance of <scope> including target, going forwards"
             },
             {
               "spokenForm": "<number> <scope>s backward",
@@ -1057,6 +1075,16 @@
           ]
         },
         {
+          "id": "branch",
+          "type": "scopeType",
+          "variations": [
+            {
+              "spokenForm": "branch",
+              "description": "Branch"
+            }
+          ]
+        },
+        {
           "id": "chapter",
           "type": "scopeType",
           "variations": [
@@ -1187,12 +1215,32 @@
           ]
         },
         {
+          "id": "identifier",
+          "type": "scopeType",
+          "variations": [
+            {
+              "spokenForm": "identifier",
+              "description": "Identifier"
+            }
+          ]
+        },
+        {
           "id": "ifStatement",
           "type": "scopeType",
           "variations": [
             {
               "spokenForm": "if state",
               "description": "If statement"
+            }
+          ]
+        },
+        {
+          "id": "instance",
+          "type": "scopeType",
+          "variations": [
+            {
+              "spokenForm": "instance",
+              "description": "Instance"
             }
           ]
         },
@@ -1383,6 +1431,16 @@
             {
               "spokenForm": "type",
               "description": "Type"
+            }
+          ]
+        },
+        {
+          "id": "unit",
+          "type": "scopeType",
+          "variations": [
+            {
+              "spokenForm": "unit",
+              "description": "Unit"
             }
           ]
         },


### PR DESCRIPTION
This is how `"backward"` looks:

<img width="540" alt="image" src="https://github.com/cursorless-dev/cursorless/assets/755842/e196de38-a3db-445c-af29-61758317e39e">

But `"forward"` didn't have the same special treatment:

<img width="550" alt="image" src="https://github.com/cursorless-dev/cursorless/assets/755842/00a87f25-c806-4984-a25f-f9f9c3855e25">

This PR makes it look as follows:

<img width="546" alt="image" src="https://github.com/cursorless-dev/cursorless/assets/755842/80bfee7f-cf4b-437d-b980-10eb68434796">

I also updated the cheatsheet json that we use to generate the [generic cheatsheet](https://www.cursorless.org/cheatsheet) while I was here

## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [x] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [x] I have not broken the cheatsheet
