### PR TITLE
Move vscode-common's TestHelpers interface to its own file.

### DIFF
--- a/packages/vscode-common/src/TestHelpers.ts
+++ b/packages/vscode-common/src/TestHelpers.ts
@@ -1,0 +1,54 @@
+import type {
+  CommandServerApi,
+  ExcludableSnapshotField,
+  ExtraSnapshotField,
+  HatTokenMap,
+  IDE,
+  NormalizedIDE,
+  ScopeProvider,
+  SerializedMarks, TargetPlainObject,
+  TestCaseSnapshot,
+  TextEditor
+} from "@cursorless/common";
+import * as vscode from "vscode";
+import {VscodeApi} from "./VscodeApi";
+
+
+export interface TestHelpers {
+  ide: NormalizedIDE;
+  injectIde: (ide: IDE) => void;
+
+  scopeProvider: ScopeProvider;
+
+  hatTokenMap: HatTokenMap;
+
+  commandServerApi: CommandServerApi;
+
+  toVscodeEditor(editor: TextEditor): vscode.TextEditor;
+
+  setStoredTarget(
+    editor: vscode.TextEditor,
+    key: string,
+    targets: TargetPlainObject[] | undefined
+  ): void;
+
+  // FIXME: Remove this once we have a better way to get this function
+  // accessible from our tests
+  takeSnapshot(
+    excludeFields: ExcludableSnapshotField[],
+    extraFields: ExtraSnapshotField[],
+    editor: TextEditor,
+    ide: IDE,
+    marks: SerializedMarks | undefined,
+    forceRealClipboard: boolean
+  ): Promise<TestCaseSnapshot>;
+
+  runIntegrationTests(): Promise<void>;
+
+  cursorlessTalonStateJsonPath: string;
+
+  /**
+   * A thin wrapper around the VSCode API that allows us to mock it for testing.
+   */
+  vscodeApi: VscodeApi;
+}

--- a/packages/vscode-common/src/TestHelpers.ts
+++ b/packages/vscode-common/src/TestHelpers.ts
@@ -6,13 +6,13 @@ import type {
   IDE,
   NormalizedIDE,
   ScopeProvider,
-  SerializedMarks, TargetPlainObject,
+  SerializedMarks,
+  TargetPlainObject,
   TestCaseSnapshot,
-  TextEditor
+  TextEditor,
 } from "@cursorless/common";
 import * as vscode from "vscode";
-import {VscodeApi} from "./VscodeApi";
-
+import { VscodeApi } from "./VscodeApi";
 
 export interface TestHelpers {
   ide: NormalizedIDE;
@@ -29,7 +29,7 @@ export interface TestHelpers {
   setStoredTarget(
     editor: vscode.TextEditor,
     key: string,
-    targets: TargetPlainObject[] | undefined
+    targets: TargetPlainObject[] | undefined,
   ): void;
 
   // FIXME: Remove this once we have a better way to get this function
@@ -40,7 +40,7 @@ export interface TestHelpers {
     editor: TextEditor,
     ide: IDE,
     marks: SerializedMarks | undefined,
-    forceRealClipboard: boolean
+    forceRealClipboard: boolean,
   ): Promise<TestCaseSnapshot>;
 
   runIntegrationTests(): Promise<void>;

--- a/packages/vscode-common/src/getExtensionApi.ts
+++ b/packages/vscode-common/src/getExtensionApi.ts
@@ -1,59 +1,10 @@
 import type {
   CommandServerApi,
-  ExcludableSnapshotField,
-  ExtraSnapshotField,
-  HatTokenMap,
-  IDE,
-  NormalizedIDE,
-  ScopeProvider,
-  SerializedMarks,
   SnippetMap,
-  TargetPlainObject,
-  TestCaseSnapshot,
-  TextEditor,
 } from "@cursorless/common";
 import * as vscode from "vscode";
 import type { Language, SyntaxNode, Tree } from "web-tree-sitter";
-import { VscodeApi } from "./VscodeApi";
-
-export interface TestHelpers {
-  ide: NormalizedIDE;
-  injectIde: (ide: IDE) => void;
-
-  scopeProvider: ScopeProvider;
-
-  hatTokenMap: HatTokenMap;
-
-  commandServerApi: CommandServerApi;
-
-  toVscodeEditor(editor: TextEditor): vscode.TextEditor;
-
-  setStoredTarget(
-    editor: vscode.TextEditor,
-    key: string,
-    targets: TargetPlainObject[] | undefined,
-  ): void;
-
-  // FIXME: Remove this once we have a better way to get this function
-  // accessible from our tests
-  takeSnapshot(
-    excludeFields: ExcludableSnapshotField[],
-    extraFields: ExtraSnapshotField[],
-    editor: TextEditor,
-    ide: IDE,
-    marks: SerializedMarks | undefined,
-    forceRealClipboard: boolean,
-  ): Promise<TestCaseSnapshot>;
-
-  runIntegrationTests(): Promise<void>;
-
-  cursorlessTalonStateJsonPath: string;
-
-  /**
-   * A thin wrapper around the VSCode API that allows us to mock it for testing.
-   */
-  vscodeApi: VscodeApi;
-}
+import {TestHelpers} from "./TestHelpers";
 
 export interface CursorlessApi {
   testHelpers: TestHelpers | undefined;

--- a/packages/vscode-common/src/getExtensionApi.ts
+++ b/packages/vscode-common/src/getExtensionApi.ts
@@ -1,10 +1,7 @@
-import type {
-  CommandServerApi,
-  SnippetMap,
-} from "@cursorless/common";
+import type { CommandServerApi, SnippetMap } from "@cursorless/common";
 import * as vscode from "vscode";
 import type { Language, SyntaxNode, Tree } from "web-tree-sitter";
-import {TestHelpers} from "./TestHelpers";
+import { TestHelpers } from "./TestHelpers";
 
 export interface CursorlessApi {
   testHelpers: TestHelpers | undefined;

--- a/packages/vscode-common/src/index.ts
+++ b/packages/vscode-common/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./getExtensionApi";
+export * from "./TestHelpers";
 export * from "./notebook";
 export * from "./testUtil/openNewEditor";
 export * from "./vscodeUtil";


### PR DESCRIPTION
This makes it easier to excise the related test-specific code from the repo.
