### PR TITLE
Expand `"type"` to include generic type arguments / parameters

### DIFF
--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/typescript/changeType10.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/typescript/changeType10.yml
@@ -1,0 +1,31 @@
+languageId: typescript
+command:
+  version: 6
+  spokenForm: change type
+  action:
+    name: clearAndSetSelection
+    target:
+      type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: type}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    useState<string>()
+    useState<Record<string, string>>()
+  selections:
+    - anchor: {line: 0, character: 9}
+      active: {line: 0, character: 9}
+    - anchor: {line: 1, character: 9}
+      active: {line: 1, character: 9}
+  marks: {}
+finalState:
+  documentContents: |-
+    useState<>()
+    useState<>()
+  selections:
+    - anchor: {line: 0, character: 9}
+      active: {line: 0, character: 9}
+    - anchor: {line: 1, character: 9}
+      active: {line: 1, character: 9}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/typescript/changeType11.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/typescript/changeType11.yml
@@ -1,0 +1,23 @@
+languageId: typescript
+command:
+  version: 6
+  spokenForm: change type
+  action:
+    name: clearAndSetSelection
+    target:
+      type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: type}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: foo<Record<string, string>>()
+  selections:
+    - anchor: {line: 0, character: 4}
+      active: {line: 0, character: 4}
+  marks: {}
+finalState:
+  documentContents: foo<>()
+  selections:
+    - anchor: {line: 0, character: 4}
+      active: {line: 0, character: 4}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/typescript/changeType12.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/typescript/changeType12.yml
@@ -1,0 +1,23 @@
+languageId: typescript
+command:
+  version: 6
+  spokenForm: change type
+  action:
+    name: clearAndSetSelection
+    target:
+      type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: type}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: foo<string, string>()
+  selections:
+    - anchor: {line: 0, character: 4}
+      active: {line: 0, character: 4}
+  marks: {}
+finalState:
+  documentContents: foo<, string>()
+  selections:
+    - anchor: {line: 0, character: 4}
+      active: {line: 0, character: 4}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/typescript/changeType13.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/typescript/changeType13.yml
@@ -1,0 +1,23 @@
+languageId: typescript
+command:
+  version: 6
+  spokenForm: change type
+  action:
+    name: clearAndSetSelection
+    target:
+      type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: type}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: foo<string, string>()
+  selections:
+    - anchor: {line: 0, character: 12}
+      active: {line: 0, character: 12}
+  marks: {}
+finalState:
+  documentContents: foo<string, >()
+  selections:
+    - anchor: {line: 0, character: 12}
+      active: {line: 0, character: 12}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/typescript/changeType14.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/typescript/changeType14.yml
@@ -1,0 +1,23 @@
+languageId: typescript
+command:
+  version: 6
+  spokenForm: change type
+  action:
+    name: clearAndSetSelection
+    target:
+      type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: type}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: Foo<string>()
+  selections:
+    - anchor: {line: 0, character: 4}
+      active: {line: 0, character: 4}
+  marks: {}
+finalState:
+  documentContents: Foo<>()
+  selections:
+    - anchor: {line: 0, character: 4}
+      active: {line: 0, character: 4}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/typescript/changeType15.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/typescript/changeType15.yml
@@ -1,0 +1,31 @@
+languageId: typescript
+command:
+  version: 6
+  spokenForm: change type
+  action:
+    name: clearAndSetSelection
+    target:
+      type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: type}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |+
+    function foo<A>() {
+        
+    }
+
+  selections:
+    - anchor: {line: 0, character: 13}
+      active: {line: 0, character: 13}
+  marks: {}
+finalState:
+  documentContents: |+
+    function foo<>() {
+        
+    }
+
+  selections:
+    - anchor: {line: 0, character: 13}
+      active: {line: 0, character: 13}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/typescript/changeType16.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/typescript/changeType16.yml
@@ -1,0 +1,29 @@
+languageId: typescript
+command:
+  version: 6
+  spokenForm: change type
+  action:
+    name: clearAndSetSelection
+    target:
+      type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: type}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |
+    const bar = <A>() => {
+        
+    }
+  selections:
+    - anchor: {line: 0, character: 13}
+      active: {line: 0, character: 13}
+  marks: {}
+finalState:
+  documentContents: |
+    const bar = <>() => {
+        
+    }
+  selections:
+    - anchor: {line: 0, character: 13}
+      active: {line: 0, character: 13}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/typescript/changeType17.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/typescript/changeType17.yml
@@ -1,0 +1,23 @@
+languageId: typescript
+command:
+  version: 6
+  spokenForm: change type
+  action:
+    name: clearAndSetSelection
+    target:
+      type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: type}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: "const foo: Record<string, string> = {}"
+  selections:
+    - anchor: {line: 0, character: 18}
+      active: {line: 0, character: 18}
+  marks: {}
+finalState:
+  documentContents: "const foo: Record<, string> = {}"
+  selections:
+    - anchor: {line: 0, character: 18}
+      active: {line: 0, character: 18}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/typescript/changeType18.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/typescript/changeType18.yml
@@ -1,0 +1,23 @@
+languageId: typescript
+command:
+  version: 6
+  spokenForm: change type
+  action:
+    name: clearAndSetSelection
+    target:
+      type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: type}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: "const foo: string = new Bar<number>(foo);"
+  selections:
+    - anchor: {line: 0, character: 24}
+      active: {line: 0, character: 24}
+  marks: {}
+finalState:
+  documentContents: "const foo: string = new (foo);"
+  selections:
+    - anchor: {line: 0, character: 24}
+      active: {line: 0, character: 24}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/typescript/changeType19.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/typescript/changeType19.yml
@@ -1,0 +1,23 @@
+languageId: typescript
+command:
+  version: 6
+  spokenForm: change type
+  action:
+    name: clearAndSetSelection
+    target:
+      type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: type}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: "const foo: Bar<number> = new Bar<number>(foo);"
+  selections:
+    - anchor: {line: 0, character: 11}
+      active: {line: 0, character: 11}
+  marks: {}
+finalState:
+  documentContents: "const foo:  = new Bar<number>(foo);"
+  selections:
+    - anchor: {line: 0, character: 11}
+      active: {line: 0, character: 11}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/typescript/changeType20.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/typescript/changeType20.yml
@@ -1,0 +1,23 @@
+languageId: typescript
+command:
+  version: 6
+  spokenForm: change type
+  action:
+    name: clearAndSetSelection
+    target:
+      type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: type}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: "const foo: Bar<number> = new Bar<number>(foo);"
+  selections:
+    - anchor: {line: 0, character: 15}
+      active: {line: 0, character: 15}
+  marks: {}
+finalState:
+  documentContents: "const foo: Bar<> = new Bar<number>(foo);"
+  selections:
+    - anchor: {line: 0, character: 15}
+      active: {line: 0, character: 15}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/typescript/clearType.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/typescript/clearType.yml
@@ -13,7 +13,7 @@ initialState:
       active: {line: 0, character: 18}
   marks: {}
 finalState:
-  documentContents: "function whatever<T>():  {}"
+  documentContents: "function whatever<>(): string {}"
   selections:
-    - anchor: {line: 0, character: 24}
-      active: {line: 0, character: 24}
+    - anchor: {line: 0, character: 18}
+      active: {line: 0, character: 18}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/typescript/clearTypeNear.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/typescript/clearTypeNear.yml
@@ -17,7 +17,7 @@ initialState:
       start: {line: 0, character: 28}
       end: {line: 0, character: 34}
 finalState:
-  documentContents: "const foo: string = new (foo);"
+  documentContents: "const foo: string = new Bar<>(foo);"
   selections:
-    - anchor: {line: 0, character: 24}
-      active: {line: 0, character: 24}
+    - anchor: {line: 0, character: 28}
+      active: {line: 0, character: 28}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/typescript/clearTypeNear2.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/typescript/clearTypeNear2.yml
@@ -17,7 +17,7 @@ initialState:
       start: {line: 0, character: 24}
       end: {line: 0, character: 30}
 finalState:
-  documentContents: "const foo:  = bar<number>(foo);"
+  documentContents: "const foo: string = bar<>(foo);"
   selections:
-    - anchor: {line: 0, character: 11}
-      active: {line: 0, character: 11}
+    - anchor: {line: 0, character: 24}
+      active: {line: 0, character: 24}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/typescript/clearTypeUrge.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/typescript/clearTypeUrge.yml
@@ -17,7 +17,7 @@ initialState:
       start: {line: 0, character: 15}
       end: {line: 0, character: 21}
 finalState:
-  documentContents: "const foo:  = new Bar<number>(foo);"
+  documentContents: "const foo: Bar<> = new Bar<number>(foo);"
   selections:
-    - anchor: {line: 0, character: 11}
-      active: {line: 0, character: 11}
+    - anchor: {line: 0, character: 15}
+      active: {line: 0, character: 15}

--- a/queries/typescript.core.scm
+++ b/queries/typescript.core.scm
@@ -177,26 +177,17 @@
 ;;!           ^^^^^^
 ;;!! useState<Record<string, string>>()
 ;;!           ^^^^^^^^^^^^^^^^^^^^^^
-(call_expression
-  type_arguments: (type_arguments
-    (_) @type
-  )
+;;!                  ^^^^^^  ^^^^^^
+(type_arguments
+  (_) @type
 )
 
 ;;!! function foo<A>() {}
 ;;!               ^
-(function_declaration
-  type_parameters: (type_parameters
-    (_) @type
-  )
-)
-
 ;;!! const foo = <A>() => {}
 ;;!               ^
-(arrow_function
-  type_parameters: (type_parameters
-    (_) @type
-  )
+(type_parameters
+  (_) @type
 )
 
 ;;!! interface Aaa {}

--- a/queries/typescript.core.scm
+++ b/queries/typescript.core.scm
@@ -174,9 +174,9 @@
 )
 
 ;;!! useState<string>()
+;;!           ^^^^^^
 ;;!! useState<Record<string, string>>()
 ;;!           ^^^^^^^^^^^^^^^^^^^^^^
-;;!                  ^^^^^^  ^^^^^^
 (call_expression
   type_arguments: (type_arguments
     (_) @type

--- a/queries/typescript.core.scm
+++ b/queries/typescript.core.scm
@@ -173,6 +173,16 @@
   type_arguments: (_)? @type.end
 )
 
+;;!! useState<string>()
+;;!! useState<Record<string, string>>()
+;;!           ^^^^^^^^^^^^^^^^^^^^^^
+;;!                  ^^^^^^  ^^^^^^
+(call_expression
+  type_arguments: (type_arguments
+    (_) @type
+  )
+)
+
 ;;!! interface Aaa {}
 ;;!! type Aaa = Bbb;
 (

--- a/queries/typescript.core.scm
+++ b/queries/typescript.core.scm
@@ -183,6 +183,22 @@
   )
 )
 
+;;!! function foo<A>() {}
+;;!               ^
+(function_declaration
+  type_parameters: (type_parameters
+    (_) @type
+  )
+)
+
+;;!! const foo = <A>() => {}
+;;!               ^
+(arrow_function
+  type_parameters: (type_parameters
+    (_) @type
+  )
+)
+
 ;;!! interface Aaa {}
 ;;!! type Aaa = Bbb;
 (


### PR DESCRIPTION
- fixes https://github.com/cursorless-dev/cursorless/issues/1231
## Checklist

- [x] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [-] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [-] I have not broken the cheatsheet
