### PR TITLE
Added support for user home variable in settings

### DIFF
--- a/packages/cursorless-vscode/src/ide/vscode/VscodeConfiguration.ts
+++ b/packages/cursorless-vscode/src/ide/vscode/VscodeConfiguration.ts
@@ -47,6 +47,16 @@ export default class VscodeConfiguration implements Configuration {
   onDidChangeConfiguration = this.notifier.registerListener;
 }
 
+/**
+ * Gets a configuration value from vscode, with supported variables expanded.
+ * For example, `${userHome}` will be expanded to the user's home directory.
+ *
+ * We currently only support `${userHome}`.
+ *
+ * @param path The path to the configuration value, eg `cursorless.snippetsDir`
+ * @returns The configuration value, with variables expanded, or undefined if
+ * the value is not set
+ */
 export function vscodeGetConfigurationString(path: string): string | undefined {
   const value = vscode.workspace.getConfiguration().get<string>(path);
 

--- a/packages/cursorless-vscode/src/ide/vscode/VscodeConfiguration.ts
+++ b/packages/cursorless-vscode/src/ide/vscode/VscodeConfiguration.ts
@@ -58,8 +58,10 @@ export default class VscodeConfiguration implements Configuration {
  * the value is not set
  */
 export function vscodeGetConfigurationString(path: string): string | undefined {
-  const value = vscode.workspace.getConfiguration().get<string>(path);
-
+  const index = path.lastIndexOf(".");
+  const section = path.substring(0, index);
+  const field = path.substring(index + 1);
+  const value = vscode.workspace.getConfiguration(section).get<string>(field);
   return value != null ? evaluateStringVariables(value) : undefined;
 }
 

--- a/packages/cursorless-vscode/src/ide/vscode/VscodeConfiguration.ts
+++ b/packages/cursorless-vscode/src/ide/vscode/VscodeConfiguration.ts
@@ -1,3 +1,4 @@
+import * as os from "node:os";
 import { HatStability } from "@cursorless/common";
 import { get } from "lodash";
 import * as vscode from "vscode";
@@ -14,6 +15,9 @@ const translators = {
   experimental: {
     hatStability(value: string) {
       return HatStability[value as keyof typeof HatStability];
+    },
+    snippetsDir: (value?: string) => {
+      return value != null ? evaluateStringVariables(value) : undefined;
     },
   },
 };
@@ -41,4 +45,21 @@ export default class VscodeConfiguration implements Configuration {
   }
 
   onDidChangeConfiguration = this.notifier.registerListener;
+}
+
+export function vscodeGetConfigurationString(path: string): string | undefined {
+  const value = vscode.workspace.getConfiguration().get<string>(path);
+
+  return value != null ? evaluateStringVariables(value) : undefined;
+}
+
+function evaluateStringVariables(value: string): string {
+  return value.replace(/\${(\w+)}/g, (match, variable) => {
+    switch (variable) {
+      case "userHome":
+        return os.homedir();
+      default:
+        throw Error(`Unknown vscode configuration variable '${variable}'`);
+    }
+  });
 }

--- a/packages/cursorless-vscode/src/ide/vscode/hats/VscodeHatRenderer.ts
+++ b/packages/cursorless-vscode/src/ide/vscode/hats/VscodeHatRenderer.ts
@@ -41,13 +41,6 @@ const hatConfigSections = [
   "cursorless.individualHatAdjustments",
 ];
 
-/**
- * Maintains the VSCode decoration type objects corresponding to each hat style.
- * This class is responsible for the actual svgs / colors used to render the
- * hats.  The decision about which hat styles should be available is up to
- * {@link VscodeEnabledHatStyles}
- */
-
 const hatShapesDirSettingId = "cursorless.private.hatShapesDir";
 
 interface SvgInfo {
@@ -56,6 +49,12 @@ interface SvgInfo {
   svgWidthPx: number;
 }
 
+/**
+ * Maintains the VSCode decoration type objects corresponding to each hat style.
+ * This class is responsible for the actual svgs / colors used to render the
+ * hats.  The decision about which hat styles should be available is up to
+ * {@link VscodeEnabledHatStyles}
+ */
 export default class VscodeHatRenderer {
   private decorationMap!: HatDecorationMap;
   private disposables: vscode.Disposable[] = [];
@@ -123,7 +122,7 @@ export default class VscodeHatRenderer {
 
   private async updateHatsDirWatcher() {
     this.hatsDirWatcherDisposable?.dispose();
-
+c
     const hatsDir = vscodeGetConfigurationString(hatShapesDirSettingId);
 
     if (hatsDir) {

--- a/packages/cursorless-vscode/src/ide/vscode/hats/VscodeHatRenderer.ts
+++ b/packages/cursorless-vscode/src/ide/vscode/hats/VscodeHatRenderer.ts
@@ -122,7 +122,6 @@ export default class VscodeHatRenderer {
 
   private async updateHatsDirWatcher() {
     this.hatsDirWatcherDisposable?.dispose();
-    c;
     const hatsDir = vscodeGetConfigurationString(hatShapesDirSettingId);
 
     if (hatsDir) {

--- a/packages/cursorless-vscode/src/ide/vscode/hats/VscodeHatRenderer.ts
+++ b/packages/cursorless-vscode/src/ide/vscode/hats/VscodeHatRenderer.ts
@@ -122,7 +122,7 @@ export default class VscodeHatRenderer {
 
   private async updateHatsDirWatcher() {
     this.hatsDirWatcherDisposable?.dispose();
-c
+    c;
     const hatsDir = vscodeGetConfigurationString(hatShapesDirSettingId);
 
     if (hatsDir) {

--- a/packages/cursorless-vscode/src/ide/vscode/hats/VscodeHatRenderer.ts
+++ b/packages/cursorless-vscode/src/ide/vscode/hats/VscodeHatRenderer.ts
@@ -8,6 +8,7 @@ import { cloneDeep, isEqual } from "lodash";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as vscode from "vscode";
+import { vscodeGetConfigurationString } from "../VscodeConfiguration";
 import VscodeEnabledHatStyleManager, {
   ExtendedHatStyleMap,
 } from "../VscodeEnabledHatStyleManager";
@@ -47,9 +48,7 @@ const hatConfigSections = [
  * {@link VscodeEnabledHatStyles}
  */
 
-const SETTING_SECTION_HAT_SHAPES_DIR = "cursorless.private";
-const SETTING_NAME_HAT_SHAPES_DIR = "hatShapesDir";
-const hatShapesDirSettingId = `${SETTING_SECTION_HAT_SHAPES_DIR}.${SETTING_NAME_HAT_SHAPES_DIR}`;
+const hatShapesDirSettingId = "cursorless.private.hatShapesDir";
 
 interface SvgInfo {
   svg: string;
@@ -125,9 +124,7 @@ export default class VscodeHatRenderer {
   private async updateHatsDirWatcher() {
     this.hatsDirWatcherDisposable?.dispose();
 
-    const hatsDir = vscode.workspace
-      .getConfiguration(SETTING_SECTION_HAT_SHAPES_DIR)
-      .get<string>(SETTING_NAME_HAT_SHAPES_DIR)!;
+    const hatsDir = vscodeGetConfigurationString(hatShapesDirSettingId);
 
     if (hatsDir) {
       await this.updateShapeOverrides(hatsDir);


### PR DESCRIPTION
eg `"cursorless.private.hatShapesDir": "C:\\Users\\Andreas\\repositories\\pokey-dotfiles\\cursorless-hat-shapes",`

## Checklist

- [/] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [/] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [/] I have not broken the cheatsheet
