### PR TITLE
Fix `boundedNonWhitespaceSequence` in cheatsheet

### DIFF
--- a/cursorless-talon/src/cheatsheet/sections/scopes.py
+++ b/cursorless-talon/src/cheatsheet/sections/scopes.py
@@ -5,5 +5,8 @@ def get_scopes():
     return get_lists(
         ["scope_type"],
         "scopeType",
-        {"argumentOrParameter": "Argument"},
+        {
+            "argumentOrParameter": "Argument",
+            "boundedNonWhitespaceSequence": "Non whitespace sequence stopped by surrounding pair delimeters",
+        },
     )


### PR DESCRIPTION
Fixes cheatsheet bug introduced in #1698 which only updated spoken form in defaults.json, which is used by cursorless.org/cheatsheet, but didn't update the code path that is used when user says "cursorless cheatsheet"

## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet
