### PR TITLE
Fix value scope nesting in Typescript

### DIFF
--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/typescript/changeNextValue.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/typescript/changeNextValue.yml
@@ -1,0 +1,30 @@
+languageId: typescript
+command:
+  version: 6
+  spokenForm: change next value
+  action:
+    name: clearAndSetSelection
+    target:
+      type: primitive
+      modifiers:
+        - type: relativeScope
+          scopeType: {type: value}
+          offset: 1
+          length: 1
+          direction: forward
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    const aaa = 0;
+    const bbb = 0;
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  marks: {}
+finalState:
+  documentContents: |-
+    const aaa = 0;
+    const bbb = ;
+  selections:
+    - anchor: {line: 1, character: 12}
+      active: {line: 1, character: 12}

--- a/queries/javascript.core.scm
+++ b/queries/javascript.core.scm
@@ -353,11 +353,14 @@
 
 ;; Match nodes at field `value` of their parent node, setting leading delimiter
 ;; to be the range until the previous named node
-(_
-  (_)? @value.leading.start.endOf
-  .
-  value: (_) @value @value.leading.end.startOf
-) @_.domain
+(
+  (_
+    (_)? @value.leading.start.endOf
+    .
+    value: (_) @value @value.leading.end.startOf
+  ) @_.domain
+  (#not-type? @_.domain variable_declarator)
+)
 
 ;;!! const aaa = {bbb};
 ;;!               ^^^


### PR DESCRIPTION
We only want nested value scopes if there is more than one declarator in a statement.

Before:

<img width="186" alt="image" src="https://github.com/cursorless-dev/cursorless/assets/755842/0aaf4491-2c68-4be2-849d-ff5c72ac968a">

After:

<img width="185" alt="image" src="https://github.com/cursorless-dev/cursorless/assets/755842/3058a007-73b0-48cc-81dd-6f5b126fa07a">

Unfortunately we have no good way to test this change until we have https://github.com/cursorless-dev/cursorless/issues/1524

**Edit**: I found a way to test it, but it's a bit hacky.

## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet
