### PR TITLE
Surrounding pairs: Fall back to text based algorithm when error node is detected.

### DIFF
--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/surroundingPair/parseTree/python/clearPair5.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/surroundingPair/parseTree/python/clearPair5.yml
@@ -1,0 +1,22 @@
+languageId: python
+command:
+  version: 5
+  spokenForm: clear pair
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: surroundingPair, delimiter: any}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: "def funk(words:list<str>):"
+  selections:
+    - anchor: {line: 0, character: 20}
+      active: {line: 0, character: 20}
+  marks: {}
+finalState:
+  documentContents: "def funk(words:list):"
+  selections:
+    - anchor: {line: 0, character: 19}
+      active: {line: 0, character: 19}


### PR DESCRIPTION
Fixes #712

## Checklist

- [x] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet
