### PR TITLE
Switch from util.isDeepStrictEqual to lodash.isEqual.

### DIFF
--- a/packages/cursorless-engine/src/core/commandVersionUpgrades/upgradeV1ToV2/upgradeStrictHere.ts
+++ b/packages/cursorless-engine/src/core/commandVersionUpgrades/upgradeV1ToV2/upgradeStrictHere.ts
@@ -1,4 +1,4 @@
-import { isDeepStrictEqual } from "util";
+import { isEqual } from "lodash";
 import { PartialPrimitiveTargetDescriptorV2 } from "@cursorless/common";
 
 const STRICT_HERE = {
@@ -16,4 +16,4 @@ const IMPLICIT_TARGET: PartialPrimitiveTargetDescriptorV2 = {
 export const upgradeStrictHere = (
   target: PartialPrimitiveTargetDescriptorV2,
 ): PartialPrimitiveTargetDescriptorV2 =>
-  isDeepStrictEqual(target, STRICT_HERE) ? IMPLICIT_TARGET : target;
+  isEqual(target, STRICT_HERE) ? IMPLICIT_TARGET : target;


### PR DESCRIPTION
upgradeStrictHere.ts uses util.isDeepStrictEqual and using that version in the web version of Cursorless will be a hassle.  Use lodash.isEqual instead: ["Performs a deep comparison between two values to determine if they are equivalent."](https://lodash.com/docs#isEqual)
