### PR TITLE
Delete ts cache on clean

### DIFF
--- a/packages/cheatsheet-local/package.json
+++ b/packages/cheatsheet-local/package.json
@@ -11,7 +11,7 @@
     "build": "pnpm build:prod",
     "build:dev": "pnpm webpack --mode=development",
     "build:prod": "pnpm webpack --mode=production --node-env=production",
-    "clean": "rm -rf ./out"
+    "clean": "rm -rf ./out tsconfig.tsbuildinfo"
   },
   "keywords": [],
   "author": "",

--- a/packages/cheatsheet/package.json
+++ b/packages/cheatsheet/package.json
@@ -7,7 +7,7 @@
     "test": "jest",
     "compile": "tsc --build",
     "watch": "tsc --build --watch",
-    "clean": "rm -rf ./out"
+    "clean": "rm -rf ./out tsconfig.tsbuildinfo"
   },
   "keywords": [],
   "author": "",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "compile": "tsc --build",
     "watch": "tsc --build --watch",
-    "clean": "rm -rf ./out"
+    "clean": "rm -rf ./out tsconfig.tsbuildinfo"
   },
   "keywords": [],
   "author": "",

--- a/packages/cursorless-engine/package.json
+++ b/packages/cursorless-engine/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "compile": "tsc --build",
     "watch": "tsc --build --watch",
-    "clean": "rm -rf ./out"
+    "clean": "rm -rf ./out tsconfig.tsbuildinfo"
   },
   "keywords": [],
   "author": "",

--- a/packages/cursorless-org-docs/package.json
+++ b/packages/cursorless-org-docs/package.json
@@ -15,7 +15,7 @@
     "write-heading-ids": "docusaurus write-heading-ids",
     "compile": "tsc --build",
     "watch": "tsc --build --watch",
-    "clean": "rm -rf ./out"
+    "clean": "rm -rf ./out tsconfig.tsbuildinfo"
   },
   "dependencies": {
     "@algolia/client-search": "4.15.0",

--- a/packages/cursorless-org/package.json
+++ b/packages/cursorless-org/package.json
@@ -10,7 +10,7 @@
     "lint": "next lint",
     "compile": "tsc --build",
     "watch": "tsc --build --watch",
-    "clean": "rm -rf ./out"
+    "clean": "rm -rf ./out tsconfig.tsbuildinfo"
   },
   "dependencies": {
     "@cursorless/cheatsheet": "workspace:*",

--- a/packages/cursorless-vscode-e2e/package.json
+++ b/packages/cursorless-vscode-e2e/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "compile": "tsc --build",
     "watch": "tsc --build --watch",
-    "clean": "rm -rf ./out"
+    "clean": "rm -rf ./out tsconfig.tsbuildinfo"
   },
   "keywords": [],
   "author": "",

--- a/packages/cursorless-vscode/package.json
+++ b/packages/cursorless-vscode/package.json
@@ -846,7 +846,7 @@
     "hat-adjustment-average": "tsx --conditions=cursorless:bundler src/scripts/hatAssignments/add.ts",
     "compile": "tsc --build",
     "watch": "tsc --build --watch",
-    "clean": "rm -rf ./out"
+    "clean": "rm -rf ./out tsconfig.tsbuildinfo"
   },
   "devDependencies": {
     "@types/chai": "^4.3.3",

--- a/packages/meta-updater/package.json
+++ b/packages/meta-updater/package.json
@@ -7,7 +7,7 @@
     "build": "esbuild ./src/index.ts --conditions=cursorless:bundler --bundle --outfile=dist/index.cjs --format=cjs --platform=node",
     "compile": "tsc --build",
     "watch": "tsc --build --watch",
-    "clean": "rm -rf ./out"
+    "clean": "rm -rf ./out tsconfig.tsbuildinfo"
   },
   "dependencies": {
     "@cursorless/common": "workspace:*",

--- a/packages/meta-updater/src/updatePackageJson.ts
+++ b/packages/meta-updater/src/updatePackageJson.ts
@@ -64,7 +64,7 @@ export async function updatePackageJson(
   const extraScripts = isRoot
     ? {}
     : {
-        clean: "rm -rf ./out",
+        clean: "rm -rf ./out tsconfig.tsbuildinfo",
       };
 
   return {

--- a/packages/test-harness/package.json
+++ b/packages/test-harness/package.json
@@ -8,7 +8,7 @@
     "test": "env CURSORLESS_TEST=true tsx --conditions=cursorless:bundler src/scripts/runTestsCI.ts",
     "compile": "tsc --build",
     "watch": "tsc --build --watch",
-    "clean": "rm -rf ./out"
+    "clean": "rm -rf ./out tsconfig.tsbuildinfo"
   },
   "keywords": [],
   "author": "",

--- a/packages/vscode-common/package.json
+++ b/packages/vscode-common/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "compile": "tsc --build",
     "watch": "tsc --build --watch",
-    "clean": "rm -rf ./out"
+    "clean": "rm -rf ./out tsconfig.tsbuildinfo"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
This is necessary to reset the ts cache; otherwise it will still think that the generated files are there and won't build them after we clean

## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet
