### PR TITLE
Fix `"item"` fallback for next-gen scope handlers

### DIFF
--- a/packages/cursorless-engine/src/processTargets/ModifierStageFactoryImpl.ts
+++ b/packages/cursorless-engine/src/processTargets/ModifierStageFactoryImpl.ts
@@ -32,10 +32,11 @@ import RelativeScopeStage from "./modifiers/RelativeScopeStage";
 import SurroundingPairStage from "./modifiers/SurroundingPairStage";
 import { ScopeHandlerFactory } from "./modifiers/scopeHandlers/ScopeHandlerFactory";
 import BoundedNonWhitespaceSequenceStage from "./modifiers/scopeTypeStages/BoundedNonWhitespaceStage";
-import ContainingSyntaxScopeStage, {
+import {
+  LegacyContainingSyntaxScopeStage,
   SimpleContainingScopeModifier,
   SimpleEveryScopeModifier,
-} from "./modifiers/scopeTypeStages/ContainingSyntaxScopeStage";
+} from "./modifiers/scopeTypeStages/LegacyContainingSyntaxScopeStage";
 import NotebookCellStage from "./modifiers/scopeTypeStages/NotebookCellStage";
 
 export class ModifierStageFactoryImpl implements ModifierStageFactory {
@@ -142,7 +143,7 @@ export class ModifierStageFactoryImpl implements ModifierStageFactory {
         );
       default:
         // Default to containing syntax scope using tree sitter
-        return new ContainingSyntaxScopeStage(
+        return new LegacyContainingSyntaxScopeStage(
           this.languageDefinitions,
           modifier as SimpleContainingScopeModifier | SimpleEveryScopeModifier,
         );

--- a/packages/cursorless-engine/src/processTargets/modifiers/ContainingScopeStage.ts
+++ b/packages/cursorless-engine/src/processTargets/modifiers/ContainingScopeStage.ts
@@ -54,6 +54,13 @@ export class ContainingScopeStage implements ModifierStage {
     );
 
     if (containingScope == null) {
+      if (scopeType.type === "collectionItem") {
+        // For `collectionItem`, fall back to generic implementation
+        return this.modifierStageFactory
+          .getLegacyScopeStage(this.modifier)
+          .run(target);
+      }
+
       throw new NoContainingScopeError(this.modifier.scopeType.type);
     }
 

--- a/packages/cursorless-engine/src/processTargets/modifiers/EveryScopeStage.ts
+++ b/packages/cursorless-engine/src/processTargets/modifiers/EveryScopeStage.ts
@@ -83,6 +83,13 @@ export class EveryScopeStage implements ModifierStage {
     }
 
     if (scopes.length === 0) {
+      if (scopeType.type === "collectionItem") {
+        // For `collectionItem`, fall back to generic implementation
+        return this.modifierStageFactory
+          .getLegacyScopeStage(this.modifier)
+          .run(target);
+      }
+
       throw new NoContainingScopeError(scopeType.type);
     }
 

--- a/packages/cursorless-engine/src/processTargets/modifiers/ItemStage/ItemStage.ts
+++ b/packages/cursorless-engine/src/processTargets/modifiers/ItemStage/ItemStage.ts
@@ -12,9 +12,10 @@ import { getInsertionDelimiter } from "../../../util/nodeSelectors";
 import { getRangeLength } from "../../../util/rangeUtils";
 import { ModifierStage } from "../../PipelineStages.types";
 import { ScopeTypeTarget } from "../../targets";
-import ContainingSyntaxScopeStage, {
+import {
+  LegacyContainingSyntaxScopeStage,
   SimpleContainingScopeModifier,
-} from "../scopeTypeStages/ContainingSyntaxScopeStage";
+} from "../scopeTypeStages/LegacyContainingSyntaxScopeStage";
 import { getIterationScope } from "./getIterationScope";
 import { tokenizeRange } from "./tokenizeRange";
 
@@ -27,7 +28,7 @@ export default class ItemStage implements ModifierStage {
   run(target: Target): Target[] {
     // First try the language specific implementation of item
     try {
-      return new ContainingSyntaxScopeStage(
+      return new LegacyContainingSyntaxScopeStage(
         this.languageDefinitions,
         this.modifier as SimpleContainingScopeModifier,
       ).run(target);

--- a/packages/cursorless-engine/src/processTargets/modifiers/scopeTypeStages/LegacyContainingSyntaxScopeStage.ts
+++ b/packages/cursorless-engine/src/processTargets/modifiers/scopeTypeStages/LegacyContainingSyntaxScopeStage.ts
@@ -25,7 +25,7 @@ export interface SimpleEveryScopeModifier extends EveryScopeModifier {
   scopeType: SimpleScopeType;
 }
 
-export default class implements ModifierStage {
+export class LegacyContainingSyntaxScopeStage implements ModifierStage {
   constructor(
     private languageDefinitions: LanguageDefinitions,
     private modifier: SimpleContainingScopeModifier | SimpleEveryScopeModifier,


### PR DESCRIPTION


## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet
