### PR TITLE
cheatsheet: Fix square corners extending past round corners

### DIFF
--- a/packages/cheatsheet/src/lib/components/CheatsheetLegendComponent.tsx
+++ b/packages/cheatsheet/src/lib/components/CheatsheetLegendComponent.tsx
@@ -20,7 +20,7 @@ export default function CheatsheetLegendComponent({
   return (
     <div
       id="legend"
-      className={`border ${borderClassName} rounded-lg bg-violet-100 dark:bg-violet-900`}
+      className={`border ${borderClassName} rounded-lg bg-violet-100 dark:bg-violet-900 overflow-hidden`}
     >
       <h2 className="text-xl text-center my-1 text-violet-900 dark:text-violet-100">
         Legend

--- a/packages/cheatsheet/src/lib/components/CheatsheetListComponent.tsx
+++ b/packages/cheatsheet/src/lib/components/CheatsheetListComponent.tsx
@@ -24,7 +24,7 @@ export default function CheatsheetListComponent({
   return (
     <div
       id={section.id}
-      className={`border ${borderClassName} rounded-lg bg-stone-100 dark:bg-stone-700`}
+      className={`border ${borderClassName} rounded-lg bg-stone-100 dark:bg-stone-700 overflow-hidden`}
     >
       <h2 className="text-xl text-center my-1">{section.name}</h2>
       <table className="w-full">

--- a/packages/cheatsheet/src/lib/components/CheatsheetNotesComponent.tsx
+++ b/packages/cheatsheet/src/lib/components/CheatsheetNotesComponent.tsx
@@ -5,7 +5,7 @@ export default function CheatsheetNotesComponent(): JSX.Element {
   return (
     <div
       id="notes"
-      className="p-2 border border-violet-300 dark:border-violet-500 rounded-lg bg-violet-100 dark:bg-violet-900"
+      className="p-2 border border-violet-300 dark:border-violet-500 rounded-lg bg-violet-100 dark:bg-violet-900 overflow-hidden"
     >
       <h2 className="text-xl text-center mb-1 text-violet-900 dark:text-violet-100">
         Notes


### PR DESCRIPTION
Before / after:

<img width="30" alt="image" src="https://github.com/cursorless-dev/cursorless/assets/755842/1fcdb2d8-a92c-445a-9a93-dfc7fa804756">

<img width="38" alt="image" src="https://github.com/cursorless-dev/cursorless/assets/755842/1c7c63ae-de85-4da6-859b-6bf2bd60d296">

## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet
