### PR TITLE
Fix pre-commit step name

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,8 +65,8 @@ repos:
         entry: pnpm transform-recorded-tests
   - repo: local
     hooks:
-      - id: format-recorded-tests
-        name: format-recorded-tests
+      - id: check-recorded-test-marks
+        name: check-recorded-test-marks
         files: ^packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/.*/[^/]*\.yml$
         language: system
         entry: pnpm transform-recorded-tests --check-marks


### PR DESCRIPTION
Fixing copy-paste error that resulted in duplicate pre-commit test step name

## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet
