### PR TITLE
fix inverted score in hatOldTokenRank

### DIFF
--- a/packages/cursorless-engine/src/util/allocateHats/HatMetrics.ts
+++ b/packages/cursorless-engine/src/util/allocateHats/HatMetrics.ts
@@ -33,7 +33,7 @@ export function hatOldTokenRank(
       hatStyle: style,
     });
 
-    return hatOldTokenRank == null ? Infinity : hatOldTokenRank;
+    return hatOldTokenRank == null ? Infinity : -hatOldTokenRank;
   };
 }
 


### PR DESCRIPTION
hatOldTokenRank decides which token, if any, to steal a hat from.
The goal is to steal a hat from the token that is least important.
As written, the code steals the hat from the token that is most important,
but only when there are no completely free hats available.
Fix that.

This does not happen often in practice.
This commit will have minimal impact on user experience.
The main benefit is avoiding future confusion over the code,
and being more robust if surrounding parts of the code change.



## Checklist

- [/] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [/] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [/] I have not broken the cheatsheet
