### PR TITLE
Make BaseTarget parameters getters stricter

### DIFF
--- a/packages/cursorless-engine/src/processTargets/targets/DocumentTarget.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/DocumentTarget.ts
@@ -3,7 +3,7 @@ import { shrinkRangeToFitContent } from "../../util/selectionUtils";
 import BaseTarget, { CommonTargetParameters } from "./BaseTarget";
 import PlainTarget from "./PlainTarget";
 
-export default class DocumentTarget extends BaseTarget {
+export default class DocumentTarget extends BaseTarget<CommonTargetParameters> {
   insertionDelimiter = "\n";
   isLine = true;
 

--- a/packages/cursorless-engine/src/processTargets/targets/ImplicitTarget.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/ImplicitTarget.ts
@@ -1,3 +1,4 @@
+import type { CommonTargetParameters } from "./BaseTarget";
 import BaseTarget from "./BaseTarget";
 
 /**
@@ -6,7 +7,7 @@ import BaseTarget from "./BaseTarget";
  * - The implicit destination in the command `"bring air"`
  * - The implicit anchor in the range `"take past air"`
  */
-export default class ImplicitTarget extends BaseTarget {
+export default class ImplicitTarget extends BaseTarget<CommonTargetParameters> {
   insertionDelimiter = "";
   isRaw = true;
   hasExplicitScopeType = false;

--- a/packages/cursorless-engine/src/processTargets/targets/InteriorTarget.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/InteriorTarget.ts
@@ -6,14 +6,14 @@ import {
   createContinuousRangeFromRanges,
   createContinuousRangeUntypedTarget,
 } from "../targetUtil/createContinuousRange";
-import BaseTarget, { CommonTargetParameters } from "./BaseTarget";
+import type { MinimumTargetParameters } from "./BaseTarget";
+import BaseTarget from "./BaseTarget";
 
-export interface InteriorTargetParameters
-  extends Omit<CommonTargetParameters, "contentRange"> {
+export interface InteriorTargetParameters extends MinimumTargetParameters {
   readonly fullInteriorRange: Range;
 }
 
-export default class InteriorTarget extends BaseTarget {
+export default class InteriorTarget extends BaseTarget<InteriorTargetParameters> {
   insertionDelimiter = " ";
   private readonly fullInteriorRange: Range;
 

--- a/packages/cursorless-engine/src/processTargets/targets/LineTarget.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/LineTarget.ts
@@ -3,9 +3,10 @@ import { Target } from "../../typings/target.types";
 import { expandToFullLine } from "../../util/rangeUtils";
 import { tryConstructPlainTarget } from "../../util/tryConstructTarget";
 import { createContinuousLineRange } from "../targetUtil/createContinuousRange";
+import type { CommonTargetParameters } from "./BaseTarget";
 import BaseTarget from "./BaseTarget";
 
-export default class LineTarget extends BaseTarget {
+export default class LineTarget extends BaseTarget<CommonTargetParameters> {
   insertionDelimiter = "\n";
   isLine = true;
 

--- a/packages/cursorless-engine/src/processTargets/targets/NotebookCellTarget.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/NotebookCellTarget.ts
@@ -3,7 +3,7 @@ import { TargetPosition } from "@cursorless/common";
 import BaseTarget, { CommonTargetParameters } from "./BaseTarget";
 import { removalUnsupportedForPosition } from "./PositionTarget";
 
-export default class NotebookCellTarget extends BaseTarget {
+export default class NotebookCellTarget extends BaseTarget<CommonTargetParameters> {
   insertionDelimiter = "\n";
   isNotebookCell = true;
 
@@ -32,7 +32,7 @@ interface NotebookCellPositionTargetParameters extends CommonTargetParameters {
   readonly position: TargetPosition;
 }
 
-export class NotebookCellPositionTarget extends BaseTarget {
+export class NotebookCellPositionTarget extends BaseTarget<NotebookCellPositionTargetParameters> {
   insertionDelimiter = "\n";
   isNotebookCell = true;
   public position: TargetPosition;

--- a/packages/cursorless-engine/src/processTargets/targets/ParagraphTarget.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/ParagraphTarget.ts
@@ -10,10 +10,11 @@ import { expandToFullLine } from "../../util/rangeUtils";
 import { constructLineTarget } from "../../util/tryConstructTarget";
 import { isSameType } from "../../util/typeUtils";
 import { createContinuousLineRange } from "../targetUtil/createContinuousRange";
+import type { CommonTargetParameters } from "./BaseTarget";
 import BaseTarget from "./BaseTarget";
 import LineTarget from "./LineTarget";
 
-export default class ParagraphTarget extends BaseTarget {
+export default class ParagraphTarget extends BaseTarget<CommonTargetParameters> {
   insertionDelimiter = "\n\n";
   isLine = true;
 

--- a/packages/cursorless-engine/src/processTargets/targets/PlainTarget.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/PlainTarget.ts
@@ -8,7 +8,7 @@ interface PlainTargetParameters extends CommonTargetParameters {
  * A target that has no leading or trailing delimiters so it's removal range
  * just consists of the content itself. Its insertion delimiter is empty string.
  */
-export default class PlainTarget extends BaseTarget {
+export default class PlainTarget extends BaseTarget<PlainTargetParameters> {
   insertionDelimiter = "";
 
   constructor(parameters: PlainTargetParameters) {

--- a/packages/cursorless-engine/src/processTargets/targets/PositionTarget.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/PositionTarget.ts
@@ -10,7 +10,7 @@ interface PositionTargetParameters extends CommonTargetParameters {
   readonly isRaw: boolean;
 }
 
-export default class PositionTarget extends BaseTarget {
+export default class PositionTarget extends BaseTarget<PositionTargetParameters> {
   insertionDelimiter: string;
   isRaw: boolean;
   private position: TargetPosition;

--- a/packages/cursorless-engine/src/processTargets/targets/RawSelectionTarget.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/RawSelectionTarget.ts
@@ -1,3 +1,4 @@
+import type { CommonTargetParameters } from "./BaseTarget";
 import BaseTarget from "./BaseTarget";
 
 /**
@@ -5,7 +6,7 @@ import BaseTarget from "./BaseTarget";
  * just consists of the content itself. Its insertion delimiter will be
  * inherited from the source in the case of a bring after a bring before
  */
-export default class RawSelectionTarget extends BaseTarget {
+export default class RawSelectionTarget extends BaseTarget<CommonTargetParameters> {
   insertionDelimiter = "";
   isRaw = true;
   isToken = false;

--- a/packages/cursorless-engine/src/processTargets/targets/ScopeTypeTarget.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/ScopeTypeTarget.ts
@@ -25,7 +25,7 @@ export interface ScopeTypeTargetParameters extends CommonTargetParameters {
   readonly trailingDelimiterRange?: Range;
 }
 
-export default class ScopeTypeTarget extends BaseTarget {
+export default class ScopeTypeTarget extends BaseTarget<ScopeTypeTargetParameters> {
   private scopeTypeType_: SimpleScopeTypeType;
   private removalRange_?: Range;
   private interiorRange_?: Range;

--- a/packages/cursorless-engine/src/processTargets/targets/SubTokenWordTarget.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/SubTokenWordTarget.ts
@@ -9,7 +9,7 @@ export interface SubTokenTargetParameters extends CommonTargetParameters {
   readonly trailingDelimiterRange?: Range;
 }
 
-export default class SubTokenWordTarget extends BaseTarget {
+export default class SubTokenWordTarget extends BaseTarget<SubTokenTargetParameters> {
   private leadingDelimiterRange_?: Range;
   private trailingDelimiterRange_?: Range;
   insertionDelimiter: string;
@@ -43,11 +43,12 @@ export default class SubTokenWordTarget extends BaseTarget {
     return getDelimitedSequenceRemovalRange(this);
   }
 
-  protected getCloneParameters() {
+  protected getCloneParameters(): SubTokenTargetParameters {
     return {
       ...this.state,
       leadingDelimiterRange: this.leadingDelimiterRange_,
       trailingDelimiterRange: this.trailingDelimiterRange_,
+      insertionDelimiter: this.insertionDelimiter,
     };
   }
 }

--- a/packages/cursorless-engine/src/processTargets/targets/SurroundingPairTarget.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/SurroundingPairTarget.ts
@@ -25,7 +25,7 @@ interface SurroundingPairTargetParameters extends CommonTargetParameters {
   readonly boundary: [Range, Range];
 }
 
-export default class SurroundingPairTarget extends BaseTarget {
+export default class SurroundingPairTarget extends BaseTarget<SurroundingPairTargetParameters> {
   insertionDelimiter = " ";
   private interiorRange_: Range;
   private boundary_: [Range, Range];

--- a/packages/cursorless-engine/src/processTargets/targets/TokenTarget.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/TokenTarget.ts
@@ -6,8 +6,9 @@ import {
   getTokenRemovalRange,
   getTokenTrailingDelimiterTarget,
 } from "../targetUtil/insertionRemovalBehaviors/TokenInsertionRemovalBehavior";
+import type { CommonTargetParameters } from "./BaseTarget";
 
-export default class TokenTarget extends BaseTarget {
+export default class TokenTarget extends BaseTarget<CommonTargetParameters> {
   insertionDelimiter = " ";
 
   getLeadingDelimiterTarget(): Target | undefined {

--- a/packages/cursorless-engine/src/processTargets/targets/UntypedTarget.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/UntypedTarget.ts
@@ -18,7 +18,7 @@ interface UntypedTargetParameters extends CommonTargetParameters {
  * - Use token delimiters (space) for removal and insertion
  * - Expand to nearest containing pair when asked for boundary or interior
  */
-export default class UntypedTarget extends BaseTarget {
+export default class UntypedTarget extends BaseTarget<UntypedTargetParameters> {
   insertionDelimiter = " ";
   hasExplicitScopeType = false;
 


### PR DESCRIPTION
## Context

https://github.com/cursorless-dev/cursorless/pull/1520#discussion_r1222855994

## What

This adds a generic to `BaseTarget`, which is expected to receive the type of the subclass' parameters. This tries its best to enforce that is the case, and ensures implementations of `getCloneParameters` return that declared type.

## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet
