### PR TITLE
Disable talonfmt

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -83,8 +83,3 @@ repos:
     rev: 23.3.0
     hooks:
       - id: black
-  - repo: https://github.com/wenkokke/talonfmt
-    rev: 1.9.5
-    hooks:
-      - id: talonfmt
-        args: ["--in-place"]


### PR DESCRIPTION
As a workaround for #1865, we're disabling talonfmt for now. This workaround should be fine for a few days, as we rarely touch our talon files



## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet
