### PR TITLE
Use arbitrary capture as insertion delimiter

### DIFF
--- a/packages/cursorless-engine/src/languages/TreeSitterQuery/QueryCapture.ts
+++ b/packages/cursorless-engine/src/languages/TreeSitterQuery/QueryCapture.ts
@@ -37,7 +37,7 @@ export interface QueryCapture {
   readonly allowMultiple: boolean;
 
   /** The insertion delimiter to use if any */
-  readonly insertionDelimiter: string | undefined;
+  readonly insertionDelimiters: string[] | undefined;
 }
 
 /**
@@ -63,7 +63,7 @@ export interface MutableQueryCapture extends QueryCapture {
   readonly document: TextDocument;
   range: Range;
   allowMultiple: boolean;
-  insertionDelimiter: string | undefined;
+  insertionDelimiters: string[] | undefined;
 }
 
 /**

--- a/packages/cursorless-engine/src/languages/TreeSitterQuery/TreeSitterQuery.ts
+++ b/packages/cursorless-engine/src/languages/TreeSitterQuery/TreeSitterQuery.ts
@@ -80,7 +80,7 @@ export class TreeSitterQuery {
             node,
             document,
             range: getNodeRange(node),
-            insertionDelimiter: undefined,
+            insertionDelimiters: undefined,
             allowMultiple: false,
           })),
         }),
@@ -114,9 +114,9 @@ export class TreeSitterQuery {
               .map(({ range }) => range)
               .reduce((accumulator, range) => range.union(accumulator)),
             allowMultiple: captures.some((capture) => capture.allowMultiple),
-            insertionDelimiter: captures.find(
-              (capture) => capture.insertionDelimiter != null,
-            )?.insertionDelimiter,
+            insertionDelimiters: captures.find(
+              (capture) => capture.insertionDelimiters != null,
+            )?.insertionDelimiters,
           };
         });
 

--- a/packages/cursorless-engine/src/languages/TreeSitterQuery/checkCaptureStartEnd.test.ts
+++ b/packages/cursorless-engine/src/languages/TreeSitterQuery/checkCaptureStartEnd.test.ts
@@ -5,7 +5,7 @@ import assert from "assert";
 
 interface TestCase {
   name: string;
-  captures: Omit<QueryCapture, "allowMultiple" | "insertionDelimiter">[];
+  captures: Omit<QueryCapture, "allowMultiple" | "insertionDelimiters">[];
   isValid: boolean;
   expectedErrorMessageIds: string[];
 }
@@ -192,7 +192,7 @@ suite("checkCaptureStartEnd", () => {
         testCase.captures.map((capture) => ({
           ...capture,
           allowMultiple: false,
-          insertionDelimiter: undefined,
+          insertionDelimiters: undefined,
         })),
         messages,
       );

--- a/packages/cursorless-engine/src/languages/TreeSitterQuery/queryPredicateOperators.ts
+++ b/packages/cursorless-engine/src/languages/TreeSitterQuery/queryPredicateOperators.ts
@@ -205,10 +205,14 @@ class Log extends QueryPredicateOperator<Log> {
  */
 class InsertionDelimiter extends QueryPredicateOperator<InsertionDelimiter> {
   name = "insertion-delimiter!" as const;
-  schema = z.tuple([q.node, q.string]);
+  schema = z.union([
+    z.tuple([q.node, q.string]),
+    z.tuple([q.node, q.string, q.string]),
+    z.tuple([q.node, q.string, q.string, q.string]),
+  ]);
 
-  run(nodeInfo: MutableQueryCapture, insertionDelimiter: string) {
-    nodeInfo.insertionDelimiter = insertionDelimiter;
+  run(nodeInfo: MutableQueryCapture, ...insertionDelimiters: string[]) {
+    nodeInfo.insertionDelimiters = insertionDelimiters;
 
     return true;
   }

--- a/packages/cursorless-engine/src/languages/TreeSitterQuery/rewriteStartOfEndOf.test.ts
+++ b/packages/cursorless-engine/src/languages/TreeSitterQuery/rewriteStartOfEndOf.test.ts
@@ -54,7 +54,7 @@ function fillOutCapture(capture: NameRange): MutableQueryCapture {
   return {
     ...capture,
     allowMultiple: false,
-    insertionDelimiter: undefined,
+    insertionDelimiters: undefined,
     document: null as unknown as TextDocument,
     node: null as unknown as SyntaxNode,
   };

--- a/packages/cursorless-engine/src/processTargets/modifiers/scopeHandlers/TreeSitterScopeHandler/TreeSitterScopeHandler.ts
+++ b/packages/cursorless-engine/src/processTargets/modifiers/scopeHandlers/TreeSitterScopeHandler/TreeSitterScopeHandler.ts
@@ -48,7 +48,7 @@ export class TreeSitterScopeHandler extends BaseTreeSitterScopeHandler {
       return undefined;
     }
 
-    const { range: contentRange, allowMultiple, insertionDelimiter } = capture;
+    const { range: contentRange, allowMultiple, insertionDelimiters } = capture;
 
     const domain =
       getRelatedRange(match, scopeTypeType, "domain", true) ?? contentRange;
@@ -70,6 +70,8 @@ export class TreeSitterScopeHandler extends BaseTreeSitterScopeHandler {
       true,
     );
 
+    const delimiter = getInsertionDelimiter(editor, match, insertionDelimiters);
+
     return {
       editor,
       domain,
@@ -84,11 +86,37 @@ export class TreeSitterScopeHandler extends BaseTreeSitterScopeHandler {
           leadingDelimiterRange,
           trailingDelimiterRange,
           interiorRange,
-          delimiter: insertionDelimiter,
+          delimiter,
         }),
       ],
     };
   }
+}
+
+function getInsertionDelimiter(
+  editor: TextEditor,
+  match: QueryMatch,
+  insertionDelimiters?: string[],
+): string | undefined {
+  if (insertionDelimiters == null) {
+    return undefined;
+  }
+
+  for (const delimiter of insertionDelimiters) {
+    if (!delimiter.startsWith("@")) {
+      return delimiter;
+    }
+
+    const capture = findCaptureByName(match, delimiter.slice(1));
+    if (capture != null) {
+      const { range } = capture;
+      if (!range.isEmpty) {
+        return editor.document.getText(range);
+      }
+    }
+  }
+
+  return undefined;
 }
 
 function dropEmptyRange(range?: Range) {


### PR DESCRIPTION
Supports a syntax like this

```
(#insertion-delimiter! @collectionItem "@collectionItem.trailing" "@collectionItem.leading" ", ")
```

After I implemented it I do wonder if we want something simpler? Maybe a boolean just telling it to include delimiters?
```
(#insertion-delimiter! ", " true)
```

Edit: I have another approach in the below pull request that I prefer. I will keep this draft here as an alternative to discuss.
https://github.com/cursorless-dev/cursorless/pull/2081

@pokey @josharian 


## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [-] I have not broken the cheatsheet
