### PR TITLE
don't override file.exclude and search.exclude

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,11 +1,5 @@
-// Place your settings in this file to overwrite default and user settings.
+// Place settings in this file to overwrite default end user settings.
 {
-  "files.exclude": {
-    "out": false // set this to true to hide the "out" folder with the compiled JS files
-  },
-  "search.exclude": {
-    "out": true // set this to false to include "out" folder in search results
-  },
   "python.formatting.provider": "black",
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   // Turn off tsc task auto detection since we have the necessary tasks as npm scripts


### PR DESCRIPTION
This is more likely to be a user preference than a Cursorless preference.

This is why out files were showing up during the live coding during the meetup.



## Checklist

- [x] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [x] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [x] I have not broken the cheatsheet
