### PR TITLE
Tighten and fix Talon actions type hints

### DIFF
--- a/cursorless-talon/src/actions/actions.py
+++ b/cursorless-talon/src/actions/actions.py
@@ -1,3 +1,5 @@
+from typing import Callable
+
 from talon import Module, actions
 
 from ..targets.target_types import CursorlessTarget, ImplicitDestination
@@ -7,7 +9,6 @@ from .execute_command import cursorless_execute_command_action
 from .homophones import cursorless_homophones_action
 
 mod = Module()
-
 
 mod.list(
     "cursorless_simple_action",
@@ -41,7 +42,7 @@ ACTION_LIST_NAMES = [
     "experimental_action",
 ]
 
-callback_actions = {
+callback_actions: dict[str, Callable[[CursorlessTarget], None]] = {
     "callAsFunction": cursorless_call_action,
     "findInDocument": actions.user.private_cursorless_find,
     "nextHomophone": cursorless_homophones_action,
@@ -67,7 +68,7 @@ no_wait_actions_post_sleep = {
         "{user.cursorless_custom_action}"
     )
 )
-def cursorless_action_or_ide_command(m) -> dict:
+def cursorless_action_or_ide_command(m) -> dict[str, str]:
     try:
         value = m.cursorless_custom_action
         type = "ide_command"
@@ -112,7 +113,7 @@ class Actions:
         return cursorless_execute_command_action(command_id, target)
 
     def private_cursorless_action_or_ide_command(
-        instruction: dict, target: CursorlessTarget
+        instruction: dict[str, str], target: CursorlessTarget
     ):
         """Perform cursorless action or ide command on target (internal use only)"""
         type = instruction["type"]

--- a/cursorless-talon/src/actions/get_text.py
+++ b/cursorless-talon/src/actions/get_text.py
@@ -7,11 +7,12 @@ from ..targets.target_types import CursorlessTarget
 
 def cursorless_get_text_action(
     target: CursorlessTarget,
+    *,
     show_decorations: Optional[bool] = None,
     ensure_single_target: Optional[bool] = None,
 ) -> list[str]:
     """Get target texts"""
-    options = {}
+    options: dict[str, bool] = {}
 
     if show_decorations is not None:
         options["showDecorations"] = show_decorations

--- a/cursorless-talon/src/actions/homophones.py
+++ b/cursorless-talon/src/actions/homophones.py
@@ -1,10 +1,13 @@
+from typing import Optional
+
 from talon import actions, app
 
+from ..targets.target_types import CursorlessTarget
 from .get_text import cursorless_get_text_action
 from .replace import cursorless_replace_action
 
 
-def cursorless_homophones_action(target: dict):
+def cursorless_homophones_action(target: CursorlessTarget):
     """Replaced target with next homophone"""
     texts = cursorless_get_text_action(target, show_decorations=False)
     try:
@@ -15,8 +18,8 @@ def cursorless_homophones_action(target: dict):
     cursorless_replace_action(target, updated_texts)
 
 
-def get_next_homophone(word: str):
-    homophones = actions.user.homophones_get(word)
+def get_next_homophone(word: str) -> str:
+    homophones: Optional[list[str]] = actions.user.homophones_get(word)
     if not homophones:
         raise LookupError(f"Found no homophones for '{word}'")
     index = (homophones.index(word.lower()) + 1) % len(homophones)
@@ -24,7 +27,7 @@ def get_next_homophone(word: str):
     return format_homophone(word, homophone)
 
 
-def format_homophone(word: str, homophone: str):
+def format_homophone(word: str, homophone: str) -> str:
     if word.isupper():
         return homophone.upper()
     if word == word.capitalize():


### PR DESCRIPTION
This fixes an incorrect type hint, removes a few implicit `Any`s, and tightens up how `cursorless_get_text_action` can be used.

## Checklist

- [ ] ~I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)~
- [ ] ~I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)~
- [x] I have not broken the cheatsheet
