### PR TITLE
Fix `is-nth-child` predicate

### DIFF
--- a/packages/cursorless-engine/src/languages/TreeSitterQuery/queryPredicateOperators.ts
+++ b/packages/cursorless-engine/src/languages/TreeSitterQuery/queryPredicateOperators.ts
@@ -42,7 +42,7 @@ class IsNthChild extends QueryPredicateOperator<IsNthChild> {
   name = "is-nth-child?" as const;
   schema = z.tuple([q.node, q.integer]);
   run({ node }: MutableQueryCapture, n: number) {
-    return node.parent?.children.indexOf(node) === n;
+    return node.parent?.children.findIndex((n) => n.id === node.id) === n;
   }
 }
 


### PR DESCRIPTION
## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet
