### PR TITLE
Relative exclusive scope should skip containing

### DIFF
--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/relativeScopes/changeNextState.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/relativeScopes/changeNextState.yml
@@ -1,0 +1,35 @@
+languageId: typescript
+command:
+  version: 6
+  spokenForm: change next state
+  action:
+    name: clearAndSetSelection
+    target:
+      type: primitive
+      modifiers:
+        - type: relativeScope
+          scopeType: {type: statement}
+          offset: 1
+          length: 1
+          direction: forward
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    if (true) {
+        console.log(1)
+    }
+
+    console.log(2)
+  selections:
+    - anchor: {line: 0, character: 4}
+      active: {line: 0, character: 4}
+  marks: {}
+finalState:
+  documentContents: |+
+    if (true) {
+        console.log(1)
+    }
+
+  selections:
+    - anchor: {line: 4, character: 0}
+      active: {line: 4, character: 0}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/relativeScopes/clearNextCall2.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/relativeScopes/clearNextCall2.yml
@@ -19,7 +19,7 @@ initialState:
       active: {line: 0, character: 0}
   marks: {}
 finalState:
-  documentContents: aaa(, ccc()) + ddd()
+  documentContents: "aaa(bbb(), ccc()) + "
   selections:
-    - anchor: {line: 0, character: 4}
-      active: {line: 0, character: 4}
+    - anchor: {line: 0, character: 20}
+      active: {line: 0, character: 20}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/relativeScopes/clearNextCall4.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/relativeScopes/clearNextCall4.yml
@@ -19,7 +19,7 @@ initialState:
       active: {line: 0, character: 1}
   marks: {}
 finalState:
-  documentContents: aaa(, ccc()) + ddd()
+  documentContents: "aaa(bbb(), ccc()) + "
   selections:
-    - anchor: {line: 0, character: 4}
-      active: {line: 0, character: 4}
+    - anchor: {line: 0, character: 20}
+      active: {line: 0, character: 20}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/relativeScopes/clearSecondNextCall.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/relativeScopes/clearSecondNextCall.yml
@@ -1,14 +1,14 @@
 languageId: ruby
 command:
   version: 5
-  spokenForm: change second next call
+  spokenForm: change next call
   action: {name: clearAndSetSelection}
   targets:
     - type: primitive
       modifiers:
         - type: relativeScope
           scopeType: {type: functionCall}
-          offset: 2
+          offset: 1
           length: 1
           direction: forward
   usePrePhraseSnapshot: true


### PR DESCRIPTION
This frequently bites me. `"two states"` refers to the if statement and the second print statement, but `"next state"` refers to the first print statement. This change makes it so it skips containing and refers to the second one instead.

```ts
    if ( | true) {
        console.log(1)
    }

    console.log(2)
```
## Checklist

- [x] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [-] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [-] I have not broken the cheatsheet
