### PR TITLE
migrate Go scopes map and list to treesitter

### DIFF
--- a/data/playground/go/go.mod
+++ b/data/playground/go/go.mod
@@ -1,0 +1,3 @@
+module cursorless.org
+
+go 1.20

--- a/data/playground/go/maps_and_lists.go
+++ b/data/playground/go/maps_and_lists.go
@@ -1,0 +1,33 @@
+package p
+
+type S struct {
+	one, a int
+}
+
+type (
+	A  [2]any
+	AA [3]A
+	AS [2]S
+	M  map[any]int
+)
+
+const one = 1
+
+func mapsAndLists() {
+	_ = A{}
+	_ = A{1}
+	_ = A{1, 2}
+	_ = A{1: 1}
+	_ = S{a: 1}
+	_ = M{"a": 1}
+	_ = M{"a": 1, 1: 1}
+	_ = AS{{}}
+	_ = AA{{1}}
+	_ = AS{{a: 1}}
+	_ = AA{{1}, {one: 1}}
+	_ = AA{{1}, {}, {one: 1}}
+	_ = &A{}
+	_ = &A{1}
+	_ = &A{one: 1}
+	_ = &A{1: 1}
+}

--- a/data/playground/go/statements.go
+++ b/data/playground/go/statements.go
@@ -1,0 +1,67 @@
+package p
+
+import (
+	"errors"
+	"fmt"
+)
+
+func statements() error {
+	fmt.Println("hello")
+	if b := false; b {
+		return nil
+	}
+	c := make(chan int, 1)
+	c <- 1
+	<-c
+	var x int
+	x = 1
+	x++
+	{
+		type T int
+		const two T = 2
+		var x T = 1
+		x--
+		x /= two
+	}
+	for {
+		break
+	}
+	defer func() {
+		recover()
+	}()
+	go func() {
+		fmt.Println("concurrency is not parallelism")
+	}()
+	var a any = "how long is a piece of me?"
+	switch a := a.(type) {
+	case int:
+		panic("wow")
+	default:
+		_ = a
+	}
+	switch {
+	case x != 2:
+		fallthrough
+	case x == 1:
+		break
+	}
+Again:
+	switch x {
+	case 1:
+		x &= 1
+		goto Again
+	case 2:
+		return fmt.Errorf("%v", x*2+x/3)
+	}
+Label:
+	for x := 0; x < 10; x++ {
+		if x == 0 {
+			continue
+		}
+		if x == 1 {
+			break Label
+		}
+		fmt.Println(x)
+	}
+	return errors.New("error")
+}

--- a/packages/cursorless-engine/src/languages/go.ts
+++ b/packages/cursorless-engine/src/languages/go.ts
@@ -11,8 +11,6 @@ import { SimpleScopeTypeType } from "@cursorless/common";
 const nodeMatchers: Partial<
   Record<SimpleScopeTypeType, NodeMatcherAlternative>
 > = {
-  map: "composite_literal",
-  list: ["composite_literal", "slice_type", "array_type"],
   ifStatement: "if_statement",
   functionCall: ["call_expression", "composite_literal"],
   functionCallee: ["call_expression[function]", "composite_literal[type]"],

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/go/changeListOne.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/go/changeListOne.yml
@@ -1,0 +1,27 @@
+languageId: go
+command:
+  version: 6
+  spokenForm: change list one
+  action:
+    name: clearAndSetSelection
+    target:
+      type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: list}
+      mark: {type: decoratedSymbol, symbolColor: default, character: '1'}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: _ = T{{1}}
+  selections:
+    - anchor: {line: 0, character: 10}
+      active: {line: 0, character: 10}
+  marks:
+    default.1:
+      start: {line: 0, character: 7}
+      end: {line: 0, character: 8}
+finalState:
+  documentContents: _ = T{}
+  selections:
+    - anchor: {line: 0, character: 6}
+      active: {line: 0, character: 6}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/go/changeListOne2.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/go/changeListOne2.yml
@@ -1,0 +1,27 @@
+languageId: go
+command:
+  version: 6
+  spokenForm: change list one
+  action:
+    name: clearAndSetSelection
+    target:
+      type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: list}
+      mark: {type: decoratedSymbol, symbolColor: default, character: '1'}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: "_ = T{{1, 2: \"a\"}}"
+  selections:
+    - anchor: {line: 0, character: 18}
+      active: {line: 0, character: 18}
+  marks:
+    default.1:
+      start: {line: 0, character: 7}
+      end: {line: 0, character: 8}
+finalState:
+  documentContents: _ = T{}
+  selections:
+    - anchor: {line: 0, character: 6}
+      active: {line: 0, character: 6}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/go/changeListTrap.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/go/changeListTrap.yml
@@ -1,0 +1,27 @@
+languageId: go
+command:
+  version: 6
+  spokenForm: change list trap
+  action:
+    name: clearAndSetSelection
+    target:
+      type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: list}
+      mark: {type: decoratedSymbol, symbolColor: default, character: t}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: _ = &T{}
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  marks:
+    default.t:
+      start: {line: 0, character: 5}
+      end: {line: 0, character: 6}
+finalState:
+  documentContents: "_ = "
+  selections:
+    - anchor: {line: 0, character: 4}
+      active: {line: 0, character: 4}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/go/changeListTrap2.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/go/changeListTrap2.yml
@@ -1,0 +1,27 @@
+languageId: go
+command:
+  version: 6
+  spokenForm: change list trap
+  action:
+    name: clearAndSetSelection
+    target:
+      type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: list}
+      mark: {type: decoratedSymbol, symbolColor: default, character: t}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: _ = &T{1}
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  marks:
+    default.t:
+      start: {line: 0, character: 5}
+      end: {line: 0, character: 6}
+finalState:
+  documentContents: "_ = "
+  selections:
+    - anchor: {line: 0, character: 4}
+      active: {line: 0, character: 4}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/go/changeListTrap3.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/go/changeListTrap3.yml
@@ -1,0 +1,27 @@
+languageId: go
+command:
+  version: 6
+  spokenForm: change list trap
+  action:
+    name: clearAndSetSelection
+    target:
+      type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: list}
+      mark: {type: decoratedSymbol, symbolColor: default, character: t}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: _ = T{}
+  selections:
+    - anchor: {line: 0, character: 7}
+      active: {line: 0, character: 7}
+  marks:
+    default.t:
+      start: {line: 0, character: 4}
+      end: {line: 0, character: 5}
+finalState:
+  documentContents: "_ = "
+  selections:
+    - anchor: {line: 0, character: 4}
+      active: {line: 0, character: 4}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/go/changeListTrap4.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/go/changeListTrap4.yml
@@ -1,0 +1,27 @@
+languageId: go
+command:
+  version: 6
+  spokenForm: change list trap
+  action:
+    name: clearAndSetSelection
+    target:
+      type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: list}
+      mark: {type: decoratedSymbol, symbolColor: default, character: t}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: "_ = T{1, 2: \"a\"}"
+  selections:
+    - anchor: {line: 0, character: 16}
+      active: {line: 0, character: 16}
+  marks:
+    default.t:
+      start: {line: 0, character: 4}
+      end: {line: 0, character: 5}
+finalState:
+  documentContents: "_ = "
+  selections:
+    - anchor: {line: 0, character: 4}
+      active: {line: 0, character: 4}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/go/changeListTwo.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/go/changeListTwo.yml
@@ -1,0 +1,27 @@
+languageId: go
+command:
+  version: 6
+  spokenForm: change list two
+  action:
+    name: clearAndSetSelection
+    target:
+      type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: list}
+      mark: {type: decoratedSymbol, symbolColor: default, character: '2'}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: "_ = T{{2: \"a\"}}"
+  selections:
+    - anchor: {line: 0, character: 15}
+      active: {line: 0, character: 15}
+  marks:
+    default.2:
+      start: {line: 0, character: 7}
+      end: {line: 0, character: 8}
+finalState:
+  documentContents: "_ = "
+  selections:
+    - anchor: {line: 0, character: 4}
+      active: {line: 0, character: 4}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/go/changeMapOne.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/go/changeMapOne.yml
@@ -1,0 +1,23 @@
+languageId: go
+command:
+  version: 6
+  spokenForm: change map one
+  action:
+    name: clearAndSetSelection
+    target:
+      type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: map}
+      mark: {type: decoratedSymbol, symbolColor: default, character: '1'}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: _ = T{{1}}
+  selections:
+    - anchor: {line: 0, character: 10}
+      active: {line: 0, character: 10}
+  marks:
+    default.1:
+      start: {line: 0, character: 7}
+      end: {line: 0, character: 8}
+thrownError: {name: NoContainingScopeError}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/go/changeMapOne2.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/go/changeMapOne2.yml
@@ -1,0 +1,27 @@
+languageId: go
+command:
+  version: 6
+  spokenForm: change map one
+  action:
+    name: clearAndSetSelection
+    target:
+      type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: map}
+      mark: {type: decoratedSymbol, symbolColor: default, character: '1'}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: "_ = T{{1, 2: \"a\"}}"
+  selections:
+    - anchor: {line: 0, character: 18}
+      active: {line: 0, character: 18}
+  marks:
+    default.1:
+      start: {line: 0, character: 7}
+      end: {line: 0, character: 8}
+finalState:
+  documentContents: _ = T{}
+  selections:
+    - anchor: {line: 0, character: 6}
+      active: {line: 0, character: 6}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/go/changeMapTrap.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/go/changeMapTrap.yml
@@ -1,0 +1,27 @@
+languageId: go
+command:
+  version: 6
+  spokenForm: change map trap
+  action:
+    name: clearAndSetSelection
+    target:
+      type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: map}
+      mark: {type: decoratedSymbol, symbolColor: default, character: t}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: _ = &T{}
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  marks:
+    default.t:
+      start: {line: 0, character: 5}
+      end: {line: 0, character: 6}
+finalState:
+  documentContents: "_ = "
+  selections:
+    - anchor: {line: 0, character: 4}
+      active: {line: 0, character: 4}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/go/changeMapTrap2.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/go/changeMapTrap2.yml
@@ -1,0 +1,27 @@
+languageId: go
+command:
+  version: 6
+  spokenForm: change map trap
+  action:
+    name: clearAndSetSelection
+    target:
+      type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: map}
+      mark: {type: decoratedSymbol, symbolColor: default, character: t}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: "_ = &T{a: 1}"
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  marks:
+    default.t:
+      start: {line: 0, character: 5}
+      end: {line: 0, character: 6}
+finalState:
+  documentContents: "_ = "
+  selections:
+    - anchor: {line: 0, character: 4}
+      active: {line: 0, character: 4}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/go/changeMapTrap3.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/go/changeMapTrap3.yml
@@ -1,0 +1,27 @@
+languageId: go
+command:
+  version: 6
+  spokenForm: change map trap
+  action:
+    name: clearAndSetSelection
+    target:
+      type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: map}
+      mark: {type: decoratedSymbol, symbolColor: default, character: t}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: _ = T{}
+  selections:
+    - anchor: {line: 0, character: 7}
+      active: {line: 0, character: 7}
+  marks:
+    default.t:
+      start: {line: 0, character: 4}
+      end: {line: 0, character: 5}
+finalState:
+  documentContents: "_ = "
+  selections:
+    - anchor: {line: 0, character: 4}
+      active: {line: 0, character: 4}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/go/changeMapTrap4.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/go/changeMapTrap4.yml
@@ -1,0 +1,27 @@
+languageId: go
+command:
+  version: 6
+  spokenForm: change map trap
+  action:
+    name: clearAndSetSelection
+    target:
+      type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: map}
+      mark: {type: decoratedSymbol, symbolColor: default, character: t}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: "_ = T{1, 2: \"a\"}"
+  selections:
+    - anchor: {line: 0, character: 16}
+      active: {line: 0, character: 16}
+  marks:
+    default.t:
+      start: {line: 0, character: 4}
+      end: {line: 0, character: 5}
+finalState:
+  documentContents: "_ = "
+  selections:
+    - anchor: {line: 0, character: 4}
+      active: {line: 0, character: 4}

--- a/queries/go.scm
+++ b/queries/go.scm
@@ -35,3 +35,150 @@
 ] @string @textFragment
 
 (comment) @comment @textFragment
+
+;; What should map and list refer to in Go programs?
+;;
+;; The obvious answer is that map should refer to map and struct composite literals,
+;; and that list should refer to slice and array composite literals.
+;;
+;; There are two problems with this answer.
+;;
+;;   * The type of a composite literal is a semantic, not a syntactic property of a program.
+;;       - What is the type of T{1: 2}? It could be array, map, or slice.
+;;       - What about T{a: 1}? It could be map or struct.
+;;       - What about T{1, 2}? It could be struct, array, or slice.
+;;     Cursorless only has syntactic information available to it.
+;;
+;;   * The user might not know the type either. With a named type, the type definition might be far away.
+;;     Or it might just be offscreen. Either way, the user needs to be able to make a decision about
+;;     what scope to use using only locally available, syntactic information.
+;;     Note that this also means that has-a predicates work better than has-no predicates.
+;;     The user can locally confirm that there is a keyed element.
+;;     She cannot confirm locally that there is no keyed element; it might just not be visible.
+;;
+;; Combining all these constraints suggests the following simple rules:
+;;
+;;   * If there is a keyed element present, then it is a map.
+;;   * If there is a non-keyed element present, then it is a list.
+;;   * If there are both or neither, then it is both a map and a list.
+;;
+;; Conveniently, this is also simple to implement.
+;;
+;; This guarantees that a user always knows how to refer to any composite literal.
+;; There are cases in which being overgenerous in matching is not ideal,
+;; but they are rarer, so let's optimize for the common case.
+;; Mixed keyed and non-keyed elements are also rare in practice.
+;; The main ambiguity is with {}, but there's little we can do about that.
+;;
+;; Go users also expect that the map and list scopes will include the type definition,
+;; as well as any & before the type. (Strictly speaking it is not part of the literal,
+;; but that's not how most humans think about it.)
+;;
+;; If you are considering changing the map and list scopes, take a look at the examples in
+;; data/playground/go/maps_and_lists.go, which cover a fairly wide variety of cases.
+
+;; maps
+
+;; &T{a: 1}
+(unary_expression
+  operator: "&"
+  (composite_literal
+    body: (literal_value
+      (keyed_element)
+    )
+  )
+) @map
+
+;; T{a: 1}
+(
+  (composite_literal
+    body: (literal_value
+      (keyed_element)
+    )
+  ) @map
+  (#not-parent-type? @map unary_expression)
+)
+
+;; {a: 1}
+(
+  (literal_value
+    (keyed_element)
+  ) @map
+  (#not-parent-type? @map composite_literal)
+)
+
+;; lists
+
+;; &T{1}
+(unary_expression
+  operator: "&"
+  (composite_literal
+    body: (literal_value
+      (literal_element)
+    )
+  )
+) @list
+
+;; T{1}
+(
+  (composite_literal
+    body: (literal_value
+      (literal_element)
+    )
+  ) @list
+  (#not-parent-type? @list unary_expression)
+)
+
+;; {1}
+(
+  (literal_value
+    (literal_element)
+  ) @list
+  (#not-parent-type? @list composite_literal)
+)
+
+;; empty composite literals
+;;
+;; each of these will fail to match { /* some comment */ }
+;; because the comment node will break the anchoring.
+;; this is rare enough to not be worth fixing now.
+
+;; &T{}
+(unary_expression
+  operator: "&"
+  (composite_literal
+    body: (literal_value
+      .
+      "{"
+      .
+      "}"
+      .
+    )
+  )
+) @list @map
+
+;; T{}
+(
+  (composite_literal
+    body: (literal_value
+      .
+      "{"
+      .
+      "}"
+      .
+    )
+  ) @list @map
+  (#not-parent-type? @list unary_expression)
+)
+
+;; {}
+(
+  (literal_value
+    .
+    "{"
+    .
+    "}"
+    .
+  ) @list @map
+  (#not-parent-type? @list composite_literal)
+)


### PR DESCRIPTION


## Checklist

- [x] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [/] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [/] I have not broken the cheatsheet
