### PR TITLE
Don't focus search editor

### DIFF
--- a/packages/cursorless-vscode/src/ide/vscode/VscodeFocusEditor.ts
+++ b/packages/cursorless-vscode/src/ide/vscode/VscodeFocusEditor.ts
@@ -32,6 +32,11 @@ export default async function vscodeFocusEditor(
   ide: VscodeIDE,
   editor: VscodeTextEditorImpl,
 ) {
+  // Focusing the search editor brings focus back to the input field.
+  if (editor.document.uri.scheme === "search-editor") {
+    return;
+  }
+
   const viewColumn = getViewColumn(editor.vscodeEditor);
   if (viewColumn != null) {
     await commands.executeCommand(columnFocusCommands[viewColumn]);

--- a/packages/cursorless-vscode/src/ide/vscode/VscodeFocusEditor.ts
+++ b/packages/cursorless-vscode/src/ide/vscode/VscodeFocusEditor.ts
@@ -33,6 +33,9 @@ export default async function vscodeFocusEditor(
   editor: VscodeTextEditorImpl,
 ) {
   // Focusing the search editor brings focus back to the input field.
+  // FIXME: This is a hack. There is no way to focus the search editor. If we
+  // could figure out if the editor was not focused, we could issue
+  // `search.action.focusNextSearchResult`.
   if (editor.document.uri.scheme === "search-editor") {
     return;
   }

--- a/packages/cursorless-vscode/src/ide/vscode/VscodeFocusEditor.ts
+++ b/packages/cursorless-vscode/src/ide/vscode/VscodeFocusEditor.ts
@@ -36,6 +36,7 @@ export default async function vscodeFocusEditor(
   // FIXME: This is a hack. There is no way to focus the search editor. If we
   // could figure out if the editor was not focused, we could issue
   // `search.action.focusNextSearchResult`.
+  // Issue: https://github.com/cursorless-dev/cursorless/issues/1722
   if (editor.document.uri.scheme === "search-editor") {
     return;
   }


### PR DESCRIPTION
Partially addresses #1722

The problem is that when you focus the search editor focus is brought back to the import/query box. For now just don't focus the editor actually makes it so if the search editor is already in focus you can now use Cursorless in it. The simplest way to get to the search editor is probably use `search.action.focusNextSearchResult`. Unfortunately there is no command to focus the results generally. Focusing the next result we of course don't want to issue every time we do a Cursorless command.

## Checklist

- [-] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [-] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [-] I have not broken the cheatsheet
