### PR TITLE
Use dependency injection for TestCaseRecorder

### DIFF
--- a/packages/cursorless-engine/src/api/CursorlessEngineApi.ts
+++ b/packages/cursorless-engine/src/api/CursorlessEngineApi.ts
@@ -1,19 +1,20 @@
 import { Command, HatTokenMap, IDE } from "@cursorless/common";
 import { Snippets } from "../core/Snippets";
 import { StoredTargetMap } from "../core/StoredTargets";
-import { TestCaseRecorder } from "../testCaseRecorder/TestCaseRecorder";
 import { ScopeProvider } from "@cursorless/common";
+import { CommandRunner } from "../CommandRunner";
+import { ReadOnlyHatMap } from "@cursorless/common";
 
 export interface CursorlessEngine {
   commandApi: CommandApi;
   scopeProvider: ScopeProvider;
   customSpokenFormGenerator: CustomSpokenFormGenerator;
-  testCaseRecorder: TestCaseRecorder;
   storedTargets: StoredTargetMap;
   hatTokenMap: HatTokenMap;
   snippets: Snippets;
   injectIde: (ide: IDE | undefined) => void;
   runIntegrationTests: () => Promise<void>;
+  addCommandRunnerDecorator: (commandRunnerDecorator: CommandRunnerDecorator) => void;
 }
 
 export interface CustomSpokenFormGenerator {
@@ -38,4 +39,14 @@ export interface CommandApi {
    * the command args are of the correct shape.
    */
   runCommandSafe(...args: unknown[]): Promise<unknown>;
+}
+
+export interface CommandRunnerDecorator {
+  /**
+   * @param commandRunner: A CommandRunner.
+   * @param readableHatMap: A ReadOnlyHatMap.
+   * @returns A new CommandRunner that invokes the provided CommandRunner in
+   *   addition to performing some other work.
+   */
+  wrapCommandRunner: (readableHatMap: ReadOnlyHatMap, commandRunner: CommandRunner) => CommandRunner;
 }

--- a/packages/cursorless-engine/src/cursorlessEngine.ts
+++ b/packages/cursorless-engine/src/cursorlessEngine.ts
@@ -63,7 +63,7 @@ export function createCursorlessEngine(
 
   ide.disposeOnExit(rangeUpdater, languageDefinitions, hatTokenMap, debug);
 
-  let commandRunnerDecorators = new Array<CommandRunnerDecorator>;
+  const commandRunnerDecorators: CommandRunnerDecorator[] = [];
 
   return {
     commandApi: {

--- a/packages/cursorless-engine/src/cursorlessEngine.ts
+++ b/packages/cursorless-engine/src/cursorlessEngine.ts
@@ -7,7 +7,7 @@ import {
   ScopeProvider,
 } from "@cursorless/common";
 import { StoredTargetMap, TestCaseRecorder, TreeSitter } from ".";
-import { CursorlessEngine } from "./api/CursorlessEngineApi";
+import { CommandRunnerDecorator, CursorlessEngine } from "./api/CursorlessEngineApi";
 import { Debug } from "./core/Debug";
 import { HatTokenMapImpl } from "./core/HatTokenMapImpl";
 import { Snippets } from "./core/Snippets";
@@ -53,8 +53,6 @@ export function createCursorlessEngine(
 
   const storedTargets = new StoredTargetMap();
 
-  const testCaseRecorder = new TestCaseRecorder(hatTokenMap, storedTargets);
-
   const languageDefinitions = new LanguageDefinitions(fileSystem, treeSitter);
 
   const talonSpokenForms = new TalonSpokenFormsJsonReader(fileSystem);
@@ -65,6 +63,8 @@ export function createCursorlessEngine(
 
   ide.disposeOnExit(rangeUpdater, languageDefinitions, hatTokenMap, debug);
 
+  let commandRunnerDecorators = new Array<CommandRunnerDecorator>;
+
   return {
     commandApi: {
       runCommand(command: Command) {
@@ -72,11 +72,11 @@ export function createCursorlessEngine(
           treeSitter,
           debug,
           hatTokenMap,
-          testCaseRecorder,
           snippets,
           storedTargets,
           languageDefinitions,
           rangeUpdater,
+          commandRunnerDecorators,
           command,
         );
       },
@@ -86,11 +86,11 @@ export function createCursorlessEngine(
           treeSitter,
           debug,
           hatTokenMap,
-          testCaseRecorder,
           snippets,
           storedTargets,
           languageDefinitions,
           rangeUpdater,
+          commandRunnerDecorators,
           ensureCommandShape(args),
         );
       },
@@ -101,13 +101,15 @@ export function createCursorlessEngine(
       customSpokenFormGenerator,
     ),
     customSpokenFormGenerator,
-    testCaseRecorder,
     storedTargets,
     hatTokenMap,
     snippets,
     injectIde,
     runIntegrationTests: () =>
       runIntegrationTests(treeSitter, languageDefinitions),
+    addCommandRunnerDecorator: (decorator: CommandRunnerDecorator) => {
+      commandRunnerDecorators.push(decorator);
+    }
   };
 }
 

--- a/packages/cursorless-engine/src/index.ts
+++ b/packages/cursorless-engine/src/index.ts
@@ -6,3 +6,4 @@ export * from "./core/StoredTargets";
 export * from "./typings/TreeSitter";
 export * from "./cursorlessEngine";
 export * from "./api/CursorlessEngineApi";
+export * from "./CommandRunner";

--- a/packages/cursorless-engine/src/index.ts
+++ b/packages/cursorless-engine/src/index.ts
@@ -6,4 +6,3 @@ export * from "./core/StoredTargets";
 export * from "./typings/TreeSitter";
 export * from "./cursorlessEngine";
 export * from "./api/CursorlessEngineApi";
-export * from "./CommandRunner";

--- a/packages/cursorless-engine/src/runCommand.ts
+++ b/packages/cursorless-engine/src/runCommand.ts
@@ -34,7 +34,7 @@ export async function runCommand(
   storedTargets: StoredTargetMap,
   languageDefinitions: LanguageDefinitions,
   rangeUpdater: RangeUpdater,
-  commandRunnerDecorators: Array<CommandRunnerDecorator>,
+  commandRunnerDecorators: CommandRunnerDecorator[],
   command: Command,
 ): Promise<unknown> {
   if (debug.active) {

--- a/packages/cursorless-engine/src/runCommand.ts
+++ b/packages/cursorless-engine/src/runCommand.ts
@@ -12,6 +12,7 @@ import { TargetPipelineRunner } from "./processTargets";
 import { MarkStageFactoryImpl } from "./processTargets/MarkStageFactoryImpl";
 import { ModifierStageFactoryImpl } from "./processTargets/ModifierStageFactoryImpl";
 import { ScopeHandlerFactoryImpl } from "./processTargets/modifiers/scopeHandlers";
+import { CommandRunnerDecorator } from "./api/CursorlessEngineApi";
 
 /**
  * Entry point for Cursorless commands. We proceed as follows:
@@ -29,11 +30,11 @@ export async function runCommand(
   treeSitter: TreeSitter,
   debug: Debug,
   hatTokenMap: HatTokenMap,
-  testCaseRecorder: TestCaseRecorder,
   snippets: Snippets,
   storedTargets: StoredTargetMap,
   languageDefinitions: LanguageDefinitions,
   rangeUpdater: RangeUpdater,
+  commandRunnerDecorators: Array<CommandRunnerDecorator>,
   command: Command,
 ): Promise<unknown> {
   if (debug.active) {
@@ -57,11 +58,8 @@ export async function runCommand(
     rangeUpdater,
   );
 
-  if (testCaseRecorder.isActive()) {
-    commandRunner = testCaseRecorder.wrapCommandRunner(
-      readableHatMap,
-      commandRunner,
-    );
+  for (var decorator of commandRunnerDecorators) {
+    commandRunner = decorator.wrapCommandRunner(readableHatMap, commandRunner);
   }
 
   return await commandRunner.run(commandComplete);

--- a/packages/cursorless-engine/src/testCaseRecorder/TestCaseRecorder.ts
+++ b/packages/cursorless-engine/src/testCaseRecorder/TestCaseRecorder.ts
@@ -459,6 +459,9 @@ export class TestCaseRecorder {
     readableHatMap: ReadOnlyHatMap,
     runner: CommandRunner,
   ): CommandRunner {
+    if (!this.isActive()) {
+      return runner;
+    }
     return {
       run: async (commandComplete: CommandComplete) => {
         try {

--- a/packages/cursorless-vscode/src/extension.ts
+++ b/packages/cursorless-vscode/src/extension.ts
@@ -49,7 +49,7 @@ import {
 import { StatusBarItem } from "./StatusBarItem";
 import { vscodeApi } from "./vscodeApi";
 import { mkdir } from "fs/promises";
-import { CommandRunner, TestCaseRecorder } from "@cursorless/cursorless-engine";
+import { TestCaseRecorder } from "@cursorless/cursorless-engine";
 import { ReadOnlyHatMap } from "@cursorless/common";
 
 /**

--- a/packages/cursorless-vscode/src/extension.ts
+++ b/packages/cursorless-vscode/src/extension.ts
@@ -52,24 +52,6 @@ import { mkdir } from "fs/promises";
 import { CommandRunner, TestCaseRecorder } from "@cursorless/cursorless-engine";
 import { ReadOnlyHatMap } from "@cursorless/common";
 
-class TestCaseRecorderCommandRunnerDecorator implements CommandRunnerDecorator {
-  testCaseRecorder: TestCaseRecorder;
-
-  constructor(testCaseRecorder: TestCaseRecorder) {
-    this.testCaseRecorder = testCaseRecorder;
-  }
-  wrapCommandRunner(readableHatMap: ReadOnlyHatMap, commandRunner: CommandRunner) {
-    if (this.testCaseRecorder.isActive()) {
-      return this.testCaseRecorder.wrapCommandRunner(
-        readableHatMap,
-        commandRunner,
-      );
-    } else {
-      return commandRunner;
-    }
-  }
-}
-
 /**
  * Extension entrypoint called by VSCode on Cursorless startup.
  * - Creates a dependency container {@link Graph} with the components that
@@ -120,7 +102,7 @@ export async function activate(
   );
 
   const testCaseRecorder = new TestCaseRecorder(hatTokenMap, storedTargets);
-  addCommandRunnerDecorator(new TestCaseRecorderCommandRunnerDecorator(testCaseRecorder));
+  addCommandRunnerDecorator(testCaseRecorder);
 
   const statusBarItem = StatusBarItem.create("cursorless.showQuickPick");
   const keyboardCommands = KeyboardCommands.create(context, statusBarItem);


### PR DESCRIPTION
Use dependency injection for getting TestCaseRecorder into CursorlessEngine.

A future PR should perhaps move TestCaseRecorder into a new package, @cursorless/cursorless-dev or similar, to isolate developer-only dependencies that are needed in production code.

This is an alternate approach to https://github.com/cursorless-dev/cursorless/pull/2001 requested in a comment.

It is also the most TypeScript I've written to date, so I probably did some things stylistically wrong. Class `TestCaseRecorderCommandRunnerDecorator` in particular feels very C++-like, not very TS-like, to me.
