### PR TITLE
migrate Go keys and values to treesitter

### DIFF
--- a/data/playground/go/values.go
+++ b/data/playground/go/values.go
@@ -1,0 +1,55 @@
+package p
+
+func returnZero() {
+	return
+}
+
+func returnOne() string {
+	return "lorem"
+}
+
+func returnOneWithCommentBefore() string {
+	return /* comment */ "lorem"
+}
+
+func returnOneWithCommentAfter() string {
+	return "lorem" /* comment */
+}
+
+
+func returnTwo() (string, string) {
+	return "lorem", "ipsum"
+}
+
+func returnTwoWithCommentInside() (string, string) {
+	return "lorem" /* comment */, "ipsum"
+}
+
+func returnTwoWithCommentBefore() (string, string) {
+	return /* comment */ "lorem", "ipsum"
+}
+
+func returnTwoWithCommentAfter() (string, string) {
+	return "lorem", "ipsum" /* comment */
+}
+
+
+func returnThree() (string, string, string) {
+	return "lorem", "ipsum", "blah"
+}
+
+func returnThreeWithCommentInside() (string, string, string) {
+	return "lorem" /* comment */, "ipsum", "blah"
+}
+
+func returnThreeWithCommentInside2() (string, string, string) {
+	return "lorem", "ipsum" /* comment */, "blah"
+}
+
+func returnThreeWithCommentBefore() (string, string, string) {
+	return /* comment */ "lorem", "ipsum", "blah"
+}
+
+func returnThreeWithCommentAfter() (string, string, string) {
+	return "lorem", "ipsum", "blah" /* comment */
+}

--- a/packages/common/src/types/Position.ts
+++ b/packages/common/src/types/Position.ts
@@ -138,4 +138,16 @@ export class Position {
   public toEmptyRange(): Range {
     return new Range(this, this);
   }
+
+  /**
+   * Return a concise string representation of the position.
+   * @returns concise representation
+   **/
+  public concise(): string {
+    return `${this.line}:${this.character}`;
+  }
+
+  public toString(): string {
+    return this.concise();
+  }
 }

--- a/packages/common/src/types/Range.ts
+++ b/packages/common/src/types/Range.ts
@@ -146,4 +146,16 @@ export class Range {
       ? new Selection(this.end, this.start)
       : new Selection(this.start, this.end);
   }
+
+  /**
+   * Return a concise string representation of the range
+   * @returns concise representation
+   **/
+  public concise(): string {
+    return `${this.start.concise()}-${this.end.concise()}`;
+  }
+
+  public toString(): string {
+    return this.concise();
+  }
 }

--- a/packages/common/src/types/Selection.ts
+++ b/packages/common/src/types/Selection.ts
@@ -72,4 +72,16 @@ export class Selection extends Range {
       this.anchor.isEqual(other.anchor) && this.active.isEqual(other.active)
     );
   }
+
+  /**
+   * Return a concise string representation of the selection
+   * @returns concise representation
+   **/
+  public concise(): string {
+    return `${this.anchor.concise()}->${this.active.concise()}`;
+  }
+
+  public toString(): string {
+    return this.concise();
+  }
 }

--- a/packages/cursorless-engine/src/languages/TreeSitterQuery/checkCaptureStartEnd.ts
+++ b/packages/cursorless-engine/src/languages/TreeSitterQuery/checkCaptureStartEnd.ts
@@ -60,7 +60,9 @@ export function checkCaptureStartEnd(
     showError(
       messages,
       "TreeSitterQuery.checkCaptures.mixRegularStartEnd",
-      `Please do not mix regular captures and start/end captures: ${captures}`,
+      `Please do not mix regular captures and start/end captures: ${captures.map(
+        ({ name, range }) => name + "@" + range.toString(),
+      )}`,
     );
     shownError = true;
   }
@@ -71,7 +73,7 @@ export function checkCaptureStartEnd(
       messages,
       "TreeSitterQuery.checkCaptures.duplicate",
       `A capture with the same name may only appear once in a single pattern: ${captures.map(
-        ({ name }) => name,
+        ({ name, range }) => name + "@" + range.toString(),
       )}`,
     );
     shownError = true;

--- a/packages/cursorless-engine/src/languages/TreeSitterQuery/queryPredicateOperators.ts
+++ b/packages/cursorless-engine/src/languages/TreeSitterQuery/queryPredicateOperators.ts
@@ -73,6 +73,22 @@ class HasMultipleChildrenOfType extends QueryPredicateOperator<HasMultipleChildr
   }
 }
 
+/**
+ * A predicate operator that returns true if the node has more than 1 child not of
+ * type {@link type} (inclusive).  For example, `(has-multiple-children-not-of-type?
+ * @foo bar)` will accept the match if the `@foo` capture has 2 or more children
+ * not of type `bar`.
+ */
+class HasMultipleChildrenNotOfType extends QueryPredicateOperator<HasMultipleChildrenNotOfType> {
+  name = "has-multiple-children-not-of-type?" as const;
+  schema = z.tuple([q.node, q.string]);
+
+  run({ node }: MutableQueryCapture, type: string) {
+    const count = node.children.filter((n) => n.type !== type).length;
+    return count > 1;
+  }
+}
+
 class ChildRange extends QueryPredicateOperator<ChildRange> {
   name = "child-range!" as const;
   schema = z.union([
@@ -187,4 +203,5 @@ export const queryPredicateOperators = [
   new AllowMultiple(),
   new InsertionDelimiter(),
   new HasMultipleChildrenOfType(),
+  new HasMultipleChildrenNotOfType(),
 ];

--- a/packages/cursorless-engine/src/languages/go.ts
+++ b/packages/cursorless-engine/src/languages/go.ts
@@ -27,11 +27,6 @@ const nodeMatchers: Partial<
     patternMatcher("parameter_declaration"),
     patternMatcher("argument_declaration"),
   ),
-  collectionKey: "keyed_element[0]",
-  value: cascadingMatcher(
-    patternMatcher("keyed_element[1]"),
-    patternMatcher("return_statement.expression_list!"),
-  ),
 };
 
 export default createPatternMatchers(nodeMatchers);


### PR DESCRIPTION
This doesn't handle all uses of key, value, and name.
Missing still are migrate Go key and value scope to treesitter

This doesn't handle all uses of key and value.

Missing still are assignment statements (name, value),
function signatures (name, value), and possibly other
places (perhaps type declarations?).

It does handle all existing uses of key, value, and name,
though, so we can start here.

The handling of multiple return values is complicated,
particularly around the handling of comments and removal ranges.
It would be nice to find a simpler approach.



## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet
