### PR TITLE
First attempt at making exit keys configurable

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -24,5 +24,8 @@
   ],
   "files.eol": "\n",
   "typescript.enablePromptUseWorkspaceTsdk": true,
-  "typescript.tsdk": "node_modules/typescript/lib"
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "[typescript]": {
+    "editor.defaultFormatter": "vscode.typescript-language-features"
+  }
 }

--- a/packages/cursorless-vscode/package.json
+++ b/packages/cursorless-vscode/package.json
@@ -927,6 +927,16 @@
             ]
           }
         },
+        "cursorless.experimental.keyboard.modal.keybindings.modifiers": {
+          "description": "Define modal keybindings for modifiers",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string",
+            "enum": [
+              "interiorOnly"
+            ]
+          }
+        },
         "cursorless.experimental.keyboard.modal.keybindings.shapes": {
           "description": "Define modal keybindings for shapes",
           "type": "object",

--- a/packages/cursorless-vscode/package.json
+++ b/packages/cursorless-vscode/package.json
@@ -902,6 +902,14 @@
             ]
           }
         },
+        "cursorless.experimental.keyboard.modal.exit_actions": {
+          "description": "Define actions that exit modal mode",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": []
+        },
         "cursorless.experimental.keyboard.modal.keybindings.colors": {
           "description": "Define modal keybindings for colors",
           "type": "object",

--- a/packages/cursorless-vscode/src/keyboard/KeyboardCommandsTargeted.ts
+++ b/packages/cursorless-vscode/src/keyboard/KeyboardCommandsTargeted.ts
@@ -235,6 +235,8 @@ export default class KeyboardCommandsTargeted {
 
     await this.highlightTarget();
 
+    const EXIT_CURSORLESS_MODE_ACTIONS:string[]=vscode.workspace.getConfiguration("cursorless.experimental.keyboard.modal").get("exit_actions")??[];
+    
     if (EXIT_CURSORLESS_MODE_ACTIONS.includes(name)) {
       // For some Cursorless actions, it is more convenient if we automatically
       // exit modal mode
@@ -284,10 +286,7 @@ function executeCursorlessCommand(action: ActionDescriptor) {
   });
 }
 
-const EXIT_CURSORLESS_MODE_ACTIONS: ActionType[] = [
-  "setSelectionBefore",
-  "setSelectionAfter",
-  "editNewLineBefore",
-  "editNewLineAfter",
-  "clearAndSetSelection",
-];
+
+
+
+

--- a/packages/cursorless-vscode/src/keyboard/KeyboardCommandsTargeted.ts
+++ b/packages/cursorless-vscode/src/keyboard/KeyboardCommandsTargeted.ts
@@ -1,6 +1,7 @@
 import {
   ActionDescriptor,
   ActionType,
+  Direction,
   LATEST_VERSION,
   PartialPrimitiveTargetDescriptor,
   PartialTargetDescriptor,
@@ -14,7 +15,7 @@ import KeyboardCommandsModal from "./KeyboardCommandsModal";
 import KeyboardHandler from "./KeyboardHandler";
 
 type TargetingMode = "replace" | "extend" | "append";
-
+type TargetModifierTypeArgument = "every" | "interiorOnly" | "excludeInterior";
 interface TargetDecoratedMarkArgument {
   color?: HatColor;
   shape?: HatShape;
@@ -151,6 +152,24 @@ export default class KeyboardCommandsTargeted {
       },
     });
 
+  
+  targetModifierType = async (mod: TargetModifierTypeArgument) =>
+    await executeCursorlessCommand({
+      name: "highlight",
+      target: {
+        type: "primitive",
+        modifiers: [
+          {
+           type: "interiorOnly",
+           
+          },
+        ],
+        mark: {
+          type: "that",
+        },
+      },
+    });
+
   private highlightTarget = () =>
     executeCursorlessCommand({
       name: "highlight",
@@ -258,7 +277,47 @@ export default class KeyboardCommandsTargeted {
         mark: {
           type: "cursor",
         },
-        modifiers: [{ type: "toRawSelection" }],
+      },
+    });
+
+  expandTarget = (direction:Direction) =>
+
+    executeCursorlessCommand({
+
+      name: "highlight",
+      target: {
+        type: "range",
+        anchor: {
+          type: "primitive",
+          mark: {
+            type: "that",
+          },
+        },
+        active: {
+          type: "primitive",
+          mark: {
+            type: "that",
+            
+          },
+          modifiers: [
+            {
+              type: "relativeScope",
+              direction: direction,
+              length: 1,
+              offset: 1,
+              scopeType: {
+                type: "token",
+              },            
+              
+            },
+
+          ],
+        },
+        excludeActive: false,
+        excludeAnchor: false,
+        
+
+        
       },
     });
 
@@ -278,7 +337,7 @@ export default class KeyboardCommandsTargeted {
     });
 }
 
-function executeCursorlessCommand(action: ActionDescriptor) {
+export function executeCursorlessCommand(action: ActionDescriptor) {
   return runCursorlessCommand({
     action,
     version: LATEST_VERSION,

--- a/packages/cursorless-vscode/src/keyboard/defaultKeymaps.ts
+++ b/packages/cursorless-vscode/src/keyboard/defaultKeymaps.ts
@@ -1,4 +1,4 @@
-import { ActionType } from "@cursorless/common";
+import { ActionType, ModifierType } from "@cursorless/common";
 import { SimpleScopeTypeType } from "@cursorless/common";
 import { HatColor, HatShape } from "../ide/vscode/hatStyles.types";
 import { isTesting } from "@cursorless/common";
@@ -22,3 +22,5 @@ export const DEFAULT_COLOR_KEYMAP: Keymap<HatColor> = isTesting()
   : {};
 
 export const DEFAULT_SHAPE_KEYMAP: Keymap<HatShape> = isTesting() ? {} : {};
+
+export const DEFAULT_MODIFIER_KEYMAP: Keymap<ModifierType> = isTesting() ? {} : {};


### PR DESCRIPTION
So unfortunately I have no idea about typescript or vscode extensions. 

For the keyboard mode the actions that exit the keyboard mode are currently fixed. I wanted to make that configurable. So I added an array to the package.json. And then simply read the setting in at exactly the place where it is needed rather than keeping it in file scope as it was before.

My questions are:
- Should the setting array be constrained with an enum. And if so do i basically copy the keybinds.actions enum list?
- How and where would you read in the settings?


So I am hoping for some input before I continue with this. 

I will try to attend one of the next cursorless meetings. Might be easier to discuss this in person.
