### PR TITLE
Remove positions from web cheatsheet

### DIFF
--- a/packages/cheatsheet/src/lib/sampleSpokenFormInfos/defaults.json
+++ b/packages/cheatsheet/src/lib/sampleSpokenFormInfos/defaults.json
@@ -1041,52 +1041,6 @@
       ]
     },
     {
-      "name": "Positions",
-      "id": "positions",
-      "items": [
-        {
-          "id": "after",
-          "type": "position",
-          "variations": [
-            {
-              "spokenForm": "after",
-              "description": "After"
-            }
-          ]
-        },
-        {
-          "id": "before",
-          "type": "position",
-          "variations": [
-            {
-              "spokenForm": "before",
-              "description": "Before"
-            }
-          ]
-        },
-        {
-          "id": "end",
-          "type": "position",
-          "variations": [
-            {
-              "spokenForm": "end of",
-              "description": "End"
-            }
-          ]
-        },
-        {
-          "id": "start",
-          "type": "position",
-          "variations": [
-            {
-              "spokenForm": "start of",
-              "description": "Start"
-            }
-          ]
-        }
-      ]
-    },
-    {
       "name": "Scope visualizer",
       "id": "scopeVisualizer",
       "items": [


### PR DESCRIPTION
I confirmed they don't show up locally, so just need to remove them here

## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet
