### PR TITLE
Expand scope visualizer api

### DIFF
--- a/packages/cursorless-vscode/src/ScopeVisualizerCommandApi.ts
+++ b/packages/cursorless-vscode/src/ScopeVisualizerCommandApi.ts
@@ -1,8 +1,15 @@
-import { ScopeType } from "@cursorless/common";
+import { Disposable, ScopeType } from "@cursorless/common";
 
-export interface ScopeVisualizerCommandApi {
+export type ScopeVisualizerListener = (
+  scopeType: ScopeType | undefined,
+  visualizationType: VisualizationType | undefined,
+) => void;
+
+export interface ScopeVisualizer {
   start(scopeType: ScopeType, visualizationType: VisualizationType): void;
   stop(): void;
+  readonly scopeType: ScopeType | undefined;
+  onDidChangeScopeType(listener: ScopeVisualizerListener): Disposable;
 }
 
 export type VisualizationType = "content" | "removal" | "iteration";

--- a/packages/cursorless-vscode/src/registerCommands.ts
+++ b/packages/cursorless-vscode/src/registerCommands.ts
@@ -14,14 +14,14 @@ import { showDocumentation, showQuickPick } from "./commands";
 import { VscodeIDE } from "./ide/vscode/VscodeIDE";
 import { VscodeHats } from "./ide/vscode/hats/VscodeHats";
 import { KeyboardCommands } from "./keyboard/KeyboardCommands";
-import { ScopeVisualizerCommandApi } from "./ScopeVisualizerCommandApi";
+import { ScopeVisualizer } from "./ScopeVisualizerCommandApi";
 
 export function registerCommands(
   extensionContext: vscode.ExtensionContext,
   vscodeIde: VscodeIDE,
   commandApi: CommandApi,
   testCaseRecorder: TestCaseRecorder,
-  scopeVisualizer: ScopeVisualizerCommandApi,
+  scopeVisualizer: ScopeVisualizer,
   keyboardCommands: KeyboardCommands,
   hats: VscodeHats,
 ): void {


### PR DESCRIPTION
- Required by #1942 to be able to tell which scope is currently being visualized to highlight it in the sidebar

## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet
