### PR TITLE
vscode: Recommend ruff extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,9 +3,10 @@
   // for the documentation about the extensions.json format
   "recommendations": [
     "AndreasArvidsson.andreas-talon",
+    "charliermarsh.ruff",
     "dbaeumer.vscode-eslint",
     "esbenp.prettier-vscode",
     "jrieken.vscode-tree-sitter-query",
-    "wenkokke.tree-sitter-talon"
+    "wenkokke.tree-sitter-talon",
   ]
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -7,6 +7,6 @@
     "dbaeumer.vscode-eslint",
     "esbenp.prettier-vscode",
     "jrieken.vscode-tree-sitter-query",
-    "wenkokke.tree-sitter-talon",
+    "wenkokke.tree-sitter-talon"
   ]
 }


### PR DESCRIPTION
We added `ruff` in #1375. There's a corresponding VSCode extension by the author, so probably a good idea to use it to surface lints earlier than pre-commit.

https://github.com/astral-sh/ruff-vscode

## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet
