### PR TITLE
Revert "Restore CI notebook tests on windows (#1581)"

### DIFF
--- a/packages/cursorless-vscode-e2e/src/suite/crossCellsSetSelection.vscode.test.ts
+++ b/packages/cursorless-vscode-e2e/src/suite/crossCellsSetSelection.vscode.test.ts
@@ -6,9 +6,12 @@ import {
 import * as assert from "assert";
 import { window } from "vscode";
 import { endToEndTestSetup, sleepWithBackoff } from "../endToEndTestSetup";
+import { skipIfWindowsCi } from "./skipIfWindowsCi";
 
 // Check that setSelection is able to focus the correct cell
 suite("Cross-cell set selection", async function () {
+  // Skipped for now; see #1260
+  skipIfWindowsCi();
   endToEndTestSetup(this);
 
   test("Cross-cell set selection", runTest);

--- a/packages/cursorless-vscode-e2e/src/suite/editNewCell.vscode.test.ts
+++ b/packages/cursorless-vscode-e2e/src/suite/editNewCell.vscode.test.ts
@@ -8,9 +8,12 @@ import * as assert from "assert";
 import { window } from "vscode";
 import { endToEndTestSetup, sleepWithBackoff } from "../endToEndTestSetup";
 import { getPlainNotebookContents } from "../notebook";
+import { skipIfWindowsCi } from "./skipIfWindowsCi";
 
 // Check that setSelection is able to focus the correct cell
 suite("Edit new cell", async function () {
+  // Skipped for now; see #1260
+  skipIfWindowsCi();
   endToEndTestSetup(this);
 
   test("drink cell", () =>

--- a/packages/cursorless-vscode-e2e/src/suite/intraCellSetSelection.vscode.test.ts
+++ b/packages/cursorless-vscode-e2e/src/suite/intraCellSetSelection.vscode.test.ts
@@ -6,9 +6,12 @@ import * as assert from "assert";
 import { window } from "vscode";
 import { endToEndTestSetup, sleepWithBackoff } from "../endToEndTestSetup";
 import { runCursorlessCommand } from "@cursorless/vscode-common";
+import { skipIfWindowsCi } from "./skipIfWindowsCi";
 
 // Check that setSelection is able to focus the correct cell
 suite("Within cell set selection", async function () {
+  // Skipped for now; see #1260
+  skipIfWindowsCi();
   endToEndTestSetup(this);
 
   test("Within cell set selection", runTest);

--- a/packages/cursorless-vscode-e2e/src/suite/skipIfWindowsCi.ts
+++ b/packages/cursorless-vscode-e2e/src/suite/skipIfWindowsCi.ts
@@ -1,0 +1,7 @@
+export function skipIfWindowsCi() {
+  suiteSetup(function () {
+    if (process.env.RUNNER_OS === "Windows" && process.env.CI === "true") {
+      this.skip();
+    }
+  });
+}


### PR DESCRIPTION
This reverts commit 34d56721a2b943360a441aeafbeeb03a7a2aed26 (#1581) because CI started failing.  See eg

- https://github.com/cursorless-dev/cursorless/actions/runs/5488035451/jobs/10000317419
- https://github.com/cursorless-dev/cursorless/actions/runs/5488386069/jobs/10001169135



## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet
