### PR TITLE
Made interface names targetable as keys

### DIFF
--- a/packages/cursorless-engine/src/languages/typescript.ts
+++ b/packages/cursorless-engine/src/languages/typescript.ts
@@ -167,6 +167,7 @@ const nodeMatchers: Partial<
       "pair[key]",
       "jsx_attribute.property_identifier!",
       "interface_declaration.object_type.property_signature[name]!",
+      "type_alias_declaration.object_type.property_signature[name]!",
       "shorthand_property_identifier",
     ],
     [":"],

--- a/packages/cursorless-engine/src/languages/typescript.ts
+++ b/packages/cursorless-engine/src/languages/typescript.ts
@@ -166,8 +166,7 @@ const nodeMatchers: Partial<
     [
       "pair[key]",
       "jsx_attribute.property_identifier!",
-      "interface_declaration.object_type.property_signature[name]!",
-      "type_alias_declaration.object_type.property_signature[name]!",
+      "object_type.property_signature[name]!",
       "shorthand_property_identifier",
     ],
     [":"],

--- a/packages/cursorless-engine/src/languages/typescript.ts
+++ b/packages/cursorless-engine/src/languages/typescript.ts
@@ -166,6 +166,7 @@ const nodeMatchers: Partial<
     [
       "pair[key]",
       "jsx_attribute.property_identifier!",
+      "interface_declaration.object_type.property_signature[name]!",
       "shorthand_property_identifier",
     ],
     [":"],

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/typescript/changeKey.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/typescript/changeKey.yml
@@ -1,0 +1,29 @@
+languageId: typescript
+command:
+  version: 6
+  spokenForm: change key
+  action:
+    name: clearAndSetSelection
+    target:
+      type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: collectionKey}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    interface Hello {
+        value: number;
+    }
+  selections:
+    - anchor: {line: 1, character: 17}
+      active: {line: 1, character: 17}
+  marks: {}
+finalState:
+  documentContents: |-
+    interface Hello {
+        : number;
+    }
+  selections:
+    - anchor: {line: 1, character: 4}
+      active: {line: 1, character: 4}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/typescript/changeKey2.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/typescript/changeKey2.yml
@@ -1,0 +1,29 @@
+languageId: typescript
+command:
+  version: 6
+  spokenForm: change key
+  action:
+    name: clearAndSetSelection
+    target:
+      type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: collectionKey}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    type Hello = {
+        value: number;
+    }
+  selections:
+    - anchor: {line: 1, character: 17}
+      active: {line: 1, character: 17}
+  marks: {}
+finalState:
+  documentContents: |-
+    type Hello = {
+        : number;
+    }
+  selections:
+    - anchor: {line: 1, character: 4}
+      active: {line: 1, character: 4}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/typescript/changeKey3.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/typescript/changeKey3.yml
@@ -1,0 +1,33 @@
+languageId: typescript
+command:
+  version: 6
+  spokenForm: change key
+  action:
+    name: clearAndSetSelection
+    target:
+      type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: collectionKey}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    function funk(): {
+        value: number;
+    } {
+        return { value: 2 }
+    }
+  selections:
+    - anchor: {line: 1, character: 17}
+      active: {line: 1, character: 17}
+  marks: {}
+finalState:
+  documentContents: |-
+    function funk(): {
+        : number;
+    } {
+        return { value: 2 }
+    }
+  selections:
+    - anchor: {line: 1, character: 4}
+      active: {line: 1, character: 4}


### PR DESCRIPTION
Fixes #1790

## Checklist

- [x] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [/] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [/] I have not broken the cheatsheet
