### PR TITLE
Updated content range for branch

### DIFF
--- a/packages/cursorless-engine/src/languages/elseIfExtractor.ts
+++ b/packages/cursorless-engine/src/languages/elseIfExtractor.ts
@@ -57,16 +57,14 @@ export function elseIfExtractor(): SelectionExtractor {
     }
 
     // If we get here, we are part of a bigger `if` statement; extend our
-    // removal range past our leading `else` keyword.
+    // content range past our leading `else` keyword.
     const { selection } = contentRange;
     return {
-      selection,
-      context: {
-        removalRange: new Selection(
-          positionFromPoint(parent.child(0)!.startPosition),
-          selection.end,
-        ),
-      },
+      selection: new Selection(
+        positionFromPoint(parent.child(0)!.startPosition),
+        selection.end,
+      ),
+      context: {},
     };
   };
 }

--- a/packages/cursorless-engine/src/processTargets/targets/DestinationImpl.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/DestinationImpl.ts
@@ -101,6 +101,7 @@ export class DestinationImpl implements Destination {
   }
 
   private constructEditWithoutDelimiters(text: string): EditWithRangeUpdater {
+    s;
     return {
       range: this.contentRange,
       text,
@@ -120,14 +121,13 @@ export class DestinationImpl implements Destination {
           ? line.firstNonWhitespaceCharacterIndex
           : line.lastNonWhitespaceCharacterIndex;
 
+        // Use the full line to include indentation
         if (contentPosition.character === nonWhitespaceCharacterIndex) {
           return this.isBefore ? line.range.start : line.range.end;
         }
-
-        return contentPosition;
-      } else {
-        return contentPosition;
       }
+
+      return contentPosition;
     })();
 
     return new Range(position, position);

--- a/packages/cursorless-engine/src/processTargets/targets/DestinationImpl.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/DestinationImpl.ts
@@ -101,7 +101,6 @@ export class DestinationImpl implements Destination {
   }
 
   private constructEditWithoutDelimiters(text: string): EditWithRangeUpdater {
-    s;
     return {
       range: this.contentRange,
       text,

--- a/packages/cursorless-engine/src/processTargets/targets/DestinationImpl.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/DestinationImpl.ts
@@ -110,15 +110,26 @@ export class DestinationImpl implements Destination {
 
   private getEditRange() {
     const position = (() => {
+      const contentPosition = this.isBefore
+        ? this.contentRange.start
+        : this.contentRange.end;
+
       if (this.isLineDelimiter) {
-        const line = this.editor.document.lineAt(
-          this.isBefore ? this.contentRange.start : this.contentRange.end,
-        );
-        return this.isBefore ? line.range.start : line.range.end;
+        const line = this.editor.document.lineAt(contentPosition);
+        const nonWhitespaceCharacterIndex = this.isBefore
+          ? line.firstNonWhitespaceCharacterIndex
+          : line.lastNonWhitespaceCharacterIndex;
+
+        if (contentPosition.character === nonWhitespaceCharacterIndex) {
+          return this.isBefore ? line.range.start : line.range.end;
+        }
+
+        return contentPosition;
       } else {
-        return this.isBefore ? this.contentRange.start : this.contentRange.end;
+        return contentPosition;
       }
     })();
+
     return new Range(position, position);
   }
 

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/rust/clearBranch5.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/rust/clearBranch5.yml
@@ -26,9 +26,9 @@ finalState:
   documentContents: |-
     if n < 0 {
         print!("{} is negative", n);
-    } else  else {
+    }  else {
         print!("{} is zero", n);
     }
   selections:
-    - anchor: {line: 2, character: 7}
-      active: {line: 2, character: 7}
+    - anchor: {line: 2, character: 2}
+      active: {line: 2, character: 2}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/rust/clearBranch6.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/rust/clearBranch6.yml
@@ -26,9 +26,9 @@ finalState:
   documentContents: |-
     if n < 0 {
         print!("{} is negative", n);
-    } else  else {
+    }  else {
         print!("{} is zero", n);
     }
   selections:
-    - anchor: {line: 2, character: 7}
-      active: {line: 2, character: 7}
+    - anchor: {line: 2, character: 2}
+      active: {line: 2, character: 2}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/rust/ditchBranch2.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/rust/ditchBranch2.yml
@@ -26,7 +26,7 @@ finalState:
   documentContents: |-
     if n < 0 {
         print!("{} is negative", n);
-    }  else {
+    } else {
         print!("{} is zero", n);
     }
   selections:

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/typescript/clearBranch4.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/typescript/clearBranch4.yml
@@ -26,9 +26,9 @@ finalState:
   documentContents: |-
     if (true) {
       const whatever = "hello";
-    } else  else {
+    }  else {
       const whatever = "hello";
     }
   selections:
-    - anchor: {line: 2, character: 7}
-      active: {line: 2, character: 7}
+    - anchor: {line: 2, character: 2}
+      active: {line: 2, character: 2}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/typescript/clearBranch5.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/typescript/clearBranch5.yml
@@ -26,9 +26,9 @@ finalState:
   documentContents: |-
     if (true) {
       const whatever = "hello";
-    } else  else {
+    }  else {
       const whatever = "hello";
     }
   selections:
-    - anchor: {line: 2, character: 7}
-      active: {line: 2, character: 7}
+    - anchor: {line: 2, character: 2}
+      active: {line: 2, character: 2}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/typescript/cloneBranch.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/typescript/cloneBranch.yml
@@ -1,0 +1,40 @@
+languageId: typescript
+command:
+  version: 6
+  spokenForm: clone branch
+  action:
+    name: insertCopyAfter
+    target:
+      type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: branch}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    if (1 > 0) {
+        
+    } else if (1 > 2) {
+        
+    } else {
+        
+    }
+  selections:
+    - anchor: {line: 2, character: 2}
+      active: {line: 2, character: 2}
+  marks: {}
+finalState:
+  documentContents: |-
+    if (1 > 0) {
+        
+    } else if (1 > 2) {
+        
+    }
+    else if (1 > 2) {
+        
+    } else {
+        
+    }
+  selections:
+    - anchor: {line: 5, character: 0}
+      active: {line: 5, character: 0}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/typescript/ditchBranch.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/typescript/ditchBranch.yml
@@ -26,7 +26,7 @@ finalState:
   documentContents: |-
     if (true) {
       const whatever = "hello";
-    }  else {
+    } else {
       const whatever = "hello";
     }
   selections:

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/typescript/ditchBranch2.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/typescript/ditchBranch2.yml
@@ -26,7 +26,7 @@ finalState:
   documentContents: |-
     if (true) {
       const whatever = "hello";
-    }  else {
+    } else {
       const whatever = "hello";
     }
   selections:


### PR DESCRIPTION
`else if` is now part of the content range for the branch. 

Updated destination `constructChangeEdit` to support line this insertion delimiters with scopes where the content range doesn't take the full line. eg `} else if`

## Checklist

- [x] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [/] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [/] I have not broken the cheatsheet
