### PR TITLE
Switch file watcher to stop use polling; bump vscode to 1.66.0

### DIFF
--- a/packages/cursorless-vscode-e2e/package.json
+++ b/packages/cursorless-vscode-e2e/package.json
@@ -29,7 +29,7 @@
     "@types/lodash": "4.14.181",
     "@types/mocha": "^8.0.4",
     "@types/sinon": "^10.0.2",
-    "@types/vscode": "~1.61.0",
+    "@types/vscode": "~1.66.0",
     "chai": "^4.3.6",
     "js-yaml": "^4.1.0",
     "mocha": "^10.2.0",

--- a/packages/cursorless-vscode/package.json
+++ b/packages/cursorless-vscode/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://www.cursorless.org/",
   "engines": {
-    "vscode": "^1.61.0"
+    "vscode": "^1.66.0"
   },
   "extensionKind": [
     "ui",
@@ -1069,7 +1069,7 @@
     "@types/sinon": "^10.0.2",
     "@types/tinycolor2": "1.4.3",
     "@types/uuid": "^8.3.4",
-    "@types/vscode": "~1.61.0",
+    "@types/vscode": "~1.66.0",
     "chai": "^4.3.6",
     "esbuild": "^0.17.11",
     "fast-xml-parser": "^4.2.5",

--- a/packages/cursorless-vscode/src/ide/vscode/VscodeFileSystem.ts
+++ b/packages/cursorless-vscode/src/ide/vscode/VscodeFileSystem.ts
@@ -1,12 +1,12 @@
 import { Disposable, FileSystem, PathChangeListener } from "@cursorless/common";
 import * as vscode from "vscode";
-import { RelativePattern, Uri, workspace } from "vscode";
+import { RelativePattern, workspace } from "vscode";
 
 export class VscodeFileSystem implements FileSystem {
   watchDir(path: string, onDidChange: PathChangeListener): Disposable {
     // FIXME: Support globs?
     const watcher = workspace.createFileSystemWatcher(
-      new RelativePattern(Uri.file(path), "**"),
+      new RelativePattern(path, "**"),
     );
 
     return vscode.Disposable.from(

--- a/packages/cursorless-vscode/src/ide/vscode/VscodeFileSystem.ts
+++ b/packages/cursorless-vscode/src/ide/vscode/VscodeFileSystem.ts
@@ -1,5 +1,4 @@
 import { Disposable, FileSystem, PathChangeListener } from "@cursorless/common";
-import * as vscode from "vscode";
 import { RelativePattern, workspace } from "vscode";
 
 export class VscodeFileSystem implements FileSystem {
@@ -9,11 +8,10 @@ export class VscodeFileSystem implements FileSystem {
       new RelativePattern(path, "**"),
     );
 
-    return vscode.Disposable.from(
-      watcher,
-      watcher.onDidChange(onDidChange),
-      watcher.onDidCreate(onDidChange),
-      watcher.onDidDelete(onDidChange),
-    );
+    watcher.onDidChange(onDidChange);
+    watcher.onDidCreate(onDidChange);
+    watcher.onDidDelete(onDidChange);
+
+    return watcher;
   }
 }

--- a/packages/cursorless-vscode/src/ide/vscode/VscodeFileSystem.ts
+++ b/packages/cursorless-vscode/src/ide/vscode/VscodeFileSystem.ts
@@ -1,52 +1,15 @@
-import {
-  Disposable,
-  FileSystem,
-  PathChangeListener,
-  walkFiles,
-} from "@cursorless/common";
-import { stat } from "fs/promises";
-import { max } from "lodash";
+import { Disposable, FileSystem, PathChangeListener } from "@cursorless/common";
+import { RelativePattern, Uri, workspace } from "vscode";
 
 export class VscodeFileSystem implements FileSystem {
   watchDir(path: string, onDidChange: PathChangeListener): Disposable {
-    // Just poll for now; we can take advantage of VSCode's sophisticated
-    // watcher later. Note that we would need to do a version check, as VSCode
-    // file watcher is only available in more recent versions of VSCode.
-    return new PollingFileSystemWatcher(path, onDidChange);
-  }
-}
-
-const CHECK_INTERVAL_MS = 1000;
-
-class PollingFileSystemWatcher implements Disposable {
-  private maxMtimeMs: number = -1;
-  private timer: NodeJS.Timer;
-
-  constructor(
-    private readonly path: string,
-    private readonly onDidChange: PathChangeListener,
-  ) {
-    this.checkForChanges = this.checkForChanges.bind(this);
-    this.timer = setInterval(this.checkForChanges, CHECK_INTERVAL_MS);
-  }
-
-  private async checkForChanges() {
-    const paths = await walkFiles(this.path);
-
-    const maxMtime =
-      max(
-        (await Promise.all(paths.map((file) => stat(file)))).map(
-          (stat) => stat.mtimeMs,
-        ),
-      ) ?? 0;
-
-    if (maxMtime > this.maxMtimeMs) {
-      this.maxMtimeMs = maxMtime;
-      this.onDidChange();
-    }
-  }
-
-  dispose() {
-    clearInterval(this.timer);
+    // FIXME: Support globs?
+    const watcher = workspace.createFileSystemWatcher(
+      new RelativePattern(Uri.file(path), "**"),
+    );
+    watcher.onDidChange(onDidChange);
+    watcher.onDidCreate(onDidChange);
+    watcher.onDidDelete(onDidChange);
+    return watcher;
   }
 }

--- a/packages/cursorless-vscode/src/ide/vscode/VscodeFileSystem.ts
+++ b/packages/cursorless-vscode/src/ide/vscode/VscodeFileSystem.ts
@@ -1,4 +1,5 @@
 import { Disposable, FileSystem, PathChangeListener } from "@cursorless/common";
+import * as vscode from "vscode";
 import { RelativePattern, Uri, workspace } from "vscode";
 
 export class VscodeFileSystem implements FileSystem {
@@ -7,9 +8,12 @@ export class VscodeFileSystem implements FileSystem {
     const watcher = workspace.createFileSystemWatcher(
       new RelativePattern(Uri.file(path), "**"),
     );
-    watcher.onDidChange(onDidChange);
-    watcher.onDidCreate(onDidChange);
-    watcher.onDidDelete(onDidChange);
-    return watcher;
+
+    return vscode.Disposable.from(
+      watcher,
+      watcher.onDidChange(onDidChange),
+      watcher.onDidCreate(onDidChange),
+      watcher.onDidDelete(onDidChange),
+    );
   }
 }

--- a/packages/cursorless-vscode/src/ide/vscode/hats/VscodeHatRenderer.ts
+++ b/packages/cursorless-vscode/src/ide/vscode/hats/VscodeHatRenderer.ts
@@ -414,10 +414,9 @@ function watchDir(
     new vscode.RelativePattern(path, `**/*${CURSORLESS_HAT_SHAPES_SUFFIX}`),
   );
 
-  return vscode.Disposable.from(
-    hatsDirWatcher,
-    hatsDirWatcher.onDidChange(onDidChange),
-    hatsDirWatcher.onDidCreate(onDidChange),
-    hatsDirWatcher.onDidDelete(onDidChange),
-  );
+  hatsDirWatcher.onDidChange(onDidChange);
+  hatsDirWatcher.onDidCreate(onDidChange);
+  hatsDirWatcher.onDidDelete(onDidChange);
+
+  return hatsDirWatcher;
 }

--- a/packages/vscode-common/package.json
+++ b/packages/vscode-common/package.json
@@ -15,7 +15,7 @@
     "@cursorless/common": "workspace:*"
   },
   "devDependencies": {
-    "@types/vscode": "~1.61.0"
+    "@types/vscode": "~1.66.0"
   },
   "types": "./out/index.d.ts",
   "exports": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -441,8 +441,8 @@ importers:
         specifier: ^8.3.4
         version: 8.3.4
       '@types/vscode':
-        specifier: ~1.61.0
-        version: 1.61.0
+        specifier: ~1.66.0
+        version: 1.66.0
       chai:
         specifier: ^4.3.6
         version: 4.3.7
@@ -493,8 +493,8 @@ importers:
         specifier: ^10.0.2
         version: 10.0.13
       '@types/vscode':
-        specifier: ~1.61.0
-        version: 1.61.0
+        specifier: ~1.66.0
+        version: 1.66.0
       chai:
         specifier: ^4.3.6
         version: 4.3.7
@@ -580,8 +580,8 @@ importers:
         version: link:../common
     devDependencies:
       '@types/vscode':
-        specifier: ~1.61.0
-        version: 1.61.0
+        specifier: ~1.66.0
+        version: 1.66.0
 
 packages:
 
@@ -4939,8 +4939,8 @@ packages:
       '@types/expect': 1.20.4
       '@types/node': 16.18.40
 
-  /@types/vscode@1.61.0:
-    resolution: {integrity: sha512-9k5Nwq45hkRwdfCFY+eKXeQQSbPoA114mF7U/4uJXRBJeGIO7MuJdhF1PnaDN+lllL9iKGQtd6FFXShBXMNaFg==}
+  /@types/vscode@1.66.0:
+    resolution: {integrity: sha512-ZfJck4M7nrGasfs4A4YbUoxis3Vu24cETw3DERsNYtDZmYSYtk6ljKexKFKhImO/ZmY6ZMsmegu2FPkXoUFImA==}
     dev: true
 
   /@types/webpack@5.28.0(webpack-cli@5.1.4):


### PR DESCRIPTION
- Fixes https://github.com/cursorless-dev/cursorless/issues/1808
- Fixes https://github.com/cursorless-dev/cursorless/issues/1846

## Checklist

- [-] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [-] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [-] I have not broken the cheatsheet
