### PR TITLE
Added private setting to change line iteration scope to paragraph

### DIFF
--- a/packages/common/src/ide/types/Configuration.ts
+++ b/packages/common/src/ide/types/Configuration.ts
@@ -9,6 +9,9 @@ export type CursorlessConfiguration = {
   experimental: { snippetsDir: string | undefined; hatStability: HatStability };
   decorationDebounceDelayMs: number;
   debug: boolean;
+  private: {
+    lineParagraphIterationScope: boolean;
+  };
 };
 
 export type CursorlessConfigKey = keyof CursorlessConfiguration;
@@ -27,6 +30,9 @@ export const CONFIGURATION_DEFAULTS: CursorlessConfiguration = {
     hatStability: HatStability.balanced,
   },
   debug: false,
+  private: {
+    lineParagraphIterationScope: false,
+  },
 };
 
 export interface Configuration {

--- a/packages/cursorless-engine/src/processTargets/modifiers/scopeHandlers/LineScopeHandler.ts
+++ b/packages/cursorless-engine/src/processTargets/modifiers/scopeHandlers/LineScopeHandler.ts
@@ -1,17 +1,25 @@
-import { Position, Range, TextEditor } from "@cursorless/common";
-import { Direction, ScopeType } from "@cursorless/common";
+import {
+  Direction,
+  Position,
+  Range,
+  ScopeType,
+  SimpleScopeTypeType,
+  TextEditor,
+} from "@cursorless/common";
+import { ide } from "../../../singletons/ide.singleton";
 import { LineTarget } from "../../targets";
 import { BaseScopeHandler } from "./BaseScopeHandler";
 import type { TargetScope } from "./scope.types";
 
 export class LineScopeHandler extends BaseScopeHandler {
   public readonly scopeType = { type: "line" } as const;
-  public readonly iterationScopeType = { type: "document" } as const;
+  public readonly iterationScopeType: ScopeType;
   protected readonly isHierarchical = false;
   public readonly includeAdjacentInEvery: boolean = true;
 
   constructor(_scopeType: ScopeType, _languageId: string) {
     super();
+    this.iterationScopeType = { type: getIterationScopeTypeType() };
   }
 
   *generateScopeCandidates(
@@ -66,4 +74,11 @@ export function fitRangeToLineContent(editor: TextEditor, range: Range) {
     endLine.lineNumber,
     endLine.lastNonWhitespaceCharacterIndex,
   );
+}
+
+function getIterationScopeTypeType(): SimpleScopeTypeType {
+  const useParagraph = ide().configuration.getOwnConfiguration(
+    "private.lineParagraphIterationScope",
+  );
+  return useParagraph ? "paragraph" : "document";
 }


### PR DESCRIPTION
`"cursorless.private.lineParagraphIterationScope": true,`

## Checklist

- [-] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [-] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [-] I have not broken the cheatsheet
