### PR TITLE
Remove `.only` to reenable tests

### DIFF
--- a/packages/cursorless-vscode-e2e/src/suite/scopes.vscode.test.ts
+++ b/packages/cursorless-vscode-e2e/src/suite/scopes.vscode.test.ts
@@ -20,7 +20,7 @@ import {
   serializeScopeFixture,
 } from "./serializeScopeFixture";
 
-suite.only("Scope test cases", async function () {
+suite("Scope test cases", async function () {
   endToEndTestSetup(this);
 
   const testPaths = getScopeTestPaths();


### PR DESCRIPTION


## Checklist

- [-] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [-] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [-] I have not broken the cheatsheet
