### PR TITLE
Added get targets action

### DIFF
--- a/packages/common/src/types/command/ActionDescriptor.ts
+++ b/packages/common/src/types/command/ActionDescriptor.ts
@@ -19,7 +19,6 @@ const simpleActionNames = [
   "findInWorkspace",
   "foldRegion",
   "followLink",
-  "private.getTargets",
   "indentLine",
   "insertCopyAfter",
   "insertCopyBefore",
@@ -47,6 +46,7 @@ const simpleActionNames = [
   "toggleLineBreakpoint",
   "toggleLineComment",
   "unfoldRegion",
+  "private.getTargets",
 ] as const;
 
 const complexActionNames = [

--- a/packages/common/src/types/command/ActionDescriptor.ts
+++ b/packages/common/src/types/command/ActionDescriptor.ts
@@ -19,6 +19,7 @@ const simpleActionNames = [
   "findInWorkspace",
   "foldRegion",
   "followLink",
+  "private.getTargets",
   "indentLine",
   "insertCopyAfter",
   "insertCopyBefore",

--- a/packages/cursorless-engine/src/actions/Actions.ts
+++ b/packages/cursorless-engine/src/actions/Actions.ts
@@ -12,6 +12,7 @@ import ExecuteCommand from "./ExecuteCommand";
 import { FindInWorkspace } from "./Find";
 import FollowLink from "./FollowLink";
 import GenerateSnippet from "./GenerateSnippet";
+import GetTargets from "./GetTargets";
 import GetText from "./GetText";
 import Highlight from "./Highlight";
 import {
@@ -144,4 +145,5 @@ export class Actions implements ActionRecord {
     this.snippets,
     this.modifierStageFactory,
   );
+  ["private.getTargets"] = new GetTargets();
 }

--- a/packages/cursorless-engine/src/actions/GetTargets.ts
+++ b/packages/cursorless-engine/src/actions/GetTargets.ts
@@ -1,0 +1,17 @@
+import { Target } from "../typings/target.types";
+import { ActionReturnValue, SimpleAction } from "./actions.types";
+
+export default class GetTargets implements SimpleAction {
+  constructor() {
+    this.run = this.run.bind(this);
+  }
+
+  async run(targets: Target[]): Promise<ActionReturnValue> {
+    return {
+      returnValue: targets.map(({ contentRange }) => ({
+        contentRange,
+      })),
+      thatTargets: targets,
+    };
+  }
+}

--- a/packages/cursorless-engine/src/generateSpokenForm/defaultSpokenForms/actions.ts
+++ b/packages/cursorless-engine/src/generateSpokenForm/defaultSpokenForms/actions.ts
@@ -60,6 +60,7 @@ export const actions = {
   executeCommand: null,
   getText: null,
   replace: null,
+  ["private.getTargets"]: null,
 
   // These actions are implemented talon-side, usually using `getText` followed
   // by some other action.

--- a/packages/cursorless-engine/src/generateSpokenForm/generateSpokenForm.ts
+++ b/packages/cursorless-engine/src/generateSpokenForm/generateSpokenForm.ts
@@ -56,6 +56,7 @@ function generateSpokenFormComponents(
     case "getText":
     case "replace":
     case "executeCommand":
+    case "private.getTargets":
       throw new NoSpokenFormError(`Action '${action.name}'`);
 
     case "replaceWithTarget":

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/actions/getTargetsBatAndCap.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/actions/getTargetsBatAndCap.yml
@@ -1,0 +1,52 @@
+languageId: plaintext
+command:
+  version: 6
+  spokenForm: get targets bat and cap
+  action:
+    name: private.getTargets
+    target:
+      type: list
+      elements:
+        - type: primitive
+          mark: {type: decoratedSymbol, symbolColor: default, character: b}
+        - type: primitive
+          mark: {type: decoratedSymbol, symbolColor: default, character: c}
+  usePrePhraseSnapshot: true
+spokenFormError: Action 'private.getTargets'
+initialState:
+  documentContents: a b c d
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  marks:
+    default.b:
+      start: {line: 0, character: 2}
+      end: {line: 0, character: 3}
+    default.c:
+      start: {line: 0, character: 4}
+      end: {line: 0, character: 5}
+finalState:
+  documentContents: a b c d
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  thatMark:
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 2}
+        end: {line: 0, character: 3}
+      isReversed: false
+      hasExplicitRange: false
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 4}
+        end: {line: 0, character: 5}
+      isReversed: false
+      hasExplicitRange: false
+returnValue:
+  - contentRange:
+      start: {line: 0, character: 2}
+      end: {line: 0, character: 3}
+  - contentRange:
+      start: {line: 0, character: 4}
+      end: {line: 0, character: 5}


### PR DESCRIPTION
Fixes #1820

```talon
info <user.cursorless_target>:
    target_info = user.private_cursorless_get_targets(cursorless_target)
    print(target_info)
```

```python
def private_cursorless_get_targets(target: Any) -> list[dict]:
        """Get information about Cursorless target"""
        return actions.user.private_cursorless_command_get(
            {
                "name": "private.getTargets",
                "target": target,
            }
        )
```

```json
[
    {"contentRange": {"start": {"line": 71, "character": 23}, "end": {"line": 71, "character": 53}}}
]
```

## Checklist

- [x] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [/] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [/] I have not broken the cheatsheet
