### PR TITLE
fix copy/paste error that breaks cheatsheet

### DIFF
--- a/cursorless-talon/src/cheatsheet/sections/special_marks.py
+++ b/cursorless-talon/src/cheatsheet/sections/special_marks.py
@@ -15,6 +15,6 @@ def get_special_marks():
     )
 
     return [
-        *get_lists(["special_mark", "unknown_symbol"], "mark"),
+        *get_lists(["simple_mark", "unknown_symbol"], "mark"),
         *line_direction_marks,
     ]


### PR DESCRIPTION
This got changed everywhere but here.



## Checklist

- [/] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [/] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [x] I have ~not broken~ fixed the cheatsheet
