### PR TITLE
Migrate Python to use next-gen scope handlers for text fragment extractors

### DIFF
--- a/data/playground/python/statements.py
+++ b/data/playground/python/statements.py
@@ -15,7 +15,6 @@ def statements():
     c = range(10)
     c.append(100)
     x = 1
-    two = 2
     x /= 2
     for i in range(10):
         if i == 0:
@@ -23,7 +22,6 @@ def statements():
         print(i)
         break
 
-    a = "how long is a piece of me?"
     age = 120
     if age > 90:
         print("You are too old to party, granny.")

--- a/data/playground/python/statements.py
+++ b/data/playground/python/statements.py
@@ -1,8 +1,9 @@
 import sys
 
+
 def statements():
-    print(sys.path[0]) # comment 1
-    print("hello") # comment 2
+    print(sys.path[0])  # comment 1
+    print("hello")  # comment 2
 
     # the below statement has additional spaces after it
     val = 1 == 2
@@ -11,11 +12,9 @@ def statements():
 
     # also the below has non-empty indentation
 
-
     c = range(10)
     c.append(100)
     x = 1
-    x++
     two = 2
     x /= 2
     for i in range(10):
@@ -34,5 +33,6 @@ def statements():
         print("You are allowed to party")
     else:
         print("You're too young to party")
+
 
 statements()

--- a/data/playground/python/statements.py
+++ b/data/playground/python/statements.py
@@ -5,12 +5,12 @@ def statements():
     print("hello") # comment 2
 
     # the below statement has additional spaces after it
-    val = 1 == 2    
+    val = 1 == 2
     if val is True:
         return
 
     # also the below has non-empty indentation
-    
+
 
     c = range(10)
     c.append(100)

--- a/data/playground/python/statements.py
+++ b/data/playground/python/statements.py
@@ -1,0 +1,38 @@
+import sys
+
+def statements():
+    print(sys.path[0]) # comment 1
+    print("hello") # comment 2
+
+    # the below statement has additional spaces after it
+    val = 1 == 2    
+    if val is True:
+        return
+
+    # also the below has non-empty indentation
+    
+
+    c = range(10)
+    c.append(100)
+    x = 1
+    x++
+    two = 2
+    x /= 2
+    for i in range(10):
+        if i == 0:
+            continue
+        print(i)
+        break
+
+    a = "how long is a piece of me?"
+    age = 120
+    if age > 90:
+        print("You are too old to party, granny.")
+    elif age < 0:
+        print("You're yet to be born")
+    elif age >= 18:
+        print("You are allowed to party")
+    else:
+        print("You're too young to party")
+
+statements()

--- a/data/playground/python/strings.py
+++ b/data/playground/python/strings.py
@@ -1,0 +1,9 @@
+
+value = 3
+
+a = 'single quote string'
+b = "double quote string"
+c = '''triple single quote string'''
+d = """triple double quote string"""
+e = r"literal string"
+f = f"format string {value}"

--- a/data/playground/python/strings.py
+++ b/data/playground/python/strings.py
@@ -1,9 +1,8 @@
-
 value = 3
 
-a = 'single quote string'
+a = "single quote string"
 b = "double quote string"
-c = '''triple single quote string'''
+c = """triple single quote string"""
 d = """triple double quote string"""
 e = r"literal string"
 f = f"format string {value}"

--- a/packages/cursorless-engine/src/languages/getTextFragmentExtractor.ts
+++ b/packages/cursorless-engine/src/languages/getTextFragmentExtractor.ts
@@ -165,7 +165,6 @@ const textFragmentExtractors: Record<
     "php",
     phpStringTextFragmentExtractor,
   ),
-  python: constructDefaultTextFragmentExtractor("python"),
   ruby: constructDefaultTextFragmentExtractor(
     "ruby",
     rubyStringTextFragmentExtractor,

--- a/packages/cursorless-engine/src/languages/python.ts
+++ b/packages/cursorless-engine/src/languages/python.ts
@@ -65,7 +65,6 @@ const nodeMatchers: Partial<
   anonymousFunction: "lambda?.lambda",
   functionCall: "call",
   functionCallee: "call[function]",
-  comment: "comment",
   condition: cascadingMatcher(
     conditionMatcher("*[condition]"),
 

--- a/packages/cursorless-engine/src/languages/python.ts
+++ b/packages/cursorless-engine/src/languages/python.ts
@@ -50,7 +50,6 @@ const nodeMatchers: Partial<
 > = {
   map: dictionaryTypes,
   list: listTypes,
-  string: "string",
   collectionItem: cascadingMatcher(
     matcher(
       itemNodeFinder("import_from_statement", "dotted_name", true),

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/python/takeString2.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/python/takeString2.yml
@@ -1,0 +1,24 @@
+languageId: python
+command:
+  version: 1
+  spokenForm: take string
+  action: setSelection
+  targets:
+    - type: primitive
+      modifier: {type: containingScope, scopeType: string}
+spokenFormError: Scope type 'string'
+initialState:
+  documentContents: |
+
+    value = """hello world"""
+  selections:
+    - anchor: {line: 1, character: 17}
+      active: {line: 1, character: 17}
+  marks: {}
+finalState:
+  documentContents: |
+
+    value = """hello world"""
+  selections:
+    - anchor: {line: 1, character: 8}
+      active: {line: 1, character: 25}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/python/takeString3.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/python/takeString3.yml
@@ -1,0 +1,24 @@
+languageId: python
+command:
+  version: 1
+  spokenForm: take string
+  action: setSelection
+  targets:
+    - type: primitive
+      modifier: {type: containingScope, scopeType: string}
+spokenFormError: Scope type 'string'
+initialState:
+  documentContents: |
+
+    value = r"hello world"
+  selections:
+    - anchor: {line: 1, character: 16}
+      active: {line: 1, character: 16}
+  marks: {}
+finalState:
+  documentContents: |
+
+    value = r"hello world"
+  selections:
+    - anchor: {line: 1, character: 8}
+      active: {line: 1, character: 22}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/python/takeString4.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/python/takeString4.yml
@@ -1,0 +1,26 @@
+languageId: python
+command:
+  version: 1
+  spokenForm: take string
+  action: setSelection
+  targets:
+    - type: primitive
+      modifier: {type: containingScope, scopeType: string}
+spokenFormError: Scope type 'string'
+initialState:
+  documentContents: |
+
+    w = "world"
+    value = f"hello {w}"
+  selections:
+    - anchor: {line: 2, character: 16}
+      active: {line: 2, character: 16}
+  marks: {}
+finalState:
+  documentContents: |
+
+    w = "world"
+    value = f"hello {w}"
+  selections:
+    - anchor: {line: 2, character: 8}
+      active: {line: 2, character: 20}

--- a/queries/python.scm
+++ b/queries/python.scm
@@ -28,6 +28,13 @@
 ] @statement
 
 (
+  (string
+    _ @textFragment.start.endOf
+    _ @textFragment.end.startOf
+  ) @string
+)
+
+(
   (function_definition
     name: (_) @functionName
     body: (_) @namedFunction.interior

--- a/queries/python.scm
+++ b/queries/python.scm
@@ -29,12 +29,10 @@
 
 (comment) @comment @textFragment
 
-(
-  (string
-    _ @textFragment.start.endOf
-    _ @textFragment.end.startOf
-  ) @string
-)
+(string
+  _ @textFragment.start.endOf
+  _ @textFragment.end.startOf
+) @string
 
 [
   (dictionary)

--- a/queries/python.scm
+++ b/queries/python.scm
@@ -27,6 +27,8 @@
   (with_statement)
 ] @statement
 
+(comment) @comment @textFragment
+
 (
   (string
     _ @textFragment.start.endOf


### PR DESCRIPTION
- Depends on #1863 

## Checklist

- [x] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [/] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [/] I have not broken the cheatsheet
- [x] merge https://github.com/cursorless-dev/cursorless/pull/1858 first as seems required
- [x] @pokey to fix a bug in the "processSurroundingPairCore" function atm that makes it not working atm (see commit message). It will be handled in a different commit before we can take this PR into account
- [x] record a test for the fix by @pokey by saying "cursorless record" and using "change string"

This PR also includes a few additional unit tests for Python strings.