### PR TITLE
fix syntax in Go test

### DIFF
--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/go/takeMap.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/go/takeMap.yml
@@ -7,13 +7,13 @@ command:
     - type: primitive
       modifier: {type: containingScope, scopeType: map, includeSiblings: false}
 initialState:
-  documentContents: x := map[string]string{"a", "b"}
+  documentContents: "x := map[string]string{\"a\": \"b\"}"
   selections:
     - anchor: {line: 0, character: 24}
       active: {line: 0, character: 24}
   marks: {}
 finalState:
-  documentContents: x := map[string]string{"a", "b"}
+  documentContents: "x := map[string]string{\"a\": \"b\"}"
   selections:
     - anchor: {line: 0, character: 5}
       active: {line: 0, character: 32}


### PR DESCRIPTION
The existing code snippet is not valid Go code. This doesn't matter at the moment, but it will soon as we rework Go scopes. Fix it.



## Checklist

- [x] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [x] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [x] I have not broken the cheatsheet
