### PR TITLE
add #trim-end predicate

### DIFF
--- a/packages/cursorless-engine/src/languages/TreeSitterQuery/queryPredicateOperators.ts
+++ b/packages/cursorless-engine/src/languages/TreeSitterQuery/queryPredicateOperators.ts
@@ -150,6 +150,25 @@ class ShrinkToMatch extends QueryPredicateOperator<ShrinkToMatch> {
   }
 }
 
+/**
+ * A predicate operator that modifies the range of the match by trimming trailing whitespace,
+ * similar to the javascript trimEnd function.
+ */
+class TrimEnd extends QueryPredicateOperator<TrimEnd> {
+  name = "trim-end!" as const;
+  schema = z.tuple([q.node]);
+
+  run(nodeInfo: MutableQueryCapture) {
+    const { document, range } = nodeInfo;
+    const text = document.getText(range);
+    const trimmed = text.trimEnd();
+    const endOffset =
+      document.offsetAt(range.end) + trimmed.length - text.length;
+    nodeInfo.range = new Range(range.start, document.positionAt(endOffset));
+    return true;
+  }
+}
+
 class AllowMultiple extends QueryPredicateOperator<AllowMultiple> {
   name = "allow-multiple!" as const;
   schema = z.tuple([q.node]);
@@ -179,6 +198,7 @@ class InsertionDelimiter extends QueryPredicateOperator<InsertionDelimiter> {
 
 export const queryPredicateOperators = [
   new NotType(),
+  new TrimEnd(),
   new NotEmpty(),
   new NotParentType(),
   new IsNthChild(),

--- a/queries/talon.scm
+++ b/queries/talon.scm
@@ -113,8 +113,8 @@
   ) @_.domain
   (#not-empty? @condition)
   (#not-empty? @_.trailing)
-  (#shrink-to-match! @condition "^(?<keep>.*)(\s|\n|\r)+-$")
-  (#shrink-to-match! @_.trailing "^.*(?<keep>(\s|\n|\r)+-)$")
+  (#trim-end! @condition)
+  (#trim-end! @_.trailing)
 )
 
 ;;!! slap: key(enter)


### PR DESCRIPTION
The same thing can be accomplished with #shrink-to-match!,
but this is considerably simpler to use, and meets a common need.

Suggested by Pokey during review of #1854.



## Checklist

- [-] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [-] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [-] I have not broken the cheatsheet
