### PR TITLE
Support wrapping snippet placeholders

### DIFF
--- a/packages/cursorless-engine/src/snippets/snippet.ts
+++ b/packages/cursorless-engine/src/snippets/snippet.ts
@@ -54,6 +54,12 @@ export function transformSnippetVariables(
         candidate.parent.replace(candidate, [placeholder]);
       }
     }
+
+    if (candidate instanceof Placeholder) {
+      if (candidate.index.toString() === placeholderName) {
+        candidate.parent.replace(candidate, [new Variable("TM_SELECTED_TEXT")]);
+      }
+    }
     return true;
   });
 }

--- a/packages/cursorless-engine/src/snippets/snippet.ts
+++ b/packages/cursorless-engine/src/snippets/snippet.ts
@@ -53,9 +53,7 @@ export function transformSnippetVariables(
         candidate.children.forEach((child) => placeholder.appendChild(child));
         candidate.parent.replace(candidate, [placeholder]);
       }
-    }
-
-    if (candidate instanceof Placeholder) {
+    } else if (candidate instanceof Placeholder) {
       if (candidate.index.toString() === placeholderName) {
         candidate.parent.replace(candidate, [new Variable("TM_SELECTED_TEXT")]);
       }

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/actions/snippets/ifWrapCap.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/actions/snippets/ifWrapCap.yml
@@ -1,0 +1,40 @@
+languageId: typescript
+command:
+  version: 6
+  spokenForm: if wrap cap
+  action:
+    name: wrapWithSnippet
+    snippetDescription:
+      type: custom
+      body: "if ($1) {\n\t$0\n}"
+      scopeType: {type: statement}
+      variableName: "0"
+    target:
+      type: primitive
+      mark: {type: decoratedSymbol, symbolColor: default, character: c}
+  usePrePhraseSnapshot: true
+spokenFormError: Custom wrap with snippet
+initialState:
+  documentContents: const value = 2;
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  marks:
+    default.c:
+      start: {line: 0, character: 0}
+      end: {line: 0, character: 5}
+finalState:
+  documentContents: |-
+    if () {
+        const value = 2;
+    }
+  selections:
+    - anchor: {line: 0, character: 4}
+      active: {line: 0, character: 4}
+  thatMark:
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 0}
+        end: {line: 2, character: 1}
+      isReversed: false
+      hasExplicitRange: true


### PR DESCRIPTION
Support wrapping placeholders/numbered holes in snippets

## Checklist

- [x] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [-] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [-] I have not broken the cheatsheet
