### PR TITLE
improve treesitter query captureStartEnd error messages

### DIFF
--- a/packages/cursorless-engine/src/languages/TreeSitterQuery/checkCaptureStartEnd.ts
+++ b/packages/cursorless-engine/src/languages/TreeSitterQuery/checkCaptureStartEnd.ts
@@ -60,7 +60,9 @@ export function checkCaptureStartEnd(
     showError(
       messages,
       "TreeSitterQuery.checkCaptures.mixRegularStartEnd",
-      `Please do not mix regular captures and start/end captures: ${captures}`,
+      `Please do not mix regular captures and start/end captures: ${captures.map(
+        ({ name, range }) => name + "@" + range.toString(),
+      )}`,
     );
     shownError = true;
   }
@@ -71,7 +73,7 @@ export function checkCaptureStartEnd(
       messages,
       "TreeSitterQuery.checkCaptures.duplicate",
       `A capture with the same name may only appear once in a single pattern: ${captures.map(
-        ({ name }) => name,
+        ({ name, range }) => name + "@" + range.toString(),
       )}`,
     );
     shownError = true;

--- a/packages/cursorless-engine/src/languages/TreeSitterQuery/checkCaptureStartEnd.ts
+++ b/packages/cursorless-engine/src/languages/TreeSitterQuery/checkCaptureStartEnd.ts
@@ -61,7 +61,7 @@ export function checkCaptureStartEnd(
       messages,
       "TreeSitterQuery.checkCaptures.mixRegularStartEnd",
       `Please do not mix regular captures and start/end captures: ${captures.map(
-        ({ name, range }) => name + "@" + range.toString(),
+        ({ name, range }) => name + " " + range.toString(),
       )}`,
     );
     shownError = true;
@@ -73,7 +73,7 @@ export function checkCaptureStartEnd(
       messages,
       "TreeSitterQuery.checkCaptures.duplicate",
       `A capture with the same name may only appear once in a single pattern: ${captures.map(
-        ({ name, range }) => name + "@" + range.toString(),
+        ({ name, range }) => name + " " + range.toString(),
       )}`,
     );
     shownError = true;


### PR DESCRIPTION
These used to print things like "[Object object]".

They are interface types, so we can't simply add a toString method.



## Checklist

- [-] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [-] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [-] I have not broken the cheatsheet
