### PR TITLE
Break the cyclic dependency between BaseTarget and UntypedTarget.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -26,4 +26,4 @@
   "typescript.enablePromptUseWorkspaceTsdk": true,
   "typescript.tsdk": "node_modules/typescript/lib",
   "eslint.workingDirectories": [{ "pattern": "packages/*/" }]
- }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -25,9 +25,5 @@
   "files.eol": "\n",
   "typescript.enablePromptUseWorkspaceTsdk": true,
   "typescript.tsdk": "node_modules/typescript/lib",
-  "eslint.workingDirectories": [
-    {
-      "pattern": "packages/*/"
-    }
-  ]
-}
+  "eslint.workingDirectories": [{ "pattern": "packages/*/" }]
+ }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -25,5 +25,9 @@
   "files.eol": "\n",
   "typescript.enablePromptUseWorkspaceTsdk": true,
   "typescript.tsdk": "node_modules/typescript/lib",
-  "eslint.workingDirectories": [{ "pattern": "packages/*/" }]
+  "eslint.workingDirectories": [
+    {
+      "pattern": "packages/*/"
+    }
+  ]
 }

--- a/packages/cursorless-engine/src/processTargets/targetUtil/createContinuousRange.ts
+++ b/packages/cursorless-engine/src/processTargets/targetUtil/createContinuousRange.ts
@@ -1,6 +1,7 @@
 import { Position, Range } from "@cursorless/common";
 import type { Target } from "../../typings/target.types";
 import { UntypedTarget } from "../targets";
+import { isSameType } from "../../util/typeUtils";
 
 export function createContinuousRange(
   startTarget: Target,
@@ -65,4 +66,36 @@ export function createContinuousRangeUntypedTarget(
     ),
     isToken: startTarget.isToken && endTarget.isToken,
   });
+}
+
+export function createContinuousRangeOrUntypedTarget(
+  isReversed: boolean,
+  startTarget: Target,
+  cloneParameters: any,
+  endTarget: Target,
+  includeStart: boolean,
+  includeEnd: boolean,
+): Target {
+  if (isSameType(startTarget, endTarget)) {
+    const constructor = Object.getPrototypeOf(startTarget).constructor;
+
+    return new constructor({
+      ...cloneParameters,
+      isReversed,
+      contentRange: createContinuousRange(
+        startTarget,
+        endTarget,
+        includeStart,
+        includeEnd,
+      ),
+    });
+  }
+
+  return createContinuousRangeUntypedTarget(
+    isReversed,
+    startTarget,
+    endTarget,
+    includeStart,
+    includeEnd,
+  );
 }

--- a/packages/cursorless-engine/src/processTargets/targetUtil/createContinuousRange.ts
+++ b/packages/cursorless-engine/src/processTargets/targetUtil/createContinuousRange.ts
@@ -44,5 +44,3 @@ export function createContinuousLineRange(
 
   return new Range(start, end);
 }
-
-

--- a/packages/cursorless-engine/src/processTargets/targetUtil/createContinuousRange.ts
+++ b/packages/cursorless-engine/src/processTargets/targetUtil/createContinuousRange.ts
@@ -1,7 +1,5 @@
 import { Position, Range } from "@cursorless/common";
 import type { Target } from "../../typings/target.types";
-import { UntypedTarget } from "../targets";
-import { isSameType } from "../../util/typeUtils";
 
 export function createContinuousRange(
   startTarget: Target,
@@ -47,55 +45,4 @@ export function createContinuousLineRange(
   return new Range(start, end);
 }
 
-export function createContinuousRangeUntypedTarget(
-  isReversed: boolean,
-  startTarget: Target,
-  endTarget: Target,
-  includeStart: boolean,
-  includeEnd: boolean,
-): UntypedTarget {
-  return new UntypedTarget({
-    editor: startTarget.editor,
-    isReversed,
-    hasExplicitRange: true,
-    contentRange: createContinuousRange(
-      startTarget,
-      endTarget,
-      includeStart,
-      includeEnd,
-    ),
-    isToken: startTarget.isToken && endTarget.isToken,
-  });
-}
 
-export function createContinuousRangeOrUntypedTarget(
-  isReversed: boolean,
-  startTarget: Target,
-  cloneParameters: any,
-  endTarget: Target,
-  includeStart: boolean,
-  includeEnd: boolean,
-): Target {
-  if (isSameType(startTarget, endTarget)) {
-    const constructor = Object.getPrototypeOf(startTarget).constructor;
-
-    return new constructor({
-      ...cloneParameters,
-      isReversed,
-      contentRange: createContinuousRange(
-        startTarget,
-        endTarget,
-        includeStart,
-        includeEnd,
-      ),
-    });
-  }
-
-  return createContinuousRangeUntypedTarget(
-    isReversed,
-    startTarget,
-    endTarget,
-    includeStart,
-    includeEnd,
-  );
-}

--- a/packages/cursorless-engine/src/processTargets/targets/BaseTarget.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/BaseTarget.ts
@@ -13,11 +13,6 @@ import {
 import { isEqual } from "lodash";
 import type { EditWithRangeUpdater } from "../../typings/Types";
 import type { Destination, Target } from "../../typings/target.types";
-import { isSameType } from "../../util/typeUtils";
-import {
-  createContinuousRange,
-  createContinuousRangeUntypedTarget,
-} from "../targetUtil/createContinuousRange";
 import { DestinationImpl } from "./DestinationImpl";
 
 /** Parameters supported by all target classes */
@@ -129,35 +124,12 @@ export abstract class BaseTarget<
 
   protected abstract getCloneParameters(): EnforceUndefined<TParameters>;
 
-  createContinuousRangeTarget(
+  abstract createContinuousRangeTarget(
     isReversed: boolean,
     endTarget: Target,
     includeStart: boolean,
     includeEnd: boolean,
-  ): Target {
-    if (isSameType(this, endTarget)) {
-      const constructor = Object.getPrototypeOf(this).constructor;
-
-      return new constructor({
-        ...this.getCloneParameters(),
-        isReversed,
-        contentRange: createContinuousRange(
-          this,
-          endTarget,
-          includeStart,
-          includeEnd,
-        ),
-      });
-    }
-
-    return createContinuousRangeUntypedTarget(
-      isReversed,
-      this,
-      endTarget,
-      includeStart,
-      includeEnd,
-    );
-  }
+  ): Target;
 
   isEqual(otherTarget: Target): boolean {
     return (

--- a/packages/cursorless-engine/src/processTargets/targets/DocumentTarget.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/DocumentTarget.ts
@@ -2,7 +2,7 @@ import { Range } from "@cursorless/common";
 import { shrinkRangeToFitContent } from "../../util/selectionUtils";
 import { BaseTarget, CommonTargetParameters, PlainTarget } from "./";
 import type { Target } from "../../typings/target.types";
-import {createContinuousRangeOrUntypedTarget} from "./UntypedTarget";
+import { createContinuousRangeOrUntypedTarget } from "./UntypedTarget";
 
 export class DocumentTarget extends BaseTarget<CommonTargetParameters> {
   type = "DocumentTarget";

--- a/packages/cursorless-engine/src/processTargets/targets/DocumentTarget.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/DocumentTarget.ts
@@ -2,9 +2,9 @@ import { Range } from "@cursorless/common";
 import { shrinkRangeToFitContent } from "../../util/selectionUtils";
 import { BaseTarget, CommonTargetParameters, PlainTarget } from "./";
 import type { Target } from "../../typings/target.types";
-import { createContinuousRangeOrUntypedTarget } from "./UntypedTarget";
+import { CommonTarget } from "./UntypedTarget";
 
-export class DocumentTarget extends BaseTarget<CommonTargetParameters> {
+export class DocumentTarget extends CommonTarget<CommonTargetParameters> {
   type = "DocumentTarget";
   insertionDelimiter = "\n";
   isLine = true;
@@ -32,22 +32,6 @@ export class DocumentTarget extends BaseTarget<CommonTargetParameters> {
         contentRange: shrinkRangeToFitContent(this.editor, this.contentRange),
       }),
     ];
-  }
-
-  createContinuousRangeTarget(
-    isReversed: boolean,
-    endTarget: Target,
-    includeStart: boolean,
-    includeEnd: boolean,
-  ): Target {
-    return createContinuousRangeOrUntypedTarget(
-      isReversed,
-      this,
-      this.getCloneParameters(),
-      endTarget,
-      includeStart,
-      includeEnd,
-    );
   }
 
   protected getCloneParameters() {

--- a/packages/cursorless-engine/src/processTargets/targets/DocumentTarget.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/DocumentTarget.ts
@@ -1,7 +1,6 @@
 import { Range } from "@cursorless/common";
 import { shrinkRangeToFitContent } from "../../util/selectionUtils";
-import { BaseTarget, CommonTargetParameters, PlainTarget } from "./";
-import type { Target } from "../../typings/target.types";
+import { CommonTargetParameters, PlainTarget } from "./";
 import { CommonTarget } from "./UntypedTarget";
 
 export class DocumentTarget extends CommonTarget<CommonTargetParameters> {

--- a/packages/cursorless-engine/src/processTargets/targets/DocumentTarget.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/DocumentTarget.ts
@@ -2,7 +2,7 @@ import { Range } from "@cursorless/common";
 import { shrinkRangeToFitContent } from "../../util/selectionUtils";
 import { BaseTarget, CommonTargetParameters, PlainTarget } from "./";
 import type { Target } from "../../typings/target.types";
-import { createContinuousRangeOrUntypedTarget } from "../targetUtil/createContinuousRange";
+import {createContinuousRangeOrUntypedTarget} from "./UntypedTarget";
 
 export class DocumentTarget extends BaseTarget<CommonTargetParameters> {
   type = "DocumentTarget";

--- a/packages/cursorless-engine/src/processTargets/targets/DocumentTarget.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/DocumentTarget.ts
@@ -1,6 +1,8 @@
 import { Range } from "@cursorless/common";
 import { shrinkRangeToFitContent } from "../../util/selectionUtils";
 import { BaseTarget, CommonTargetParameters, PlainTarget } from "./";
+import type { Target } from "../../typings/target.types";
+import { createContinuousRangeOrUntypedTarget } from "../targetUtil/createContinuousRange";
 
 export class DocumentTarget extends BaseTarget<CommonTargetParameters> {
   type = "DocumentTarget";
@@ -30,6 +32,22 @@ export class DocumentTarget extends BaseTarget<CommonTargetParameters> {
         contentRange: shrinkRangeToFitContent(this.editor, this.contentRange),
       }),
     ];
+  }
+
+  createContinuousRangeTarget(
+    isReversed: boolean,
+    endTarget: Target,
+    includeStart: boolean,
+    includeEnd: boolean,
+  ): Target {
+    return createContinuousRangeOrUntypedTarget(
+      isReversed,
+      this,
+      this.getCloneParameters(),
+      endTarget,
+      includeStart,
+      includeEnd,
+    );
   }
 
   protected getCloneParameters() {

--- a/packages/cursorless-engine/src/processTargets/targets/ImplicitTarget.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/ImplicitTarget.ts
@@ -1,6 +1,6 @@
 import { BaseTarget, CommonTargetParameters } from ".";
 import type { Target } from "../../typings/target.types";
-import {createContinuousRangeOrUntypedTarget} from "./UntypedTarget";
+import { createContinuousRangeOrUntypedTarget } from "./UntypedTarget";
 
 /**
  * A target that was not explicitly spoken by the user. For example:

--- a/packages/cursorless-engine/src/processTargets/targets/ImplicitTarget.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/ImplicitTarget.ts
@@ -1,6 +1,6 @@
 import { BaseTarget, CommonTargetParameters } from ".";
 import type { Target } from "../../typings/target.types";
-import { createContinuousRangeOrUntypedTarget } from "../targetUtil/createContinuousRange";
+import {createContinuousRangeOrUntypedTarget} from "./UntypedTarget";
 
 /**
  * A target that was not explicitly spoken by the user. For example:

--- a/packages/cursorless-engine/src/processTargets/targets/ImplicitTarget.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/ImplicitTarget.ts
@@ -1,5 +1,4 @@
-import { BaseTarget, CommonTargetParameters } from ".";
-import type { Target } from "../../typings/target.types";
+import { CommonTargetParameters } from ".";
 import { CommonTarget } from "./UntypedTarget";
 
 /**

--- a/packages/cursorless-engine/src/processTargets/targets/ImplicitTarget.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/ImplicitTarget.ts
@@ -1,4 +1,6 @@
 import { BaseTarget, CommonTargetParameters } from ".";
+import type { Target } from "../../typings/target.types";
+import { createContinuousRangeOrUntypedTarget } from "../targetUtil/createContinuousRange";
 
 /**
  * A target that was not explicitly spoken by the user. For example:
@@ -17,6 +19,22 @@ export class ImplicitTarget extends BaseTarget<CommonTargetParameters> {
   getLeadingDelimiterTarget = () => undefined;
   getTrailingDelimiterTarget = () => undefined;
   getRemovalRange = () => this.contentRange;
+
+  createContinuousRangeTarget(
+    isReversed: boolean,
+    endTarget: Target,
+    includeStart: boolean,
+    includeEnd: boolean,
+  ): Target {
+    return createContinuousRangeOrUntypedTarget(
+      isReversed,
+      this,
+      this.getCloneParameters(),
+      endTarget,
+      includeStart,
+      includeEnd,
+    );
+  }
 
   protected getCloneParameters = () => this.state;
 }

--- a/packages/cursorless-engine/src/processTargets/targets/ImplicitTarget.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/ImplicitTarget.ts
@@ -1,6 +1,6 @@
 import { BaseTarget, CommonTargetParameters } from ".";
 import type { Target } from "../../typings/target.types";
-import { createContinuousRangeOrUntypedTarget } from "./UntypedTarget";
+import { CommonTarget } from "./UntypedTarget";
 
 /**
  * A target that was not explicitly spoken by the user. For example:
@@ -8,7 +8,7 @@ import { createContinuousRangeOrUntypedTarget } from "./UntypedTarget";
  * - The implicit destination in the command `"bring air"`
  * - The implicit anchor in the range `"take past air"`
  */
-export class ImplicitTarget extends BaseTarget<CommonTargetParameters> {
+export class ImplicitTarget extends CommonTarget<CommonTargetParameters> {
   type = "ImplicitTarget";
   insertionDelimiter = "";
   isRaw = true;
@@ -19,22 +19,6 @@ export class ImplicitTarget extends BaseTarget<CommonTargetParameters> {
   getLeadingDelimiterTarget = () => undefined;
   getTrailingDelimiterTarget = () => undefined;
   getRemovalRange = () => this.contentRange;
-
-  createContinuousRangeTarget(
-    isReversed: boolean,
-    endTarget: Target,
-    includeStart: boolean,
-    includeEnd: boolean,
-  ): Target {
-    return createContinuousRangeOrUntypedTarget(
-      isReversed,
-      this,
-      this.getCloneParameters(),
-      endTarget,
-      includeStart,
-      includeEnd,
-    );
-  }
 
   protected getCloneParameters = () => this.state;
 }

--- a/packages/cursorless-engine/src/processTargets/targets/InteriorTarget.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/InteriorTarget.ts
@@ -3,10 +3,8 @@ import { BaseTarget, MinimumTargetParameters } from ".";
 import { Target } from "../../typings/target.types";
 import { shrinkRangeToFitContent } from "../../util/selectionUtils";
 import { isSameType } from "../../util/typeUtils";
-import {
-  createContinuousRangeFromRanges,
-} from "../targetUtil/createContinuousRange";
-import {createContinuousRangeUntypedTarget} from "./UntypedTarget";
+import { createContinuousRangeFromRanges } from "../targetUtil/createContinuousRange";
+import { createContinuousRangeUntypedTarget } from "./UntypedTarget";
 
 export interface InteriorTargetParameters extends MinimumTargetParameters {
   readonly fullInteriorRange: Range;

--- a/packages/cursorless-engine/src/processTargets/targets/InteriorTarget.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/InteriorTarget.ts
@@ -5,8 +5,8 @@ import { shrinkRangeToFitContent } from "../../util/selectionUtils";
 import { isSameType } from "../../util/typeUtils";
 import {
   createContinuousRangeFromRanges,
-  createContinuousRangeUntypedTarget,
 } from "../targetUtil/createContinuousRange";
+import {createContinuousRangeUntypedTarget} from "./UntypedTarget";
 
 export interface InteriorTargetParameters extends MinimumTargetParameters {
   readonly fullInteriorRange: Range;

--- a/packages/cursorless-engine/src/processTargets/targets/LineTarget.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/LineTarget.ts
@@ -3,7 +3,7 @@ import { BaseTarget, CommonTargetParameters } from ".";
 import { Target } from "../../typings/target.types";
 import { expandToFullLine } from "../../util/rangeUtils";
 import { tryConstructPlainTarget } from "../../util/tryConstructTarget";
-import { createContinuousLineRange } from "../targetUtil/createContinuousRange";
+import { createContinuousLineRange, createContinuousRangeOrUntypedTarget } from "../targetUtil/createContinuousRange";
 
 export class LineTarget extends BaseTarget<CommonTargetParameters> {
   type = "LineTarget";
@@ -61,8 +61,10 @@ export class LineTarget extends BaseTarget<CommonTargetParameters> {
       });
     }
 
-    return super.createContinuousRangeTarget(
+    return createContinuousRangeOrUntypedTarget(
       isReversed,
+      this,
+      this.getCloneParameters(),
       endTarget,
       includeStart,
       includeEnd,

--- a/packages/cursorless-engine/src/processTargets/targets/LineTarget.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/LineTarget.ts
@@ -5,8 +5,8 @@ import { expandToFullLine } from "../../util/rangeUtils";
 import { tryConstructPlainTarget } from "../../util/tryConstructTarget";
 import {
   createContinuousLineRange,
-  createContinuousRangeOrUntypedTarget,
 } from "../targetUtil/createContinuousRange";
+import {createContinuousRangeOrUntypedTarget} from "./UntypedTarget";
 
 export class LineTarget extends BaseTarget<CommonTargetParameters> {
   type = "LineTarget";

--- a/packages/cursorless-engine/src/processTargets/targets/LineTarget.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/LineTarget.ts
@@ -3,7 +3,10 @@ import { BaseTarget, CommonTargetParameters } from ".";
 import { Target } from "../../typings/target.types";
 import { expandToFullLine } from "../../util/rangeUtils";
 import { tryConstructPlainTarget } from "../../util/tryConstructTarget";
-import { createContinuousLineRange, createContinuousRangeOrUntypedTarget } from "../targetUtil/createContinuousRange";
+import {
+  createContinuousLineRange,
+  createContinuousRangeOrUntypedTarget,
+} from "../targetUtil/createContinuousRange";
 
 export class LineTarget extends BaseTarget<CommonTargetParameters> {
   type = "LineTarget";

--- a/packages/cursorless-engine/src/processTargets/targets/LineTarget.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/LineTarget.ts
@@ -3,10 +3,8 @@ import { BaseTarget, CommonTargetParameters } from ".";
 import { Target } from "../../typings/target.types";
 import { expandToFullLine } from "../../util/rangeUtils";
 import { tryConstructPlainTarget } from "../../util/tryConstructTarget";
-import {
-  createContinuousLineRange,
-} from "../targetUtil/createContinuousRange";
-import {createContinuousRangeOrUntypedTarget} from "./UntypedTarget";
+import { createContinuousLineRange } from "../targetUtil/createContinuousRange";
+import { createContinuousRangeOrUntypedTarget } from "./UntypedTarget";
 
 export class LineTarget extends BaseTarget<CommonTargetParameters> {
   type = "LineTarget";

--- a/packages/cursorless-engine/src/processTargets/targets/NotebookCellTarget.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/NotebookCellTarget.ts
@@ -3,7 +3,7 @@ import { BaseTarget, CommonTargetParameters } from ".";
 import { Destination } from "../../typings/target.types";
 import { NotebookCellDestination } from "./NotebookCellDestination";
 import type { Target } from "../../typings/target.types";
-import {createContinuousRangeOrUntypedTarget} from "./UntypedTarget";
+import { createContinuousRangeOrUntypedTarget } from "./UntypedTarget";
 
 export class NotebookCellTarget extends BaseTarget<CommonTargetParameters> {
   type = "NotebookCellTarget";

--- a/packages/cursorless-engine/src/processTargets/targets/NotebookCellTarget.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/NotebookCellTarget.ts
@@ -3,9 +3,9 @@ import { BaseTarget, CommonTargetParameters } from ".";
 import { Destination } from "../../typings/target.types";
 import { NotebookCellDestination } from "./NotebookCellDestination";
 import type { Target } from "../../typings/target.types";
-import { createContinuousRangeOrUntypedTarget } from "./UntypedTarget";
+import { CommonTarget } from "./UntypedTarget";
 
-export class NotebookCellTarget extends BaseTarget<CommonTargetParameters> {
+export class NotebookCellTarget extends CommonTarget<CommonTargetParameters> {
   type = "NotebookCellTarget";
   insertionDelimiter = "\n";
   isNotebookCell = true;
@@ -17,22 +17,6 @@ export class NotebookCellTarget extends BaseTarget<CommonTargetParameters> {
   getLeadingDelimiterTarget = () => undefined;
   getTrailingDelimiterTarget = () => undefined;
   getRemovalRange = () => this.contentRange;
-
-  createContinuousRangeTarget(
-    isReversed: boolean,
-    endTarget: Target,
-    includeStart: boolean,
-    includeEnd: boolean,
-  ): Target {
-    return createContinuousRangeOrUntypedTarget(
-      isReversed,
-      this,
-      this.getCloneParameters(),
-      endTarget,
-      includeStart,
-      includeEnd,
-    );
-  }
 
   protected getCloneParameters() {
     return this.state;

--- a/packages/cursorless-engine/src/processTargets/targets/NotebookCellTarget.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/NotebookCellTarget.ts
@@ -1,8 +1,7 @@
 import { InsertionMode } from "@cursorless/common";
-import { BaseTarget, CommonTargetParameters } from ".";
+import { CommonTargetParameters } from ".";
 import { Destination } from "../../typings/target.types";
 import { NotebookCellDestination } from "./NotebookCellDestination";
-import type { Target } from "../../typings/target.types";
 import { CommonTarget } from "./UntypedTarget";
 
 export class NotebookCellTarget extends CommonTarget<CommonTargetParameters> {

--- a/packages/cursorless-engine/src/processTargets/targets/NotebookCellTarget.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/NotebookCellTarget.ts
@@ -3,7 +3,7 @@ import { BaseTarget, CommonTargetParameters } from ".";
 import { Destination } from "../../typings/target.types";
 import { NotebookCellDestination } from "./NotebookCellDestination";
 import type { Target } from "../../typings/target.types";
-import { createContinuousRangeOrUntypedTarget } from "../targetUtil/createContinuousRange";
+import {createContinuousRangeOrUntypedTarget} from "./UntypedTarget";
 
 export class NotebookCellTarget extends BaseTarget<CommonTargetParameters> {
   type = "NotebookCellTarget";

--- a/packages/cursorless-engine/src/processTargets/targets/NotebookCellTarget.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/NotebookCellTarget.ts
@@ -2,6 +2,8 @@ import { InsertionMode } from "@cursorless/common";
 import { BaseTarget, CommonTargetParameters } from ".";
 import { Destination } from "../../typings/target.types";
 import { NotebookCellDestination } from "./NotebookCellDestination";
+import type { Target } from "../../typings/target.types";
+import { createContinuousRangeOrUntypedTarget } from "../targetUtil/createContinuousRange";
 
 export class NotebookCellTarget extends BaseTarget<CommonTargetParameters> {
   type = "NotebookCellTarget";
@@ -15,6 +17,22 @@ export class NotebookCellTarget extends BaseTarget<CommonTargetParameters> {
   getLeadingDelimiterTarget = () => undefined;
   getTrailingDelimiterTarget = () => undefined;
   getRemovalRange = () => this.contentRange;
+
+  createContinuousRangeTarget(
+    isReversed: boolean,
+    endTarget: Target,
+    includeStart: boolean,
+    includeEnd: boolean,
+  ): Target {
+    return createContinuousRangeOrUntypedTarget(
+      isReversed,
+      this,
+      this.getCloneParameters(),
+      endTarget,
+      includeStart,
+      includeEnd,
+    );
+  }
 
   protected getCloneParameters() {
     return this.state;

--- a/packages/cursorless-engine/src/processTargets/targets/ParagraphTarget.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/ParagraphTarget.ts
@@ -10,10 +10,8 @@ import { Target } from "../../typings/target.types";
 import { expandToFullLine } from "../../util/rangeUtils";
 import { constructLineTarget } from "../../util/tryConstructTarget";
 import { isSameType } from "../../util/typeUtils";
-import {
-  createContinuousLineRange,
-} from "../targetUtil/createContinuousRange";
-import {createContinuousRangeOrUntypedTarget} from "./UntypedTarget";
+import { createContinuousLineRange } from "../targetUtil/createContinuousRange";
+import { createContinuousRangeOrUntypedTarget } from "./UntypedTarget";
 
 export class ParagraphTarget extends BaseTarget<CommonTargetParameters> {
   type = "ParagraphTarget";

--- a/packages/cursorless-engine/src/processTargets/targets/ParagraphTarget.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/ParagraphTarget.ts
@@ -12,8 +12,8 @@ import { constructLineTarget } from "../../util/tryConstructTarget";
 import { isSameType } from "../../util/typeUtils";
 import {
   createContinuousLineRange,
-  createContinuousRangeOrUntypedTarget,
 } from "../targetUtil/createContinuousRange";
+import {createContinuousRangeOrUntypedTarget} from "./UntypedTarget";
 
 export class ParagraphTarget extends BaseTarget<CommonTargetParameters> {
   type = "ParagraphTarget";

--- a/packages/cursorless-engine/src/processTargets/targets/ParagraphTarget.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/ParagraphTarget.ts
@@ -10,7 +10,7 @@ import { Target } from "../../typings/target.types";
 import { expandToFullLine } from "../../util/rangeUtils";
 import { constructLineTarget } from "../../util/tryConstructTarget";
 import { isSameType } from "../../util/typeUtils";
-import { createContinuousLineRange } from "../targetUtil/createContinuousRange";
+import { createContinuousLineRange, createContinuousRangeOrUntypedTarget } from "../targetUtil/createContinuousRange";
 
 export class ParagraphTarget extends BaseTarget<CommonTargetParameters> {
   type = "ParagraphTarget";
@@ -105,8 +105,10 @@ export class ParagraphTarget extends BaseTarget<CommonTargetParameters> {
       });
     }
 
-    return super.createContinuousRangeTarget(
+    return createContinuousRangeOrUntypedTarget(
       isReversed,
+      this,
+      this.getCloneParameters(),
       endTarget,
       includeStart,
       includeEnd,

--- a/packages/cursorless-engine/src/processTargets/targets/ParagraphTarget.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/ParagraphTarget.ts
@@ -10,7 +10,10 @@ import { Target } from "../../typings/target.types";
 import { expandToFullLine } from "../../util/rangeUtils";
 import { constructLineTarget } from "../../util/tryConstructTarget";
 import { isSameType } from "../../util/typeUtils";
-import { createContinuousLineRange, createContinuousRangeOrUntypedTarget } from "../targetUtil/createContinuousRange";
+import {
+  createContinuousLineRange,
+  createContinuousRangeOrUntypedTarget,
+} from "../targetUtil/createContinuousRange";
 
 export class ParagraphTarget extends BaseTarget<CommonTargetParameters> {
   type = "ParagraphTarget";

--- a/packages/cursorless-engine/src/processTargets/targets/PlainTarget.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/PlainTarget.ts
@@ -1,5 +1,4 @@
-import { BaseTarget, CommonTargetParameters } from ".";
-import type { Target } from "../../typings/target.types";
+import { CommonTargetParameters } from ".";
 import { CommonTarget } from "./UntypedTarget";
 
 interface PlainTargetParameters extends CommonTargetParameters {

--- a/packages/cursorless-engine/src/processTargets/targets/PlainTarget.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/PlainTarget.ts
@@ -1,4 +1,7 @@
 import { BaseTarget, CommonTargetParameters } from ".";
+import type { Target } from "../../typings/target.types";
+import { createContinuousRangeOrUntypedTarget } from "../targetUtil/createContinuousRange";
+
 
 interface PlainTargetParameters extends CommonTargetParameters {
   readonly isToken?: boolean;
@@ -23,6 +26,22 @@ export class PlainTarget extends BaseTarget<PlainTargetParameters> {
   getLeadingDelimiterTarget = () => undefined;
   getTrailingDelimiterTarget = () => undefined;
   getRemovalRange = () => this.contentRange;
+
+  createContinuousRangeTarget(
+    isReversed: boolean,
+    endTarget: Target,
+    includeStart: boolean,
+    includeEnd: boolean,
+  ): Target {
+    return createContinuousRangeOrUntypedTarget(
+      isReversed,
+      this,
+      this.getCloneParameters(),
+      endTarget,
+      includeStart,
+      includeEnd,
+    );
+  }
 
   protected getCloneParameters() {
     return {

--- a/packages/cursorless-engine/src/processTargets/targets/PlainTarget.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/PlainTarget.ts
@@ -2,7 +2,6 @@ import { BaseTarget, CommonTargetParameters } from ".";
 import type { Target } from "../../typings/target.types";
 import { createContinuousRangeOrUntypedTarget } from "../targetUtil/createContinuousRange";
 
-
 interface PlainTargetParameters extends CommonTargetParameters {
   readonly isToken?: boolean;
   readonly insertionDelimiter?: string;

--- a/packages/cursorless-engine/src/processTargets/targets/PlainTarget.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/PlainTarget.ts
@@ -1,6 +1,6 @@
 import { BaseTarget, CommonTargetParameters } from ".";
 import type { Target } from "../../typings/target.types";
-import {createContinuousRangeOrUntypedTarget} from "./UntypedTarget";
+import { createContinuousRangeOrUntypedTarget } from "./UntypedTarget";
 
 interface PlainTargetParameters extends CommonTargetParameters {
   readonly isToken?: boolean;

--- a/packages/cursorless-engine/src/processTargets/targets/PlainTarget.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/PlainTarget.ts
@@ -1,6 +1,6 @@
 import { BaseTarget, CommonTargetParameters } from ".";
 import type { Target } from "../../typings/target.types";
-import { createContinuousRangeOrUntypedTarget } from "./UntypedTarget";
+import { CommonTarget } from "./UntypedTarget";
 
 interface PlainTargetParameters extends CommonTargetParameters {
   readonly isToken?: boolean;
@@ -12,7 +12,7 @@ interface PlainTargetParameters extends CommonTargetParameters {
  * just consists of the content itself. Its insertion delimiter is empty string,
  * unless specified.
  */
-export class PlainTarget extends BaseTarget<PlainTargetParameters> {
+export class PlainTarget extends CommonTarget<PlainTargetParameters> {
   type = "PlainTarget";
   insertionDelimiter: string;
 
@@ -25,22 +25,6 @@ export class PlainTarget extends BaseTarget<PlainTargetParameters> {
   getLeadingDelimiterTarget = () => undefined;
   getTrailingDelimiterTarget = () => undefined;
   getRemovalRange = () => this.contentRange;
-
-  createContinuousRangeTarget(
-    isReversed: boolean,
-    endTarget: Target,
-    includeStart: boolean,
-    includeEnd: boolean,
-  ): Target {
-    return createContinuousRangeOrUntypedTarget(
-      isReversed,
-      this,
-      this.getCloneParameters(),
-      endTarget,
-      includeStart,
-      includeEnd,
-    );
-  }
 
   protected getCloneParameters() {
     return {

--- a/packages/cursorless-engine/src/processTargets/targets/PlainTarget.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/PlainTarget.ts
@@ -1,6 +1,6 @@
 import { BaseTarget, CommonTargetParameters } from ".";
 import type { Target } from "../../typings/target.types";
-import { createContinuousRangeOrUntypedTarget } from "../targetUtil/createContinuousRange";
+import {createContinuousRangeOrUntypedTarget} from "./UntypedTarget";
 
 interface PlainTargetParameters extends CommonTargetParameters {
   readonly isToken?: boolean;

--- a/packages/cursorless-engine/src/processTargets/targets/RawSelectionTarget.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/RawSelectionTarget.ts
@@ -1,13 +1,13 @@
 import { BaseTarget, CommonTargetParameters } from ".";
 import type { Target } from "../../typings/target.types";
-import { createContinuousRangeOrUntypedTarget } from "./UntypedTarget";
+import { CommonTarget } from "./UntypedTarget";
 
 /**
  * A target that has no leading or trailing delimiters so it's removal range
  * just consists of the content itself. Its insertion delimiter will be
  * inherited from the source in the case of a bring after a bring before
  */
-export class RawSelectionTarget extends BaseTarget<CommonTargetParameters> {
+export class RawSelectionTarget extends CommonTarget<CommonTargetParameters> {
   type = "RawSelectionTarget";
   insertionDelimiter = "";
   isRaw = true;
@@ -16,22 +16,6 @@ export class RawSelectionTarget extends BaseTarget<CommonTargetParameters> {
   getLeadingDelimiterTarget = () => undefined;
   getTrailingDelimiterTarget = () => undefined;
   getRemovalRange = () => this.contentRange;
-
-  createContinuousRangeTarget(
-    isReversed: boolean,
-    endTarget: Target,
-    includeStart: boolean,
-    includeEnd: boolean,
-  ): Target {
-    return createContinuousRangeOrUntypedTarget(
-      isReversed,
-      this,
-      this.getCloneParameters(),
-      endTarget,
-      includeStart,
-      includeEnd,
-    );
-  }
 
   protected getCloneParameters = () => this.state;
 }

--- a/packages/cursorless-engine/src/processTargets/targets/RawSelectionTarget.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/RawSelectionTarget.ts
@@ -1,6 +1,6 @@
 import { BaseTarget, CommonTargetParameters } from ".";
 import type { Target } from "../../typings/target.types";
-import {createContinuousRangeOrUntypedTarget} from "./UntypedTarget";
+import { createContinuousRangeOrUntypedTarget } from "./UntypedTarget";
 
 /**
  * A target that has no leading or trailing delimiters so it's removal range

--- a/packages/cursorless-engine/src/processTargets/targets/RawSelectionTarget.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/RawSelectionTarget.ts
@@ -1,6 +1,6 @@
 import { BaseTarget, CommonTargetParameters } from ".";
 import type { Target } from "../../typings/target.types";
-import { createContinuousRangeOrUntypedTarget } from "../targetUtil/createContinuousRange";
+import {createContinuousRangeOrUntypedTarget} from "./UntypedTarget";
 
 /**
  * A target that has no leading or trailing delimiters so it's removal range

--- a/packages/cursorless-engine/src/processTargets/targets/RawSelectionTarget.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/RawSelectionTarget.ts
@@ -1,4 +1,6 @@
 import { BaseTarget, CommonTargetParameters } from ".";
+import type { Target } from "../../typings/target.types";
+import { createContinuousRangeOrUntypedTarget } from "../targetUtil/createContinuousRange";
 
 /**
  * A target that has no leading or trailing delimiters so it's removal range
@@ -14,6 +16,22 @@ export class RawSelectionTarget extends BaseTarget<CommonTargetParameters> {
   getLeadingDelimiterTarget = () => undefined;
   getTrailingDelimiterTarget = () => undefined;
   getRemovalRange = () => this.contentRange;
+
+  createContinuousRangeTarget(
+    isReversed: boolean,
+    endTarget: Target,
+    includeStart: boolean,
+    includeEnd: boolean,
+  ): Target {
+    return createContinuousRangeOrUntypedTarget(
+      isReversed,
+      this,
+      this.getCloneParameters(),
+      endTarget,
+      includeStart,
+      includeEnd,
+    );
+  }
 
   protected getCloneParameters = () => this.state;
 }

--- a/packages/cursorless-engine/src/processTargets/targets/RawSelectionTarget.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/RawSelectionTarget.ts
@@ -1,5 +1,4 @@
-import { BaseTarget, CommonTargetParameters } from ".";
-import type { Target } from "../../typings/target.types";
+import { CommonTargetParameters } from ".";
 import { CommonTarget } from "./UntypedTarget";
 
 /**

--- a/packages/cursorless-engine/src/processTargets/targets/ScopeTypeTarget.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/ScopeTypeTarget.ts
@@ -10,8 +10,8 @@ import { isSameType } from "../../util/typeUtils";
 import {
   createContinuousRange,
   createContinuousRangeFromRanges,
-  createContinuousRangeOrUntypedTarget,
 } from "../targetUtil/createContinuousRange";
+import {createContinuousRangeOrUntypedTarget} from "./UntypedTarget";
 import { getDelimitedSequenceRemovalRange } from "../targetUtil/insertionRemovalBehaviors/DelimitedSequenceInsertionRemovalBehavior";
 import {
   getTokenLeadingDelimiterTarget,

--- a/packages/cursorless-engine/src/processTargets/targets/ScopeTypeTarget.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/ScopeTypeTarget.ts
@@ -10,6 +10,7 @@ import { isSameType } from "../../util/typeUtils";
 import {
   createContinuousRange,
   createContinuousRangeFromRanges,
+  createContinuousRangeOrUntypedTarget,
 } from "../targetUtil/createContinuousRange";
 import { getDelimitedSequenceRemovalRange } from "../targetUtil/insertionRemovalBehaviors/DelimitedSequenceInsertionRemovalBehavior";
 import {
@@ -134,8 +135,10 @@ export class ScopeTypeTarget extends BaseTarget<ScopeTypeTargetParameters> {
       }
     }
 
-    return super.createContinuousRangeTarget(
+    return createContinuousRangeOrUntypedTarget(
       isReversed,
+      this,
+      this.getCloneParameters(),
       endTarget,
       includeStart,
       includeEnd,

--- a/packages/cursorless-engine/src/processTargets/targets/ScopeTypeTarget.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/ScopeTypeTarget.ts
@@ -11,7 +11,7 @@ import {
   createContinuousRange,
   createContinuousRangeFromRanges,
 } from "../targetUtil/createContinuousRange";
-import {createContinuousRangeOrUntypedTarget} from "./UntypedTarget";
+import { createContinuousRangeOrUntypedTarget } from "./UntypedTarget";
 import { getDelimitedSequenceRemovalRange } from "../targetUtil/insertionRemovalBehaviors/DelimitedSequenceInsertionRemovalBehavior";
 import {
   getTokenLeadingDelimiterTarget,

--- a/packages/cursorless-engine/src/processTargets/targets/SubTokenWordTarget.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/SubTokenWordTarget.ts
@@ -3,10 +3,8 @@ import { BaseTarget, CommonTargetParameters } from ".";
 import { Target } from "../../typings/target.types";
 import { tryConstructPlainTarget } from "../../util/tryConstructTarget";
 import { isSameType } from "../../util/typeUtils";
-import {
-  createContinuousRange,
-} from "../targetUtil/createContinuousRange";
-import {createContinuousRangeOrUntypedTarget} from "./UntypedTarget";
+import { createContinuousRange } from "../targetUtil/createContinuousRange";
+import { createContinuousRangeOrUntypedTarget } from "./UntypedTarget";
 import { getDelimitedSequenceRemovalRange } from "../targetUtil/insertionRemovalBehaviors/DelimitedSequenceInsertionRemovalBehavior";
 
 export interface SubTokenTargetParameters extends CommonTargetParameters {

--- a/packages/cursorless-engine/src/processTargets/targets/SubTokenWordTarget.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/SubTokenWordTarget.ts
@@ -5,8 +5,8 @@ import { tryConstructPlainTarget } from "../../util/tryConstructTarget";
 import { isSameType } from "../../util/typeUtils";
 import {
   createContinuousRange,
-  createContinuousRangeOrUntypedTarget,
 } from "../targetUtil/createContinuousRange";
+import {createContinuousRangeOrUntypedTarget} from "./UntypedTarget";
 import { getDelimitedSequenceRemovalRange } from "../targetUtil/insertionRemovalBehaviors/DelimitedSequenceInsertionRemovalBehavior";
 
 export interface SubTokenTargetParameters extends CommonTargetParameters {

--- a/packages/cursorless-engine/src/processTargets/targets/SubTokenWordTarget.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/SubTokenWordTarget.ts
@@ -3,7 +3,7 @@ import { BaseTarget, CommonTargetParameters } from ".";
 import { Target } from "../../typings/target.types";
 import { tryConstructPlainTarget } from "../../util/tryConstructTarget";
 import { isSameType } from "../../util/typeUtils";
-import { createContinuousRange } from "../targetUtil/createContinuousRange";
+import { createContinuousRange, createContinuousRangeOrUntypedTarget } from "../targetUtil/createContinuousRange";
 import { getDelimitedSequenceRemovalRange } from "../targetUtil/insertionRemovalBehaviors/DelimitedSequenceInsertionRemovalBehavior";
 
 export interface SubTokenTargetParameters extends CommonTargetParameters {
@@ -67,8 +67,10 @@ export class SubTokenWordTarget extends BaseTarget<SubTokenTargetParameters> {
       });
     }
 
-    return super.createContinuousRangeTarget(
+    return createContinuousRangeOrUntypedTarget(
       isReversed,
+      this,
+      this.getCloneParameters(),
       endTarget,
       includeStart,
       includeEnd,

--- a/packages/cursorless-engine/src/processTargets/targets/SubTokenWordTarget.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/SubTokenWordTarget.ts
@@ -3,7 +3,10 @@ import { BaseTarget, CommonTargetParameters } from ".";
 import { Target } from "../../typings/target.types";
 import { tryConstructPlainTarget } from "../../util/tryConstructTarget";
 import { isSameType } from "../../util/typeUtils";
-import { createContinuousRange, createContinuousRangeOrUntypedTarget } from "../targetUtil/createContinuousRange";
+import {
+  createContinuousRange,
+  createContinuousRangeOrUntypedTarget,
+} from "../targetUtil/createContinuousRange";
 import { getDelimitedSequenceRemovalRange } from "../targetUtil/insertionRemovalBehaviors/DelimitedSequenceInsertionRemovalBehavior";
 
 export interface SubTokenTargetParameters extends CommonTargetParameters {

--- a/packages/cursorless-engine/src/processTargets/targets/SurroundingPairTarget.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/SurroundingPairTarget.ts
@@ -11,7 +11,7 @@ import {
   getTokenRemovalRange,
   getTokenTrailingDelimiterTarget,
 } from "../targetUtil/insertionRemovalBehaviors/TokenInsertionRemovalBehavior";
-import { createContinuousRangeOrUntypedTarget } from "../targetUtil/createContinuousRange";
+import {createContinuousRangeOrUntypedTarget} from "./UntypedTarget";
 
 interface SurroundingPairTargetParameters extends CommonTargetParameters {
   /**

--- a/packages/cursorless-engine/src/processTargets/targets/SurroundingPairTarget.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/SurroundingPairTarget.ts
@@ -11,6 +11,7 @@ import {
   getTokenRemovalRange,
   getTokenTrailingDelimiterTarget,
 } from "../targetUtil/insertionRemovalBehaviors/TokenInsertionRemovalBehavior";
+import { createContinuousRangeOrUntypedTarget } from "../targetUtil/createContinuousRange";
 
 interface SurroundingPairTargetParameters extends CommonTargetParameters {
   /**
@@ -68,6 +69,22 @@ export class SurroundingPairTarget extends BaseTarget<SurroundingPairTargetParam
           isReversed: this.isReversed,
           contentRange,
         }),
+    );
+  }
+
+  createContinuousRangeTarget(
+    isReversed: boolean,
+    endTarget: Target,
+    includeStart: boolean,
+    includeEnd: boolean,
+  ): Target {
+    return createContinuousRangeOrUntypedTarget(
+      isReversed,
+      this,
+      this.getCloneParameters(),
+      endTarget,
+      includeStart,
+      includeEnd,
     );
   }
 

--- a/packages/cursorless-engine/src/processTargets/targets/SurroundingPairTarget.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/SurroundingPairTarget.ts
@@ -11,7 +11,7 @@ import {
   getTokenRemovalRange,
   getTokenTrailingDelimiterTarget,
 } from "../targetUtil/insertionRemovalBehaviors/TokenInsertionRemovalBehavior";
-import {createContinuousRangeOrUntypedTarget} from "./UntypedTarget";
+import { createContinuousRangeOrUntypedTarget } from "./UntypedTarget";
 
 interface SurroundingPairTargetParameters extends CommonTargetParameters {
   /**

--- a/packages/cursorless-engine/src/processTargets/targets/SurroundingPairTarget.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/SurroundingPairTarget.ts
@@ -11,7 +11,7 @@ import {
   getTokenRemovalRange,
   getTokenTrailingDelimiterTarget,
 } from "../targetUtil/insertionRemovalBehaviors/TokenInsertionRemovalBehavior";
-import { createContinuousRangeOrUntypedTarget } from "./UntypedTarget";
+import { CommonTarget } from "./UntypedTarget";
 
 interface SurroundingPairTargetParameters extends CommonTargetParameters {
   /**
@@ -29,7 +29,7 @@ interface SurroundingPairTargetParameters extends CommonTargetParameters {
   readonly boundary: [Range, Range];
 }
 
-export class SurroundingPairTarget extends BaseTarget<SurroundingPairTargetParameters> {
+export class SurroundingPairTarget extends CommonTarget<SurroundingPairTargetParameters> {
   type = "SurroundingPairTarget";
   insertionDelimiter = " ";
   private interiorRange_: Range;
@@ -69,22 +69,6 @@ export class SurroundingPairTarget extends BaseTarget<SurroundingPairTargetParam
           isReversed: this.isReversed,
           contentRange,
         }),
-    );
-  }
-
-  createContinuousRangeTarget(
-    isReversed: boolean,
-    endTarget: Target,
-    includeStart: boolean,
-    includeEnd: boolean,
-  ): Target {
-    return createContinuousRangeOrUntypedTarget(
-      isReversed,
-      this,
-      this.getCloneParameters(),
-      endTarget,
-      includeStart,
-      includeEnd,
     );
   }
 

--- a/packages/cursorless-engine/src/processTargets/targets/SurroundingPairTarget.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/SurroundingPairTarget.ts
@@ -1,10 +1,5 @@
 import { Range } from "@cursorless/common";
-import {
-  BaseTarget,
-  CommonTargetParameters,
-  InteriorTarget,
-  TokenTarget,
-} from ".";
+import { CommonTargetParameters, InteriorTarget, TokenTarget } from ".";
 import { Target } from "../../typings/target.types";
 import {
   getTokenLeadingDelimiterTarget,

--- a/packages/cursorless-engine/src/processTargets/targets/TokenTarget.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/TokenTarget.ts
@@ -6,9 +6,9 @@ import {
   getTokenRemovalRange,
   getTokenTrailingDelimiterTarget,
 } from "../targetUtil/insertionRemovalBehaviors/TokenInsertionRemovalBehavior";
-import { createContinuousRangeOrUntypedTarget } from "./UntypedTarget";
+import { CommonTarget } from "./UntypedTarget";
 
-export class TokenTarget extends BaseTarget<CommonTargetParameters> {
+export class TokenTarget extends CommonTarget<CommonTargetParameters> {
   type = "TokenTarget";
   insertionDelimiter = " ";
 
@@ -20,22 +20,6 @@ export class TokenTarget extends BaseTarget<CommonTargetParameters> {
   }
   getRemovalRange(): Range {
     return getTokenRemovalRange(this);
-  }
-
-  createContinuousRangeTarget(
-    isReversed: boolean,
-    endTarget: Target,
-    includeStart: boolean,
-    includeEnd: boolean,
-  ): Target {
-    return createContinuousRangeOrUntypedTarget(
-      isReversed,
-      this,
-      this.getCloneParameters(),
-      endTarget,
-      includeStart,
-      includeEnd,
-    );
   }
 
   protected getCloneParameters() {

--- a/packages/cursorless-engine/src/processTargets/targets/TokenTarget.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/TokenTarget.ts
@@ -6,7 +6,7 @@ import {
   getTokenRemovalRange,
   getTokenTrailingDelimiterTarget,
 } from "../targetUtil/insertionRemovalBehaviors/TokenInsertionRemovalBehavior";
-import { createContinuousRangeOrUntypedTarget } from "../targetUtil/createContinuousRange";
+import {createContinuousRangeOrUntypedTarget} from "./UntypedTarget";
 
 export class TokenTarget extends BaseTarget<CommonTargetParameters> {
   type = "TokenTarget";

--- a/packages/cursorless-engine/src/processTargets/targets/TokenTarget.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/TokenTarget.ts
@@ -1,5 +1,5 @@
 import { Range } from "@cursorless/common";
-import { BaseTarget, CommonTargetParameters } from ".";
+import { CommonTargetParameters } from ".";
 import { Target } from "../../typings/target.types";
 import {
   getTokenLeadingDelimiterTarget,

--- a/packages/cursorless-engine/src/processTargets/targets/TokenTarget.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/TokenTarget.ts
@@ -6,6 +6,7 @@ import {
   getTokenRemovalRange,
   getTokenTrailingDelimiterTarget,
 } from "../targetUtil/insertionRemovalBehaviors/TokenInsertionRemovalBehavior";
+import { createContinuousRangeOrUntypedTarget } from "../targetUtil/createContinuousRange";
 
 export class TokenTarget extends BaseTarget<CommonTargetParameters> {
   type = "TokenTarget";
@@ -19,6 +20,22 @@ export class TokenTarget extends BaseTarget<CommonTargetParameters> {
   }
   getRemovalRange(): Range {
     return getTokenRemovalRange(this);
+  }
+
+  createContinuousRangeTarget(
+    isReversed: boolean,
+    endTarget: Target,
+    includeStart: boolean,
+    includeEnd: boolean,
+  ): Target {
+    return createContinuousRangeOrUntypedTarget(
+      isReversed,
+      this,
+      this.getCloneParameters(),
+      endTarget,
+      includeStart,
+      includeEnd,
+    );
   }
 
   protected getCloneParameters() {

--- a/packages/cursorless-engine/src/processTargets/targets/TokenTarget.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/TokenTarget.ts
@@ -6,7 +6,7 @@ import {
   getTokenRemovalRange,
   getTokenTrailingDelimiterTarget,
 } from "../targetUtil/insertionRemovalBehaviors/TokenInsertionRemovalBehavior";
-import {createContinuousRangeOrUntypedTarget} from "./UntypedTarget";
+import { createContinuousRangeOrUntypedTarget } from "./UntypedTarget";
 
 export class TokenTarget extends BaseTarget<CommonTargetParameters> {
   type = "TokenTarget";

--- a/packages/cursorless-engine/src/processTargets/targets/UntypedTarget.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/UntypedTarget.ts
@@ -1,12 +1,13 @@
 import { Range } from "@cursorless/common";
 import { BaseTarget, CommonTargetParameters } from ".";
 import type { Target } from "../../typings/target.types";
-import { createContinuousRangeUntypedTarget } from "../targetUtil/createContinuousRange";
 import {
   getTokenLeadingDelimiterTarget,
   getTokenRemovalRange,
   getTokenTrailingDelimiterTarget,
 } from "../targetUtil/insertionRemovalBehaviors/TokenInsertionRemovalBehavior";
+import {createContinuousRange} from "../targetUtil/createContinuousRange";
+import {isSameType} from "../../util/typeUtils";
 
 interface UntypedTargetParameters extends CommonTargetParameters {
   readonly hasExplicitRange: boolean;
@@ -65,3 +66,57 @@ export class UntypedTarget extends BaseTarget<UntypedTargetParameters> {
     };
   }
 }
+
+export function createContinuousRangeUntypedTarget(
+  isReversed: boolean,
+  startTarget: Target,
+  endTarget: Target,
+  includeStart: boolean,
+  includeEnd: boolean
+): UntypedTarget {
+  return new UntypedTarget({
+    editor: startTarget.editor,
+    isReversed,
+    hasExplicitRange: true,
+    contentRange: createContinuousRange(
+      startTarget,
+      endTarget,
+      includeStart,
+      includeEnd
+    ),
+    isToken: startTarget.isToken && endTarget.isToken,
+  });
+}
+
+export function createContinuousRangeOrUntypedTarget(
+  isReversed: boolean,
+  startTarget: Target,
+  cloneParameters: any,
+  endTarget: Target,
+  includeStart: boolean,
+  includeEnd: boolean
+): Target {
+  if (isSameType(startTarget, endTarget)) {
+    const constructor = Object.getPrototypeOf(startTarget).constructor;
+
+    return new constructor({
+      ...cloneParameters,
+      isReversed,
+      contentRange: createContinuousRange(
+        startTarget,
+        endTarget,
+        includeStart,
+        includeEnd
+      ),
+    });
+  }
+
+  return createContinuousRangeUntypedTarget(
+    isReversed,
+    startTarget,
+    endTarget,
+    includeStart,
+    includeEnd
+  );
+}
+

--- a/packages/cursorless-engine/src/processTargets/targets/UntypedTarget.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/UntypedTarget.ts
@@ -1,5 +1,5 @@
 import { Range } from "@cursorless/common";
-import { BaseTarget, CommonTargetParameters } from ".";
+import { BaseTarget, MinimumTargetParameters, CommonTargetParameters } from ".";
 import type { Target } from "../../typings/target.types";
 import {
   getTokenLeadingDelimiterTarget,
@@ -8,6 +8,31 @@ import {
 } from "../targetUtil/insertionRemovalBehaviors/TokenInsertionRemovalBehavior";
 import { createContinuousRange } from "../targetUtil/createContinuousRange";
 import { isSameType } from "../../util/typeUtils";
+
+/**
+ * An abstract target base class who createContinueRangeTarget method returns either
+ * a createContinuousRange if this and endTarget have the same type or
+ * otherwise returns an UntypedTarget from this to endTarget.
+ */
+export abstract class CommonTarget<
+  in out TParameters extends MinimumTargetParameters
+> extends BaseTarget<TParameters> {
+  createContinuousRangeTarget(
+    isReversed: boolean,
+    endTarget: Target,
+    includeStart: boolean,
+    includeEnd: boolean,
+  ): Target {
+    return createContinuousRangeOrUntypedTarget(
+      isReversed,
+      this,
+      this.getCloneParameters(),
+      endTarget,
+      includeStart,
+      includeEnd,
+    );
+  }
+}
 
 interface UntypedTargetParameters extends CommonTargetParameters {
   readonly hasExplicitRange: boolean;

--- a/packages/cursorless-engine/src/processTargets/targets/UntypedTarget.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/UntypedTarget.ts
@@ -6,8 +6,8 @@ import {
   getTokenRemovalRange,
   getTokenTrailingDelimiterTarget,
 } from "../targetUtil/insertionRemovalBehaviors/TokenInsertionRemovalBehavior";
-import {createContinuousRange} from "../targetUtil/createContinuousRange";
-import {isSameType} from "../../util/typeUtils";
+import { createContinuousRange } from "../targetUtil/createContinuousRange";
+import { isSameType } from "../../util/typeUtils";
 
 interface UntypedTargetParameters extends CommonTargetParameters {
   readonly hasExplicitRange: boolean;
@@ -72,7 +72,7 @@ export function createContinuousRangeUntypedTarget(
   startTarget: Target,
   endTarget: Target,
   includeStart: boolean,
-  includeEnd: boolean
+  includeEnd: boolean,
 ): UntypedTarget {
   return new UntypedTarget({
     editor: startTarget.editor,
@@ -82,7 +82,7 @@ export function createContinuousRangeUntypedTarget(
       startTarget,
       endTarget,
       includeStart,
-      includeEnd
+      includeEnd,
     ),
     isToken: startTarget.isToken && endTarget.isToken,
   });
@@ -94,7 +94,7 @@ export function createContinuousRangeOrUntypedTarget(
   cloneParameters: any,
   endTarget: Target,
   includeStart: boolean,
-  includeEnd: boolean
+  includeEnd: boolean,
 ): Target {
   if (isSameType(startTarget, endTarget)) {
     const constructor = Object.getPrototypeOf(startTarget).constructor;
@@ -106,7 +106,7 @@ export function createContinuousRangeOrUntypedTarget(
         startTarget,
         endTarget,
         includeStart,
-        includeEnd
+        includeEnd,
       ),
     });
   }
@@ -116,7 +116,6 @@ export function createContinuousRangeOrUntypedTarget(
     startTarget,
     endTarget,
     includeStart,
-    includeEnd
+    includeEnd,
   );
 }
-

--- a/packages/cursorless-engine/src/processTargets/targets/UntypedTarget.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/UntypedTarget.ts
@@ -15,7 +15,7 @@ import { isSameType } from "../../util/typeUtils";
  * otherwise returns an UntypedTarget from this to endTarget.
  */
 export abstract class CommonTarget<
-  in out TParameters extends MinimumTargetParameters
+  in out TParameters extends MinimumTargetParameters,
 > extends BaseTarget<TParameters> {
   createContinuousRangeTarget(
     isReversed: boolean,


### PR DESCRIPTION
This PR factors `createContinuousRangeTarget` out of BaseTarget into a new function, `createContinuousRangeOrUntypedTarget`, which is used by a variety of target types.  As a result, BaseTarget.ts no longer needs to import UntypedTarget (indirectly through createContinuousRange.ts).