### PR TITLE
Added ts `as` and `satisfices` support for `type` scope

### DIFF
--- a/packages/cursorless-engine/src/languages/typescript.ts
+++ b/packages/cursorless-engine/src/languages/typescript.ts
@@ -230,10 +230,16 @@ const nodeMatchers: Partial<
     // Typed parameters, properties, and functions
     typeMatcher(),
     // matcher(findTypeNode, selectWithLeadingDelimiter(":")),
-    // Type alias/interface declarations
     patternMatcher(
+      // Type alias/interface declarations
       "export_statement?.type_alias_declaration",
       "export_statement?.interface_declaration",
+      // as type declarations
+      "as_expression.generic_type!",
+      "as_expression.predefined_type!",
+      // satisfices type declaration
+      "satisfies_expression.generic_type!",
+      "satisfies_expression.predefined_type!",
     ),
   ),
   argumentOrParameter: argumentMatcher("formal_parameters", "arguments"),

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/typescript/changeType.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/typescript/changeType.yml
@@ -1,0 +1,23 @@
+languageId: typescript
+command:
+  version: 6
+  spokenForm: change type
+  action:
+    name: clearAndSetSelection
+    target:
+      type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: type}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: const value = 2 as number;
+  selections:
+    - anchor: {line: 0, character: 19}
+      active: {line: 0, character: 19}
+  marks: {}
+finalState:
+  documentContents: const value = 2 as ;
+  selections:
+    - anchor: {line: 0, character: 19}
+      active: {line: 0, character: 19}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/typescript/changeType2.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/typescript/changeType2.yml
@@ -1,0 +1,23 @@
+languageId: typescript
+command:
+  version: 6
+  spokenForm: change type
+  action:
+    name: clearAndSetSelection
+    target:
+      type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: type}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: const map = {} as Record<string, number>;
+  selections:
+    - anchor: {line: 0, character: 18}
+      active: {line: 0, character: 18}
+  marks: {}
+finalState:
+  documentContents: const map = {} as ;
+  selections:
+    - anchor: {line: 0, character: 18}
+      active: {line: 0, character: 18}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/typescript/changeType3.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/typescript/changeType3.yml
@@ -1,0 +1,23 @@
+languageId: typescript
+command:
+  version: 6
+  spokenForm: change type
+  action:
+    name: clearAndSetSelection
+    target:
+      type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: type}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: const value = 2 as const satisfies number;
+  selections:
+    - anchor: {line: 0, character: 35}
+      active: {line: 0, character: 35}
+  marks: {}
+finalState:
+  documentContents: const value = 2 as const satisfies ;
+  selections:
+    - anchor: {line: 0, character: 35}
+      active: {line: 0, character: 35}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/typescript/changeType4.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/typescript/changeType4.yml
@@ -1,0 +1,23 @@
+languageId: typescript
+command:
+  version: 6
+  spokenForm: change type
+  action:
+    name: clearAndSetSelection
+    target:
+      type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: type}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: const meta = {} as const satisfies Record<string, number>;
+  selections:
+    - anchor: {line: 0, character: 35}
+      active: {line: 0, character: 35}
+  marks: {}
+finalState:
+  documentContents: const meta = {} as const satisfies ;
+  selections:
+    - anchor: {line: 0, character: 35}
+      active: {line: 0, character: 35}


### PR DESCRIPTION
Fixes #1155

## Checklist

- [x] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [/] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [/] I have not broken the cheatsheet
