### PR TITLE
Add Go support to snippets

### DIFF
--- a/cursorless-snippets/functionDeclaration.cursorless-snippets
+++ b/cursorless-snippets/functionDeclaration.cursorless-snippets
@@ -50,6 +50,23 @@
       {
         "scope": {
           "langIds": [
+            "go"
+          ]
+        },
+        "body": [
+          "func $name($parameterList) {",
+          "\t$body",
+          "}"
+        ],
+        "variables": {
+          "name": {
+            "formatter": "camelCase"
+          }
+        }
+      },
+      {
+        "scope": {
+          "langIds": [
             "python"
           ]
         },

--- a/cursorless-snippets/ifElseStatement.cursorless-snippets
+++ b/cursorless-snippets/ifElseStatement.cursorless-snippets
@@ -26,6 +26,20 @@
       {
         "scope": {
           "langIds": [
+            "go"
+          ]
+        },
+        "body": [
+          "if $condition {",
+          "\t$consequence",
+          "} else {",
+          "\t$alternative",
+          "}"
+        ]
+      },
+      {
+        "scope": {
+          "langIds": [
             "python"
           ]
         },

--- a/cursorless-snippets/ifStatement.cursorless-snippets
+++ b/cursorless-snippets/ifStatement.cursorless-snippets
@@ -24,6 +24,18 @@
       {
         "scope": {
           "langIds": [
+            "go"
+          ]
+        },
+        "body": [
+          "if $condition {",
+          "\t$consequence",
+          "}"
+        ]
+      },
+      {
+        "scope": {
+          "langIds": [
             "python"
           ]
         },


### PR DESCRIPTION
This brings Go support to all appropriate built-in cursorless snippets. Go is tantalizingly close to typescript, but just different enough to need its own bodies.

## Checklist

- [n/a] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [n/a] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [n/a] I have not broken the cheatsheet
