### PR TITLE
Made python match a cursorless statement scope

### DIFF
--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/python/changeState.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/python/changeState.yml
@@ -1,0 +1,26 @@
+languageId: python
+command:
+  version: 6
+  spokenForm: change state
+  action:
+    name: clearAndSetSelection
+    target:
+      type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: statement}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    match value:
+        case 0:
+            pass
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  marks: {}
+finalState:
+  documentContents: ""
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}

--- a/queries/python.scm
+++ b/queries/python.scm
@@ -17,6 +17,7 @@
   (if_statement)
   (import_from_statement)
   (import_statement)
+  (match_statement)
   (nonlocal_statement)
   (pass_statement)
   (print_statement)


### PR DESCRIPTION


## Checklist

- [x] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [/] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [/] I have not broken the cheatsheet
