### PR TITLE
Support `/` on windows for fixtures grep

### DIFF
--- a/packages/common/src/testUtil/getFixturePaths.ts
+++ b/packages/common/src/testUtil/getFixturePaths.ts
@@ -28,7 +28,9 @@ export function getRecordedTestPaths() {
   return walkFilesSync(directory)
     .filter((p) => p.endsWith(".yml") || p.endsWith(".yaml"))
     .map((p) => ({
-      name: path.relative(relativeDir, p.substring(0, p.lastIndexOf("."))),
+      name: path
+        .relative(relativeDir, p.substring(0, p.lastIndexOf(".")))
+        .replaceAll("\\", "/"),
       path: p,
     }));
 }


### PR DESCRIPTION
Can now on windows use `/` in `testSubsetGrep.properties`

Fixes #1779

## Checklist

- [-] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [-] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [-] I have not broken the cheatsheet
