### PR TITLE
Use simple syntax node for mutable query captures

### DIFF
--- a/packages/cursorless-engine/src/languages/TreeSitterQuery/QueryCapture.ts
+++ b/packages/cursorless-engine/src/languages/TreeSitterQuery/QueryCapture.ts
@@ -1,5 +1,19 @@
 import { Range } from "@cursorless/common";
-import { SyntaxNode } from "web-tree-sitter";
+import { Point } from "web-tree-sitter";
+
+/**
+ * Simple representation of the tree sitter syntax node. Used by
+ * {@link MutableQueryCapture} to avoid using range/text and other mutable
+ * parameters directly from the node.
+ */
+export interface SimpleSyntaxNode {
+  readonly id: number;
+  readonly type: string;
+  readonly startPosition: Point;
+  readonly endPosition: Point;
+  readonly parent: SimpleSyntaxNode | null;
+  readonly children: Array<SimpleSyntaxNode>;
+}
 
 /**
  * A capture of a query pattern against a syntax tree.  Often corresponds to a
@@ -39,11 +53,9 @@ export interface QueryMatch {
  */
 export interface MutableQueryCapture extends QueryCapture {
   /**
-   * The tree-sitter node that was captured. Note that the range may have already
-   * been altered by a prior operator, so please use {@link range} instead of
-   * trying to retrieve the range from the node.
+   * The tree-sitter node that was captured.
    */
-  readonly node: SyntaxNode;
+  readonly node: SimpleSyntaxNode;
 
   range: Range;
   allowMultiple: boolean;


### PR DESCRIPTION


## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet
