### PR TITLE
document short paint

### DIFF
--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -311,6 +311,25 @@ foo.bar baz|bongo
 
 Saying `"every paint"` would select `foo.bar` and `baz|bongo`.
 
+##### `"short paint"`
+
+The `"short paint"` modifier will expand the target forward and backward until it hits whitespace or a [surrounding pair](#surrounding-pair) delimiter.
+`"short paint"` will expand over pair delimeters that do not surround the premodified target;
+
+With the text `(aaa[bbb]ccc ddd)` ...
+
+- `"take short paint air"` would select `aaa[bbb]ccc`.
+  - The target starts as `aaa`.
+  - Trying to expand to the left, we immediately hit a `(`, which is part of a paren pair that surrounds the original `aaa`, so that stops leftward expansion.
+  - Trying to expand to the right, we hit a `[`, and that pair of square brackets does not surround the original `aaa`, so rightward expansion continues.
+  - Rightward expansion continues over the `ccc`, then hits a space and stops.
+- `"take short paint square"` would select `aaa[bbb]ccc`.
+  - The target starts as `[`.
+  - The expansion is not stopped by either the square brackets because they do not surround themselves.
+- `"take short paint bat"` would select `bbb`.
+  - The target starts as `bbb`.
+  - The expansion is stopped by the square packets that surround `bbb`.
+
 ##### `"instance"`
 
 The `"instance"` modifier searches for occurrences of the text of the target. For example:

--- a/packages/cheatsheet/src/lib/sampleSpokenFormInfos/defaults.json
+++ b/packages/cheatsheet/src/lib/sampleSpokenFormInfos/defaults.json
@@ -1104,7 +1104,7 @@
           "variations": [
             {
               "spokenForm": "short paint",
-              "description": "Bounded non whitespace sequence"
+              "description": "Non whitespace sequence stopped by surrounding pair delimeters"
             }
           ]
         },


### PR DESCRIPTION
For #839 and #1549.

Added a section about "short paint" in main reference page.  Improved explanation in cheatsheet.

## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [X] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [X] I have not broken the cheatsheet
