### PR TITLE
Reduce extension dependencies

### DIFF
--- a/packages/common/src/extensionDependencies.ts
+++ b/packages/common/src/extensionDependencies.ts
@@ -1,8 +1,6 @@
 export const extensionDependencies = [
   "pokey.parse-tree",
+
+  // Necessary for the `drink cell` and `pour cell` tests
   "ms-toolsai.jupyter",
-  "scalameta.metals",
-  "ms-python.python",
-  "mrob95.vscode-talonscript",
-  "jrieken.vscode-tree-sitter-query",
 ];

--- a/packages/cursorless-vscode/package.json
+++ b/packages/cursorless-vscode/package.json
@@ -1016,6 +1016,33 @@
         "extensions": [
           ".cursorless-snippets"
         ]
+      },
+      {
+        "id": "talon",
+        "aliases": [
+          "Talon"
+        ],
+        "extensions": [
+          ".talon"
+        ]
+      },
+      {
+        "id": "scala",
+        "aliases": [
+          "Scala"
+        ],
+        "extensions": [
+          ".scala"
+        ]
+      },
+      {
+        "id": "scm",
+        "aliases": [
+          "Tree-sitter Query"
+        ],
+        "extensions": [
+          ".scm"
+        ]
       }
     ],
     "jsonValidation": [

--- a/packages/cursorless-vscode/src/scripts/initLaunchSandbox.ts
+++ b/packages/cursorless-vscode/src/scripts/initLaunchSandbox.ts
@@ -6,7 +6,7 @@
 import { extensionDependencies } from "@cursorless/common";
 import * as cp from "child_process";
 
-const extraExtensions = ["pokey.command-server", "pokey.talon"];
+const extraExtensions = ["pokey.command-server"];
 
 async function main() {
   try {


### PR DESCRIPTION
Fixes #1814

There is no problem with registering `.scm`. If the user is using scheme there is still a good probability that their Scheme extension would win over Cursorless and if not vscode has a file association setting they can use.

## Checklist

- [/] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [/] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [/] I have not broken the cheatsheet
