### PR TITLE
add Windows specifics to test subset file

### DIFF
--- a/packages/test-harness/src/testSubset.ts
+++ b/packages/test-harness/src/testSubset.ts
@@ -8,12 +8,17 @@ import { getCursorlessRepoRoot } from "@cursorless/common";
  */
 export function testSubsetGrepString(): string {
   const inFile = testSubsetFilePath();
-  return fs
+  let grepStr = fs
     .readFileSync(inFile, "utf-8")
     .split(/\r?\n/)
     .map((line) => line.trim())
     .filter((line) => line.length > 0 && !line.startsWith("#"))
     .join("|");
+  if (process.platform === "win32") {
+    // Path separators are OS specific ("/" for Linux/MacOS and "\\" for Windows).
+    grepStr = grepStr.replaceAll("/", "\\\\");
+  }
+  return grepStr;
 }
 
 /**


### PR DESCRIPTION

## Checklist

- [/] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [/] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [/] I have not broken the cheatsheet
