### PR TITLE
Add stronger typing for `Object.fromEntries`

### DIFF
--- a/typings/object.d.ts
+++ b/typings/object.d.ts
@@ -9,4 +9,24 @@ type ObjectKeys<T> = T extends object
 
 interface ObjectConstructor {
   keys<T>(o: T): ObjectKeys<T>;
+
+  fromEntries<
+    V extends PropertyKey,
+    T extends [readonly [V, any]] | Array<readonly [V, any]>,
+  >(
+    entries: T,
+  ): Flatten<UnionToIntersection<FromEntries<T[number]>>>;
 }
+
+// From https://github.com/microsoft/TypeScript/issues/35745#issuecomment-566932289
+type UnionToIntersection<T> = (T extends T ? (p: T) => void : never) extends (
+  p: infer U,
+) => void
+  ? U
+  : never;
+type FromEntries<T extends readonly [PropertyKey, any]> = T extends T
+  ? Record<T[0], T[1]>
+  : never;
+type Flatten<T> = object & {
+  [P in keyof T]: T[P];
+};


### PR DESCRIPTION


## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet
