### PR TITLE
Support mapping from key to VSCode command in Cursorless keyboard mode

### DIFF
--- a/changelog/2023-11-modalKeyboardVscodeCommands.md
+++ b/changelog/2023-11-modalKeyboardVscodeCommands.md
@@ -1,0 +1,6 @@
+---
+tags: [enhancement, keyboard]
+pullRequest: 2026
+---
+
+- Add support for running VSCode commands from the experimental modal keyboard interface. See the [keyboard modal docs](https://www.cursorless.org/docs/user/experimental/keyboard/modal/) for more info.

--- a/docs/user/experimental/keyboard/modal.md
+++ b/docs/user/experimental/keyboard/modal.md
@@ -97,6 +97,24 @@ To bind keys that do not have modifiers (eg just pressing `a`), add entries like
     "z": "bolt",
     "w": "crosshairs"
   },
+  "cursorless.experimental.keyboard.modal.keybindings.vscodeCommands": {
+    // For simple commands, just use the command name
+    // "aa": "workbench.action.editor.changeLanguageMode",
+
+    // For commands with args, use the following format
+    // "am": {
+    //   "commandId": "some.command.id",
+    //   "args": ["foo", 0]
+    // }
+
+    // If you'd like to run the command on the active target, use the following format
+    "am": {
+      "commandId": "editor.action.joinLines",
+      "executeAtTarget": true,
+      // "keepChangedSelection": true,
+      // "exitCursorlessMode": true,
+    }
+  }
 ```
 
 Any supported scopes, actions, or colors can be added to these sections, using the same identifiers that appear in the second column of your customisation csvs. Feel free to add / tweak / remove the keyboard shortcuts above as you see fit.

--- a/packages/cursorless-vscode/package.json
+++ b/packages/cursorless-vscode/package.json
@@ -909,6 +909,41 @@
             ]
           }
         },
+        "cursorless.experimental.keyboard.modal.keybindings.vscodeCommands": {
+          "description": "Define modal keybindings for running vscode commands",
+          "type": "object",
+          "additionalProperties": {
+            "type": [
+              "string",
+              "object"
+            ],
+            "properties": {
+              "commandId": {
+                "type": "string",
+                "description": "The vscode command to run"
+              },
+              "args": {
+                "type": "array",
+                "description": "The arguments to pass to the command"
+              },
+              "executeAtTarget": {
+                "type": "boolean",
+                "description": "If `true`, indicates that the command should be executed at the target by moving the cursor there first, running the command, and then moving the cursor back to the original position"
+              },
+              "keepChangedSelection": {
+                "type": "boolean",
+                "description": "If `true`, the selection will be retained after the command is run, rather than being restored to its original position. This setting only applies when `executeAtTarget` is `true`."
+              },
+              "exitCursorlessMode": {
+                "type": "boolean",
+                "description": "If `true`, indicates that the command should exit cursorless mode after it is run."
+              }
+            },
+            "required": [
+              "commandId"
+            ]
+          }
+        },
         "cursorless.experimental.keyboard.modal.keybindings.colors": {
           "description": "Define modal keybindings for colors",
           "type": "object",

--- a/packages/cursorless-vscode/src/keyboard/defaultKeymaps.ts
+++ b/packages/cursorless-vscode/src/keyboard/defaultKeymaps.ts
@@ -5,6 +5,16 @@ import { isTesting } from "@cursorless/common";
 
 export type Keymap<T> = Record<string, T>;
 
+export type ModalVscodeCommandDescriptor =
+  | string
+  | {
+      commandId: string;
+      args?: unknown[];
+      executeAtTarget?: boolean;
+      keepChangedSelection?: boolean;
+      exitCursorlessMode?: boolean;
+    };
+
 // FIXME: Switch to a better mocking setup. We don't use our built in
 // configuration set up because that is probably going to live server side, and
 // the keyboard setup will probably live client side
@@ -20,5 +30,22 @@ export const DEFAULT_SCOPE_KEYMAP: Keymap<SimpleScopeTypeType> = isTesting()
 export const DEFAULT_COLOR_KEYMAP: Keymap<HatColor> = isTesting()
   ? { d: "default" }
   : {};
+
+export const DEFAULT_VSCODE_COMMAND_KEYMAP: Keymap<ModalVscodeCommandDescriptor> =
+  isTesting()
+    ? {
+        c: "editor.action.addCommentLine",
+        mc: {
+          commandId: "editor.action.addCommentLine",
+          executeAtTarget: true,
+        },
+        mm: {
+          commandId: "editor.action.addCommentLine",
+          executeAtTarget: true,
+          keepChangedSelection: true,
+          exitCursorlessMode: true,
+        },
+      }
+    : {};
 
 export const DEFAULT_SHAPE_KEYMAP: Keymap<HatShape> = isTesting() ? {} : {};


### PR DESCRIPTION
- Fixes #1963

## Checklist

- [x] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [x] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [-] I have not broken the cheatsheet
