### PR TITLE
Tweak hat sizes

### DIFF
--- a/packages/cursorless-vscode/src/ide/vscode/hats/shapeAdjustments.ts
+++ b/packages/cursorless-vscode/src/ide/vscode/hats/shapeAdjustments.ts
@@ -15,30 +15,23 @@ export const defaultShapeAdjustments: IndividualHatAdjustmentMap = {
     sizeAdjustment: -30,
   },
   ex: {
-    sizeAdjustment: -15,
+    sizeAdjustment: -12.5,
   },
   fox: {
-    sizeAdjustment: -10,
+    sizeAdjustment: -5,
   },
   wing: {
     sizeAdjustment: -2.5,
   },
-  hole: {
-    sizeAdjustment: -5.5,
-  },
+  hole: {},
   frame: {
     sizeAdjustment: -20,
   },
   curve: {
-    sizeAdjustment: -6,
-    verticalOffset: -3,
+    verticalOffset: -5,
   },
-  eye: {
-    sizeAdjustment: -4.5,
-  },
+  eye: {},
   play: {},
-  bolt: {
-    sizeAdjustment: -5.5,
-  },
+  bolt: {},
   crosshairs: {},
 };


### PR DESCRIPTION
Since we updated our hat shapes I have been tweaking my own internal shape settings. 

## Checklist

- [-] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [-] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [-] I have not broken the cheatsheet
