### PR TITLE
Migrate Python name and type scopes

### DIFF
--- a/packages/cursorless-engine/src/languages/python.ts
+++ b/packages/cursorless-engine/src/languages/python.ts
@@ -69,17 +69,6 @@ const nodeMatchers: Partial<
     // Ternaries
     patternMatcher("conditional_expression[1]"),
   ),
-  type: leadingMatcher(
-    ["function_definition[return_type]", "*[type]"],
-    [":", "->"],
-  ),
-  name: [
-    "assignment[left]",
-    "augmented_assignment[left]",
-    "typed_parameter.identifier!",
-    "parameters.identifier!",
-    "*[name]",
-  ],
   argumentOrParameter: cascadingMatcher(
     argumentMatcher("parameters", "argument_list"),
     matcher(patternFinder("call.generator_expression!"), childRangeSelector()),

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/python/changeEveryName.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/python/changeEveryName.yml
@@ -1,0 +1,33 @@
+languageId: python
+command:
+  version: 6
+  spokenForm: change every name
+  action:
+    name: clearAndSetSelection
+    target:
+      type: primitive
+      modifiers:
+        - type: everyScope
+          scopeType: {type: name}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    aaa = bbb
+    aaa: str = bbb
+    aaa: str
+  selections:
+    - anchor: {line: 2, character: 8}
+      active: {line: 2, character: 8}
+  marks: {}
+finalState:
+  documentContents: |2-
+     = bbb
+    : str = bbb
+    : str
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+    - anchor: {line: 1, character: 0}
+      active: {line: 1, character: 0}
+    - anchor: {line: 2, character: 0}
+      active: {line: 2, character: 0}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/python/changeEveryName2.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/python/changeEveryName2.yml
@@ -1,0 +1,31 @@
+languageId: python
+command:
+  version: 6
+  spokenForm: change every name
+  action:
+    name: clearAndSetSelection
+    target:
+      type: primitive
+      modifiers:
+        - type: everyScope
+          scopeType: {type: name}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    def aaa():
+        bbb = ccc
+        ddd = eee
+  selections:
+    - anchor: {line: 2, character: 13}
+      active: {line: 2, character: 13}
+  marks: {}
+finalState:
+  documentContents: |-
+    def aaa():
+         = ccc
+         = eee
+  selections:
+    - anchor: {line: 1, character: 4}
+      active: {line: 1, character: 4}
+    - anchor: {line: 2, character: 4}
+      active: {line: 2, character: 4}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/python/changeEveryName3.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/python/changeEveryName3.yml
@@ -1,0 +1,29 @@
+languageId: python
+command:
+  version: 6
+  spokenForm: change every name
+  action:
+    name: clearAndSetSelection
+    target:
+      type: primitive
+      modifiers:
+        - type: everyScope
+          scopeType: {type: name}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    def aaa(bbb, ccc: str):
+        pass
+  selections:
+    - anchor: {line: 0, character: 21}
+      active: {line: 0, character: 21}
+  marks: {}
+finalState:
+  documentContents: |-
+    def aaa(, : str):
+        pass
+  selections:
+    - anchor: {line: 0, character: 8}
+      active: {line: 0, character: 8}
+    - anchor: {line: 0, character: 10}
+      active: {line: 0, character: 10}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/python/changeEveryType.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/python/changeEveryType.yml
@@ -1,0 +1,29 @@
+languageId: python
+command:
+  version: 6
+  spokenForm: change every type
+  action:
+    name: clearAndSetSelection
+    target:
+      type: primitive
+      modifiers:
+        - type: everyScope
+          scopeType: {type: type}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    def aaa(bbb, ccc: str, ddd: str):
+        pass
+  selections:
+    - anchor: {line: 0, character: 8}
+      active: {line: 0, character: 8}
+  marks: {}
+finalState:
+  documentContents: |-
+    def aaa(bbb, ccc: , ddd: ):
+        pass
+  selections:
+    - anchor: {line: 0, character: 18}
+      active: {line: 0, character: 18}
+    - anchor: {line: 0, character: 25}
+      active: {line: 0, character: 25}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/python/changeEveryType2.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/python/changeEveryType2.yml
@@ -1,0 +1,31 @@
+languageId: python
+command:
+  version: 6
+  spokenForm: change every type
+  action:
+    name: clearAndSetSelection
+    target:
+      type: primitive
+      modifiers:
+        - type: everyScope
+          scopeType: {type: type}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    def aaa():
+        bbb: str
+        ccc: str = "hello"
+  selections:
+    - anchor: {line: 2, character: 22}
+      active: {line: 2, character: 22}
+  marks: {}
+finalState:
+  documentContents: |-
+    def aaa():
+        bbb: 
+        ccc:  = "hello"
+  selections:
+    - anchor: {line: 1, character: 9}
+      active: {line: 1, character: 9}
+    - anchor: {line: 2, character: 9}
+      active: {line: 2, character: 9}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/python/changeType.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/python/changeType.yml
@@ -1,0 +1,27 @@
+languageId: python
+command:
+  version: 6
+  spokenForm: change type
+  action:
+    name: clearAndSetSelection
+    target:
+      type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: type}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    def aaa(bbb, ccc: int):
+        pass
+  selections:
+    - anchor: {line: 0, character: 13}
+      active: {line: 0, character: 13}
+  marks: {}
+finalState:
+  documentContents: |-
+    def aaa(bbb, ccc: ):
+        pass
+  selections:
+    - anchor: {line: 0, character: 18}
+      active: {line: 0, character: 18}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/python/changeType2.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/python/changeType2.yml
@@ -1,0 +1,21 @@
+languageId: python
+command:
+  version: 6
+  spokenForm: change type
+  action:
+    name: clearAndSetSelection
+    target:
+      type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: type}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    def aaa(bbb, ccc: int):
+        pass
+  selections:
+    - anchor: {line: 0, character: 8}
+      active: {line: 0, character: 8}
+  marks: {}
+thrownError: {name: NoContainingScopeError}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/python/chuckName.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/python/chuckName.yml
@@ -1,0 +1,31 @@
+languageId: python
+command:
+  version: 6
+  spokenForm: chuck name
+  action:
+    name: remove
+    target:
+      type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: name}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    aaa = bbb
+    aaa: str = bbb
+  selections:
+    - anchor: {line: 0, character: 9}
+      active: {line: 0, character: 9}
+    - anchor: {line: 1, character: 9}
+      active: {line: 1, character: 14}
+  marks: {}
+finalState:
+  documentContents: |-
+    bbb
+    bbb
+  selections:
+    - anchor: {line: 0, character: 3}
+      active: {line: 0, character: 3}
+    - anchor: {line: 1, character: 0}
+      active: {line: 1, character: 3}

--- a/queries/python.scm
+++ b/queries/python.scm
@@ -38,14 +38,74 @@
   right: (_) @value @_.leading.end.startOf
 ) @_.domain
 
+;; value:
 ;;!! a /= 25
 ;;!       ^^
 ;;!   xxxxxx
 ;;!  -------
+;; name:
+;;!! a /= 25
+;;!  ^
+;;!  xxxxx
+;;!  -------
 (augmented_assignment
+  left: (_) @name @name.trailing.start.endOf @value.leading.start.endOf
+  right: (_) @value @value.leading.end.startOf @name.trailing.end.startOf
+) @_.domain
+
+;;!! a = 25
+;;!  ^
+;;!  xxxx
+;;!  ------
+;;!! a: int = 25
+;;!  ^
+;;!  xxxxxxxxx
+;;!  -----------
+(assignment
+  left: (_) @name @name.trailing.start.endOf
+  right: (_)? @name.trailing.end.startOf
+) @_.domain
+
+(_
+  name: (_) @name
+) @_.domain
+
+;;!! def aaa(bbb):
+;;!          ^^^
+(parameters
+  (identifier) @name
+)
+
+;;!! def aaa(bbb: str):
+;;!          ^^^
+;;!          --------
+(typed_parameter
+  .
+  (_) @name
+) @_.domain
+
+;; Matches any node at field `type` of its parent, with leading delimiter until
+;; previous named node. For example:
+;;!! aaa: str = "bbb";
+;;!       ^^^
+;;!  -----------------
+;;!     xxxxx
+(_
   (_) @_.leading.start.endOf
   .
-  right: (_) @value @_.leading.end.startOf
+  type: (_) @type @_.leading.end.startOf
+) @_.domain
+
+;;!!  def aaa() -> str:
+;;!                ^^^
+;;!            xxxxxxx
+;;!  [-----------------
+;;!!      pass
+;;!   --------]
+(function_definition
+  (_) @_.leading.start.endOf
+  .
+  return_type: (_) @type @_.leading.end.startOf
 ) @_.domain
 
 ;;!! d = {"a": 1234}
@@ -127,7 +187,7 @@
 ) @class @className.domain
 
 (module) @className.iteration @class.iteration
-(module) @statement.iteration
+(module) @statement.iteration @value.iteration @name.iteration
 (module) @namedFunction.iteration @functionName.iteration
 (class_definition) @namedFunction.iteration @functionName.iteration
 
@@ -138,7 +198,8 @@
 ;;!      *****
 ;;!!     c = 2
 ;;!      *****>
-(block) @statement.iteration @value.iteration
+(block) @statement.iteration @value.iteration @name.iteration
+(block) @type.iteration
 
 ;;!! {"a": 1, "b": 2, "c": 3}
 ;;!   **********************
@@ -150,6 +211,6 @@
 ;;!! def func(a=0, b=1):
 ;;!           ********
 (parameters
-  "(" @value.iteration.start.endOf
-  ")" @value.iteration.end.startOf
+  "(" @value.iteration.start.endOf @name.iteration.start.endOf @type.iteration.start.endOf
+  ")" @value.iteration.end.startOf @name.iteration.end.startOf @type.iteration.end.startOf
 )


### PR DESCRIPTION

## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet
