### PR TITLE
Don't report error for self parameter name

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,3 +12,6 @@ select = ["E", "F", "C4", "I001", "UP", "SIM"]
 ignore = ["E501", "SIM105", "UP035"]
 target-version = "py39"
 extend-exclude = ["vendor", "data/playground/**/*.py"]
+
+[tool.pyright]
+reportSelfClsParameterName = false


### PR DESCRIPTION
Suppresses `Instance methods should take a "self" parameter` warnings in editors that use pyright (eg VSCode). Due to the way Talon defines action classes, these warnings are almost always noise in any Talon user file set

## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet
