### PR TITLE
Made jsx attributes be referable as item

### DIFF
--- a/packages/cursorless-engine/src/languages/typescript.ts
+++ b/packages/cursorless-engine/src/languages/typescript.ts
@@ -161,6 +161,7 @@ const nodeMatchers: Partial<
   map: mapTypes,
   list: listTypes,
   string: ["string", "template_string"],
+  collectionItem: "jsx_attribute",
   collectionKey: trailingMatcher(
     [
       "pair[key]",

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/typescript/clearEveryItem.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/typescript/clearEveryItem.yml
@@ -1,0 +1,24 @@
+languageId: javascriptreact
+command:
+  version: 5
+  spokenForm: clear every item
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: everyScope
+          scopeType: {type: collectionItem}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: <Button data-testid="Action Button" data-variant="bare"></Button>
+  selections:
+    - anchor: {line: 0, character: 8}
+      active: {line: 0, character: 8}
+  marks: {}
+finalState:
+  documentContents: <Button  ></Button>
+  selections:
+    - anchor: {line: 0, character: 8}
+      active: {line: 0, character: 8}
+    - anchor: {line: 0, character: 9}
+      active: {line: 0, character: 9}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/typescript/clearItem4.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/typescript/clearItem4.yml
@@ -1,0 +1,22 @@
+languageId: javascriptreact
+command:
+  version: 5
+  spokenForm: clear item
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: collectionItem}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: <Button data-testid="Action Button" data-variant="bare"></Button>
+  selections:
+    - anchor: {line: 0, character: 8}
+      active: {line: 0, character: 8}
+  marks: {}
+finalState:
+  documentContents: <Button  data-variant="bare"></Button>
+  selections:
+    - anchor: {line: 0, character: 8}
+      active: {line: 0, character: 8}


### PR DESCRIPTION
Fixes #912

## Checklist

- [x] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet
