### PR TITLE
Enable explicit gray color for default hats

### DIFF
--- a/cursorless-talon/src/marks/mark.py
+++ b/cursorless-talon/src/marks/mark.py
@@ -58,10 +58,14 @@ def cursorless_grapheme(m) -> str:
 
 
 @mod.capture(
-    rule="[{user.cursorless_hat_color}] [{user.cursorless_hat_shape}] <user.cursorless_grapheme>"
+    rule="[{user.cursorless_hat_color} | gray] [{user.cursorless_hat_shape}] <user.cursorless_grapheme>"
 )
 def cursorless_decorated_symbol(m) -> dict[str, Any]:
     """A decorated symbol"""
+    if m[0] == "gray":
+        actions.app.notify(
+            "The color 'gray' is the default and don't need to be spoken out loud. Just say 'take air' instead of 'take gray air'"
+        )
     hat_color = getattr(m, "cursorless_hat_color", "default")
     try:
         hat_style_name = f"{hat_color}-{m.cursorless_hat_shape}"

--- a/cursorless-talon/src/marks/mark.py
+++ b/cursorless-talon/src/marks/mark.py
@@ -64,7 +64,7 @@ def cursorless_decorated_symbol(m) -> dict[str, Any]:
     """A decorated symbol"""
     if m[0] == "gray":
         actions.app.notify(
-            "The color 'gray' is the default and don't need to be spoken out loud. Just say 'take air' instead of 'take gray air'"
+            "The color 'gray' is the default and doesn't need to be spoken out loud. Just say eg 'take air' instead of 'take gray air'"
         )
     hat_color = getattr(m, "cursorless_hat_color", "default")
     try:


### PR DESCRIPTION
Fixes #1511

## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet
