### PR TITLE
migrate Python scope 'comment'

### DIFF
--- a/packages/cursorless-engine/src/languages/python.ts
+++ b/packages/cursorless-engine/src/languages/python.ts
@@ -66,7 +66,6 @@ const nodeMatchers: Partial<
   anonymousFunction: "lambda?.lambda",
   functionCall: "call",
   functionCallee: "call[function]",
-  comment: "comment",
   condition: cascadingMatcher(
     conditionMatcher("*[condition]"),
 

--- a/queries/python.scm
+++ b/queries/python.scm
@@ -27,6 +27,8 @@
   (with_statement)
 ] @statement
 
+(comment) @comment @textFragment
+
 (
   (function_definition
     name: (_) @functionName


### PR DESCRIPTION
## Checklist

- [/] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [/] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [/] I have not broken the cheatsheet

- [x] I have confirmed `vizualize comment` work (it didn't work before)
- [x] I have confirmed `take comment` still work. And I ran the test subset on "languages\\python\\" and it passed.
