### PR TITLE
Updated doc string to be representative

### DIFF
--- a/packages/cursorless-engine/src/core/commandRunner/selectionToStoredTarget.ts
+++ b/packages/cursorless-engine/src/core/commandRunner/selectionToStoredTarget.ts
@@ -3,8 +3,7 @@ import { SelectionWithEditor } from "../../typings/Types";
 
 /**
  * Given a selection with an editor, constructs an appropriate `Target` to use
- * for a `that` mark.  It uses an `UntypedTarget`, and if the selection is
- * empty, it sets `hasExplicitRange` to `false`.
+ * for a `that` mark. It uses an `UntypedTarget` and sets `hasExplicitRange` to `true`.
  *
  * @param selection The selection with editor to be converted
  * @returns A target that can be used for a `that` mark


### PR DESCRIPTION
Forgot to update doc string in previous pr

## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet
