### PR TITLE
Switch scala dependency extension

### DIFF
--- a/packages/common/src/extensionDependencies.ts
+++ b/packages/common/src/extensionDependencies.ts
@@ -1,10 +1,11 @@
 export const extensionDependencies = [
+  // Cursorless access to Tree sitter
   "pokey.parse-tree",
 
-  // Register necessary file extensions for tests
-  "scalameta.metals",
-  "mrob95.vscode-talonscript",
-  "jrieken.vscode-tree-sitter-query",
+  // Register necessary language-IDs for tests
+  "scala-lang.scala", // scala
+  "mrob95.vscode-talonscript", // talon
+  "jrieken.vscode-tree-sitter-query", // scm
 
   // Necessary for the `drink cell` and `pour cell` tests
   "ms-toolsai.jupyter",


### PR DESCRIPTION
`scalameta.metals` includes `scala-lang.scala` that actually adds the language identifier that we need. Switch to it directly to avoid installing more extensions than necessary

## Checklist

- [/] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [/] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [/] I have not broken the cheatsheet
