### PR TITLE
 Change debug log to represent tree sitter query syntax 

### DIFF
--- a/packages/cursorless-engine/src/core/Debug.ts
+++ b/packages/cursorless-engine/src/core/Debug.ts
@@ -103,10 +103,10 @@ export class Debug {
   ) {
     const field = cursor.currentFieldName();
     const fieldText = field != null ? `${field}: ` : "";
-    const ident = " ".repeat(index);
+    const indent = " ".repeat(index);
     const nodeIsLast = index === nodes.length - 1;
     const { nodeIsNamed } = cursor;
-    let text = `${ident}${fieldText}`;
+    let text = `${indent}${fieldText}`;
 
     if (nodeIsNamed) {
       text += `(${cursor.nodeType}`;
@@ -115,10 +115,6 @@ export class Debug {
       }
     } else {
       text += `"${cursor.nodeType}"`;
-    }
-
-    if (nodeIsLast) {
-      text += " @cursor";
     }
 
     console.log(text);
@@ -131,7 +127,7 @@ export class Debug {
     }
 
     if (nodeIsNamed && !nodeIsLast) {
-      console.log(`${ident})`);
+      console.log(`${indent})`);
     }
   }
 

--- a/packages/cursorless-engine/src/core/Debug.ts
+++ b/packages/cursorless-engine/src/core/Debug.ts
@@ -38,7 +38,7 @@ export class Debug {
 
   log(...args: any[]) {
     if (this.active) {
-      console.debug(...args);
+      console.log(...args);
     }
   }
 
@@ -108,12 +108,12 @@ export class Debug {
     const leafText = ancestors[ancestors.length - 1].text
       .replace(/\s+/g, " ")
       .substring(0, 100);
-    console.debug(">".repeat(ancestors.length), `"${leafText}"`);
+    console.log(">".repeat(ancestors.length), `"${leafText}"`);
   }
 
   private printCursorLocationInfo(cursor: TreeCursor, depth: number) {
     const field = cursor.currentFieldName();
     const fieldText = field != null ? `${field}: ` : "";
-    console.debug(">".repeat(depth + 1), `${fieldText}${cursor.nodeType}`);
+    console.log(">".repeat(depth + 1), `${fieldText}${cursor.nodeType}`);
   }
 }


### PR DESCRIPTION
from
```
> source_file
> source_file
>> declarations
>> declarations
>>> settings_declaration
>>> settings_declaration
>>>> left: settings()
>>>> left: settings()
>>>> "settings()"
>>>> "settings()"
```

to
```
(source_file
 (declarations
  (settings_declaration
   left: "settings()" @cursor
  )
 )
)
```

`console.debug` is the culprit in why we got to duplicated lines. Switching to `console.log` removes the duplicated lines. I think this is an improvement until we do #1115 

I'm not totally sure if I like the `@cursor`. 

## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet
