### PR TITLE
Cleanup docusaurus config

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "fix:syncpack": "pnpm syncpack fix-mismatches",
     "init-vscode-sandbox": "pnpm --filter=@cursorless/cursorless-vscode init-launch-sandbox",
     "lint:meta": "pnpm run meta-updater:base --test",
-    "lint:ts": "eslint packages --ext ts,tsx",
+    "lint:ts": "eslint packages --ext ts,tsx,mts",
     "lint": "pnpm run lint:meta && syncpack list-mismatches && pnpm run lint:ts",
     "meta-updater:base": "pnpm --filter=@cursorless/meta-updater build && meta-updater",
     "preinstall": "npx only-allow pnpm",


### PR DESCRIPTION
And ensure linter is actually running on it

## Checklist

- [-] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [-] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [-] I have not broken the cheatsheet
