### PR TITLE
Support `as const` for `"type"`

### DIFF
--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/typescript/changeType9.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/typescript/changeType9.yml
@@ -1,0 +1,23 @@
+languageId: typescript
+command:
+  version: 6
+  spokenForm: change type
+  action:
+    name: clearAndSetSelection
+    target:
+      type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: type}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: const aaa = "bbb" as const;
+  selections:
+    - anchor: {line: 0, character: 12}
+      active: {line: 0, character: 12}
+  marks: {}
+finalState:
+  documentContents: const aaa = "bbb" as ;
+  selections:
+    - anchor: {line: 0, character: 21}
+      active: {line: 0, character: 21}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/typescript/chuckType5.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/typescript/chuckType5.yml
@@ -1,0 +1,23 @@
+languageId: typescript
+command:
+  version: 6
+  spokenForm: chuck type
+  action:
+    name: remove
+    target:
+      type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: type}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: const aaa = "bbb" as const;
+  selections:
+    - anchor: {line: 0, character: 12}
+      active: {line: 0, character: 12}
+  marks: {}
+finalState:
+  documentContents: const aaa = "bbb";
+  selections:
+    - anchor: {line: 0, character: 12}
+      active: {line: 0, character: 12}

--- a/queries/typescript.core.scm
+++ b/queries/typescript.core.scm
@@ -198,10 +198,7 @@
 ;;!  ----------
 (as_expression
   (_) @_.leading.start.endOf
-  [
-    (generic_type)
-    (predefined_type)
-  ] @type @_.leading.end.startOf
+  (_) @type @_.leading.end.startOf
 ) @_.domain
 
 ;;!! aaa satisfies Bbb


### PR DESCRIPTION
- Fixes https://github.com/cursorless-dev/cursorless/issues/1990

## Checklist

- [x] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [-] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [-] I have not broken the cheatsheet
