### PR TITLE
Support "name" and "value" in guard of Python for-each statements

### DIFF
--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/javascript/changeName4.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/javascript/changeName4.yml
@@ -1,0 +1,23 @@
+languageId: javascript
+command:
+  version: 6
+  spokenForm: change name
+  action:
+    name: clearAndSetSelection
+    target:
+      type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: name}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: for (const aaa of bbb) {}
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  marks: {}
+finalState:
+  documentContents: for (const  of bbb) {}
+  selections:
+    - anchor: {line: 0, character: 11}
+      active: {line: 0, character: 11}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/javascript/changeName5.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/javascript/changeName5.yml
@@ -1,0 +1,19 @@
+languageId: javascript
+command:
+  version: 6
+  spokenForm: change name
+  action:
+    name: clearAndSetSelection
+    target:
+      type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: name}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: for (const aaa of bbb) {}
+  selections:
+    - anchor: {line: 0, character: 24}
+      active: {line: 0, character: 24}
+  marks: {}
+thrownError: {name: NoContainingScopeError}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/javascript/changeValue4.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/javascript/changeValue4.yml
@@ -1,0 +1,23 @@
+languageId: javascript
+command:
+  version: 6
+  spokenForm: change value
+  action:
+    name: clearAndSetSelection
+    target:
+      type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: value}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: for (const aaa of bbb) {}
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  marks: {}
+finalState:
+  documentContents: for (const aaa of ) {}
+  selections:
+    - anchor: {line: 0, character: 18}
+      active: {line: 0, character: 18}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/javascript/changeValue5.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/javascript/changeValue5.yml
@@ -1,0 +1,19 @@
+languageId: javascript
+command:
+  version: 6
+  spokenForm: change value
+  action:
+    name: clearAndSetSelection
+    target:
+      type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: value}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: for (const aaa of bbb) {}
+  selections:
+    - anchor: {line: 0, character: 24}
+      active: {line: 0, character: 24}
+  marks: {}
+thrownError: {name: NoContainingScopeError}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/python/changeName.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/python/changeName.yml
@@ -1,0 +1,27 @@
+languageId: python
+command:
+  version: 6
+  spokenForm: change name
+  action:
+    name: clearAndSetSelection
+    target:
+      type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: name}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    for aaa in bbb:
+        pass
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  marks: {}
+finalState:
+  documentContents: |-
+    for  in bbb:
+        pass
+  selections:
+    - anchor: {line: 0, character: 4}
+      active: {line: 0, character: 4}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/python/changeName2.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/python/changeName2.yml
@@ -1,0 +1,21 @@
+languageId: python
+command:
+  version: 6
+  spokenForm: change name
+  action:
+    name: clearAndSetSelection
+    target:
+      type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: name}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    for aaa in bbb:
+        pass
+  selections:
+    - anchor: {line: 1, character: 4}
+      active: {line: 1, character: 4}
+  marks: {}
+thrownError: {name: NoContainingScopeError}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/python/changeValue3.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/python/changeValue3.yml
@@ -1,0 +1,27 @@
+languageId: python
+command:
+  version: 6
+  spokenForm: change value
+  action:
+    name: clearAndSetSelection
+    target:
+      type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: value}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    for aaa in bbb:
+        pass
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  marks: {}
+finalState:
+  documentContents: |-
+    for aaa in :
+        pass
+  selections:
+    - anchor: {line: 0, character: 11}
+      active: {line: 0, character: 11}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/python/changeValue4.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/python/changeValue4.yml
@@ -1,0 +1,21 @@
+languageId: python
+command:
+  version: 6
+  spokenForm: change value
+  action:
+    name: clearAndSetSelection
+    target:
+      type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: value}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    for aaa in bbb:
+        pass
+  selections:
+    - anchor: {line: 1, character: 4}
+      active: {line: 1, character: 4}
+  marks: {}
+thrownError: {name: NoContainingScopeError}

--- a/queries/javascript.core.scm
+++ b/queries/javascript.core.scm
@@ -310,6 +310,14 @@
   (_) @value
 ) @_.domain
 
+;; name:
+;;!! for (const aaa of bbb) {}
+;;!             ^^^
+;;!  ----------------------
+;; value:
+;;!! for (const aaa of bbb) {}
+;;!                    ^^^
+;;!  ----------------------
 (for_in_statement
   left: (_) @name
   right: (_) @value

--- a/queries/javascript.core.scm
+++ b/queries/javascript.core.scm
@@ -310,6 +310,12 @@
   (_) @value
 ) @_.domain
 
+(for_in_statement
+  left: (_) @name
+  right: (_) @value
+  ")" @_.domain.end.endOf
+) @_.domain.start.startOf
+
 [
   (program)
   (formal_parameters)

--- a/queries/python.scm
+++ b/queries/python.scm
@@ -84,7 +84,7 @@
 ;;!             ^^^
 ;;!  ---------------
 (for_statement
-  right: (identifier) @value
+  right: (_) @value
   ":" @value.domain.end
 ) @value.domain.start.startOf
 

--- a/queries/python.scm
+++ b/queries/python.scm
@@ -80,6 +80,14 @@
   (_) @value
 ) @_.domain
 
+;;!! for aaa in bbb:
+;;!             ^^^
+;;!  ---------------
+(for_statement
+  right: (identifier) @value
+  ":" @value.domain.end
+) @value.domain.start.startOf
+
 (comment) @comment @textFragment
 
 (string

--- a/queries/python.scm
+++ b/queries/python.scm
@@ -84,9 +84,10 @@
 ;;!             ^^^
 ;;!  ---------------
 (for_statement
+  left: (_) @name
   right: (_) @value
-  ":" @value.domain.end
-) @value.domain.start.startOf
+  ":" @_.domain.end
+) @_.domain.start.startOf
 
 (comment) @comment @textFragment
 

--- a/queries/python.scm
+++ b/queries/python.scm
@@ -80,8 +80,13 @@
   (_) @value
 ) @_.domain
 
+;; value:
 ;;!! for aaa in bbb:
 ;;!             ^^^
+;;!  ---------------
+;; name:
+;;!! for aaa in bbb:
+;;!      ^^^
 ;;!  ---------------
 (for_statement
   left: (_) @name


### PR DESCRIPTION
- Depends on https://github.com/cursorless-dev/cursorless/pull/1922, which migrates `"name"` in Python
- Depends on #1924, which migrates `value` in Typescript

## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet
