### PR TITLE
Remove cyclic dependency between notebook.ts and notebookLegacy.ts.

### DIFF
--- a/packages/cursorless-vscode/src/ide/vscode/notebook/notebookLegacy.ts
+++ b/packages/cursorless-vscode/src/ide/vscode/notebook/notebookLegacy.ts
@@ -4,7 +4,6 @@ import { commands, NotebookDocument, TextDocument } from "vscode";
 import { toVscodeEditor } from "../toVscodeEditor";
 import type { VscodeIDE } from "../VscodeIDE";
 import type { VscodeTextEditorImpl } from "../VscodeTextEditorImpl";
-import { getNotebookFromCellDocument } from "./notebook";
 
 export async function focusNotebookCellLegacy(
   ide: VscodeIDE,
@@ -18,10 +17,10 @@ export async function focusNotebookCellLegacy(
 
   const vscodeActiveEditor = toVscodeEditor(activeTextEditor);
 
-  const editorNotebook = getNotebookFromCellDocument(
+  const editorNotebook = getNotebookFromCellDocumentLegacy(
     editor.vscodeEditor.document,
   );
-  const activeEditorNotebook = getNotebookFromCellDocument(
+  const activeEditorNotebook = getNotebookFromCellDocumentLegacy(
     vscodeActiveEditor.document,
   );
 


### PR DESCRIPTION
Once `isVscodeLegacyNotebookVersion` has determined that `getNotebookFromCellDocument` should call `getNotebookFromCellDocumentLegacy`, there is no need for `getNotebookFromCellDocumentLegacy` to determine that again, and doing so forces a cyclic import dependency.