### PR TITLE
Properly calculate range when inserting delimiters into CRLF documents

### DIFF
--- a/packages/common/src/types/TextDocument.ts
+++ b/packages/common/src/types/TextDocument.ts
@@ -1,5 +1,5 @@
-import type { Position, Range, TextLine } from "..";
 import type { URI } from "vscode-uri";
+import type { EndOfLine, Position, Range, TextLine } from "..";
 
 export interface TextDocument {
   /**
@@ -30,6 +30,12 @@ export interface TextDocument {
    * The range of the text document.
    */
   readonly range: Range;
+
+  /**
+   * The {@link EndOfLine end of line} sequence that is predominately
+   * used in this document.
+   */
+  readonly eol: EndOfLine;
 
   /**
    * Returns a text line denoted by the line number. Note

--- a/packages/cursorless-engine/src/processTargets/targets/PositionTarget.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/PositionTarget.ts
@@ -125,7 +125,7 @@ export default class PositionTarget extends BaseTarget<PositionTargetParameters>
     const startIndex = this.isBefore
       ? baseStartOffset + this.indentationString.length
       : baseStartOffset +
-        this.insertionDelimiter.length +
+        this.getLengthOfInsertionDelimiter() +
         this.indentationString.length;
 
     const endIndex = startIndex + text.length;
@@ -134,6 +134,15 @@ export default class PositionTarget extends BaseTarget<PositionTargetParameters>
       this.editor.document.positionAt(startIndex),
       this.editor.document.positionAt(endIndex),
     );
+  }
+
+  private getLengthOfInsertionDelimiter(): number {
+    // Went inserting a new line with eol `CRLF` each `\n` will be converted to
+    // `\r\n` and therefore the length is doubled.
+    if (this.isLineDelimiter && this.editor.document.eol === "CRLF") {
+      return this.insertionDelimiter.length * 2;
+    }
+    return this.insertionDelimiter.length;
   }
 }
 

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/lineEndings/pourBlock.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/lineEndings/pourBlock.yml
@@ -1,0 +1,22 @@
+languageId: python
+command:
+  version: 5
+  spokenForm: pour block
+  action: {name: editNewLineAfter}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: paragraph}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: "    # foo"
+  selections:
+    - anchor: {line: 0, character: 4}
+      active: {line: 0, character: 4}
+  marks: {}
+finalState:
+  documentContents: "    # foo\r\n\r\n    "
+  selections:
+    - anchor: {line: 2, character: 4}
+      active: {line: 2, character: 4}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/lineEndings/pourState.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/lineEndings/pourState.yml
@@ -1,0 +1,22 @@
+languageId: python
+command:
+  version: 5
+  spokenForm: pour state
+  action: {name: editNewLineAfter}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: statement}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: "def whatever():\r\n    if True:\r\n        pass"
+  selections:
+    - anchor: {line: 1, character: 4}
+      active: {line: 1, character: 4}
+  marks: {}
+finalState:
+  documentContents: "def whatever():\r\n    if True:\r\n        pass\r\n    "
+  selections:
+    - anchor: {line: 3, character: 4}
+      active: {line: 3, character: 4}

--- a/packages/cursorless-vscode/src/ide/vscode/VscodeTextDocumentImpl.ts
+++ b/packages/cursorless-vscode/src/ide/vscode/VscodeTextDocumentImpl.ts
@@ -1,5 +1,12 @@
-import { Position, Range, TextDocument, TextLine } from "@cursorless/common";
 import {
+  EndOfLine,
+  Position,
+  Range,
+  TextDocument,
+  TextLine,
+} from "@cursorless/common";
+import {
+  fromVscodeEndOfLine,
   fromVscodePosition,
   toVscodePosition,
   toVscodeRange,
@@ -28,6 +35,10 @@ export class VscodeTextDocumentImpl implements TextDocument {
   get range(): Range {
     const { end } = this.document.lineAt(this.document.lineCount - 1).range;
     return new Range(0, 0, end.line, end.character);
+  }
+
+  get eol(): EndOfLine {
+    return fromVscodeEndOfLine(this.document.eol);
   }
 
   constructor(private document: vscode.TextDocument) {}


### PR DESCRIPTION
## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet
