### PR TITLE
cursorless_command("replaceWithTarget") fix

### DIFF
--- a/cursorless-talon-dev/src/cursorless_test.talon
+++ b/cursorless-talon-dev/src/cursorless_test.talon
@@ -5,6 +5,8 @@ tag: user.cursorless
 # For testing our public api
 test api command <user.cursorless_target>:
     user.cursorless_command("setSelection", cursorless_target)
+test api command bring <user.cursorless_target>:
+    user.cursorless_command("replaceWithTarget", cursorless_target)
 test api insert snippet:
     user.cursorless_insert_snippet("Hello, $foo!  My name is $bar!")
 test api insert snippet by name:

--- a/cursorless-talon/src/actions/actions.py
+++ b/cursorless-talon/src/actions/actions.py
@@ -87,7 +87,7 @@ class Actions:
         if action_name in callback_actions:
             callback_actions[action_name](target)
         elif action_name in ["replaceWithTarget", "moveToTarget"]:
-            actions.user.cursorless_bring_move(
+            actions.user.private_cursorless_bring_move(
                 action_name, BringMoveTargets(target, ImplicitDestination())
             )
         elif action_name in no_wait_actions:

--- a/packages/cursorless-engine/src/test/fixtures/talonApi.fixture.ts
+++ b/packages/cursorless-engine/src/test/fixtures/talonApi.fixture.ts
@@ -9,6 +9,14 @@ const setSelectionAction: ActionDescriptor = {
     mark: { type: "cursor" },
   },
 };
+const replaceWithTargetAction: ActionDescriptor = {
+  name: "replaceWithTarget",
+  source: {
+    type: "primitive",
+    mark: { type: "decoratedSymbol", symbolColor: "default", character: "a" },
+  },
+  destination: { type: "implicit" },
+};
 const insertSnippetAction: ActionDescriptor = {
   name: "insertSnippet",
   destination: { type: "implicit" },
@@ -57,6 +65,7 @@ const wrapWithSnippetByNameAction: ActionDescriptor = {
  */
 export const talonApiFixture = [
   spokenFormTest("test api command this", setSelectionAction),
+  spokenFormTest("test api command bring air", replaceWithTargetAction),
   spokenFormTest("test api insert snippet", insertSnippetAction),
   spokenFormTest("test api insert snippet by name", insertSnippetByNameAction),
   spokenFormTest("test api wrap with snippet this", wrapWithSnippetAction),


### PR DESCRIPTION
Fixes #1811

I have not added any Talon side tests. The reason for this is that the failing code path is not used with voice commands. You could only hit this bug by manually calling our public python api.

## Checklist

- [x] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [/] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [/] I have not broken the cheatsheet
