### PR TITLE
Restore CI notebook tests on windows

### DIFF
--- a/packages/cursorless-vscode-e2e/src/suite/crossCellsSetSelection.vscode.test.ts
+++ b/packages/cursorless-vscode-e2e/src/suite/crossCellsSetSelection.vscode.test.ts
@@ -6,12 +6,9 @@ import {
 import * as assert from "assert";
 import { window } from "vscode";
 import { endToEndTestSetup, sleepWithBackoff } from "../endToEndTestSetup";
-import { skipIfWindowsCi } from "./skipIfWindowsCi";
 
 // Check that setSelection is able to focus the correct cell
 suite("Cross-cell set selection", async function () {
-  // Skipped for now; see #1260
-  skipIfWindowsCi();
   endToEndTestSetup(this);
 
   test("Cross-cell set selection", runTest);

--- a/packages/cursorless-vscode-e2e/src/suite/editNewCell.vscode.test.ts
+++ b/packages/cursorless-vscode-e2e/src/suite/editNewCell.vscode.test.ts
@@ -8,12 +8,9 @@ import * as assert from "assert";
 import { window } from "vscode";
 import { endToEndTestSetup, sleepWithBackoff } from "../endToEndTestSetup";
 import { getPlainNotebookContents } from "../notebook";
-import { skipIfWindowsCi } from "./skipIfWindowsCi";
 
 // Check that setSelection is able to focus the correct cell
 suite("Edit new cell", async function () {
-  // Skipped for now; see #1260
-  skipIfWindowsCi();
   endToEndTestSetup(this);
 
   test("drink cell", () =>

--- a/packages/cursorless-vscode-e2e/src/suite/intraCellSetSelection.vscode.test.ts
+++ b/packages/cursorless-vscode-e2e/src/suite/intraCellSetSelection.vscode.test.ts
@@ -6,12 +6,9 @@ import * as assert from "assert";
 import { window } from "vscode";
 import { endToEndTestSetup, sleepWithBackoff } from "../endToEndTestSetup";
 import { runCursorlessCommand } from "@cursorless/vscode-common";
-import { skipIfWindowsCi } from "./skipIfWindowsCi";
 
 // Check that setSelection is able to focus the correct cell
 suite("Within cell set selection", async function () {
-  // Skipped for now; see #1260
-  skipIfWindowsCi();
   endToEndTestSetup(this);
 
   test("Within cell set selection", runTest);

--- a/packages/cursorless-vscode-e2e/src/suite/skipIfWindowsCi.ts
+++ b/packages/cursorless-vscode-e2e/src/suite/skipIfWindowsCi.ts
@@ -1,7 +1,0 @@
-export function skipIfWindowsCi() {
-  suiteSetup(function () {
-    if (process.env.RUNNER_OS === "Windows" && process.env.CI === "true") {
-      this.skip();
-    }
-  });
-}


### PR DESCRIPTION
Fixes #1260

I have now run the windows tests five times and everything appears to be working. If we run into any future problems this vscode command might be useful
`workbench.action.revertAndCloseActiveEditor`

## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet
