### PR TITLE
implement "visible" scope

### DIFF
--- a/cursorless-talon/src/modifiers/scopes.py
+++ b/cursorless-talon/src/modifiers/scopes.py
@@ -78,6 +78,7 @@ scope_types = {
     "short paint": "boundedNonWhitespaceSequence",
     "link": "url",
     "cell": "notebookCell",
+    "visible": "visible",
 }
 
 

--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -337,6 +337,7 @@ We have experimental support for prefixing a command with `"from <target>"` to n
 
 - `"from funk take every instance air"`: selects all instances of the token with a hat over the letter `a` in the current function
 - `"from air take next instance bat"`: selects the next instance of the token with a hat over the letter `b` starting from the token with a hat over the letter `a`
+- `"from visible take every instance drum"`: selects all instances of the token with a hat over the letter `d` that are currently visible in the editor
 
 Note that the `"from"` modifier is not enabled by default; you must remove the `-` at the start of the line starting with `-from` in your `experimental/experimental_actions.csv` [settings csv](./customization.md). Note also that this feature is considered experimental and may change in the future.
 

--- a/docs/user/experimental/keyboard/modal.md
+++ b/docs/user/experimental/keyboard/modal.md
@@ -59,6 +59,7 @@ To bind keys that do not have modifiers (eg just pressing `a`), add entries like
     "ss": "boundedNonWhitespaceSequence",
     "sa": "argumentOrParameter",
     "sl": "url",
+    "vz": "visible",
   },
   "cursorless.experimental.keyboard.modal.keybindings.actions": {
     "t": "setSelection",

--- a/packages/cheatsheet/src/lib/sampleSpokenFormInfos/defaults.json
+++ b/packages/cheatsheet/src/lib/sampleSpokenFormInfos/defaults.json
@@ -1465,6 +1465,16 @@
           ]
         },
         {
+          "id": "visible",
+          "type": "scopeType",
+          "variations": [
+            {
+              "spokenForm": "visible",
+              "description": "Visible content in editor"
+            }
+          ]
+        },
+        {
           "id": "word",
           "type": "scopeType",
           "variations": [

--- a/packages/common/src/types/command/PartialTargetDescriptor.types.ts
+++ b/packages/common/src/types/command/PartialTargetDescriptor.types.ts
@@ -131,7 +131,8 @@ export type SimpleScopeTypeType =
   | "nonWhitespaceSequence"
   | "boundedNonWhitespaceSequence"
   | "url"
-  | "notebookCell";
+  | "notebookCell"
+  | "visible";
 
 export interface SimpleScopeType {
   type: SimpleScopeTypeType;

--- a/packages/cursorless-engine/src/processTargets/modifiers/scopeHandlers/ScopeHandlerFactoryImpl.ts
+++ b/packages/cursorless-engine/src/processTargets/modifiers/scopeHandlers/ScopeHandlerFactoryImpl.ts
@@ -3,6 +3,7 @@ import {
   CharacterScopeHandler,
   CustomRegexScopeHandler,
   DocumentScopeHandler,
+  VisibleScopeHandler,
   IdentifierScopeHandler,
   LineScopeHandler,
   NonWhitespaceSequenceScopeHandler,
@@ -60,6 +61,8 @@ export class ScopeHandlerFactoryImpl implements ScopeHandlerFactory {
         return new ParagraphScopeHandler(scopeType, languageId);
       case "document":
         return new DocumentScopeHandler(scopeType, languageId);
+      case "visible":
+        return new VisibleScopeHandler(scopeType, languageId);
       case "oneOf":
         return OneOfScopeHandler.create(this, scopeType, languageId);
       case "nonWhitespaceSequence":

--- a/packages/cursorless-engine/src/processTargets/modifiers/scopeHandlers/VisibleScopeHandler.ts
+++ b/packages/cursorless-engine/src/processTargets/modifiers/scopeHandlers/VisibleScopeHandler.ts
@@ -1,0 +1,35 @@
+import { TextEditor, Position } from "@cursorless/common";
+import { Direction, ScopeType } from "@cursorless/common";
+import { PlainTarget } from "../../targets";
+import BaseScopeHandler from "./BaseScopeHandler";
+import { TargetScope } from "./scope.types";
+
+export default class VisibleScopeHandler extends BaseScopeHandler {
+  public readonly scopeType = { type: "visible" } as const;
+  public readonly iterationScopeType = { type: "document" } as const;
+  protected readonly isHierarchical = false;
+
+  constructor(_scopeType: ScopeType, _languageId: string) {
+    super();
+  }
+
+  protected *generateScopeCandidates(
+    editor: TextEditor,
+    _position: Position,
+    _direction: Direction,
+  ): Iterable<TargetScope> {
+    yield {
+      editor,
+      domain: editor.document.range,
+      getTargets: (isReversed) =>
+        editor.visibleRanges.map(
+          (range) =>
+            new PlainTarget({
+              editor,
+              isReversed,
+              contentRange: range,
+            }),
+        ),
+    };
+  }
+}

--- a/packages/cursorless-engine/src/processTargets/modifiers/scopeHandlers/index.ts
+++ b/packages/cursorless-engine/src/processTargets/modifiers/scopeHandlers/index.ts
@@ -19,6 +19,7 @@ export * from "./ParagraphScopeHandler";
 export { default as ParagraphScopeHandler } from "./ParagraphScopeHandler";
 export * from "./SentenceScopeHandler/SentenceScopeHandler";
 export { default as SentenceScopeHandler } from "./SentenceScopeHandler/SentenceScopeHandler";
+export { default as VisibleScopeHandler } from "./VisibleScopeHandler";
 export * from "./RegexScopeHandler";
 export * from "./ScopeHandlerFactory";
 export * from "./ScopeHandlerFactoryImpl";

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/scopes/visible/changeVisible.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/scopes/visible/changeVisible.yml
@@ -1,0 +1,23 @@
+languageId: plaintext
+command:
+  version: 6
+  spokenForm: change visible
+  action:
+    name: clearAndSetSelection
+    target:
+      type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: visible}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: abc
+  selections:
+    - anchor: {line: 0, character: 3}
+      active: {line: 0, character: 3}
+  marks: {}
+finalState:
+  documentContents: ""
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}

--- a/packages/cursorless-vscode/package.json
+++ b/packages/cursorless-vscode/package.json
@@ -776,6 +776,7 @@
               "notebookCell",
               "paragraph",
               "document",
+              "visible",
               "character",
               "word",
               "boundedNonWhitespaceSequence",

--- a/schemas/cursorless-snippets.json
+++ b/schemas/cursorless-snippets.json
@@ -117,6 +117,7 @@
         "notebookCell",
         "paragraph",
         "document",
+        "visible",
         "character",
         "word",
         "nonWhitespaceSequence",


### PR DESCRIPTION
Some progress! But definitely not working yet.

Very much :confused_dog: here. Would love some help,
ideally live at the next community meeting that I can attend.
No need to look at this in advance.

Things to discuss (notes to self):

* seems like containment = null is correct for "visible" 
  scope, and it seems like that's what the code says, 
  but...vscode begs to differ. halp?
  - we yield multiple ranges but only one gets used
  - if primary cursor is offscreen, we get an error 
    indicating that the range is not found
* definition of visible: i propose we leave it up to 
  VSCode, which mean does not include folded or partially 
  visible lines. the value of visible is that it does 
  exactly what it says on the tin.
* testing strategy: use lots of newlines?
* did I find all the places that need updating?


Fixes #1607