### PR TITLE
Add iteration scope for markdown items

### DIFF
--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/markdown/changeEveryItem.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/markdown/changeEveryItem.yml
@@ -1,0 +1,47 @@
+languageId: markdown
+command:
+  version: 6
+  spokenForm: change every item
+  action:
+    name: clearAndSetSelection
+    target:
+      type: primitive
+      modifiers:
+        - type: everyScope
+          scopeType: {type: collectionItem}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    ddd eee:
+
+    - aaa
+    - bbb
+    - ccc
+
+    fff ggg:
+
+    - hhh
+    - iii
+  selections:
+    - anchor: {line: 4, character: 5}
+      active: {line: 4, character: 5}
+  marks: {}
+finalState:
+  documentContents: |-
+    ddd eee:
+
+    - 
+    - 
+    - 
+
+    fff ggg:
+
+    - hhh
+    - iii
+  selections:
+    - anchor: {line: 2, character: 2}
+      active: {line: 2, character: 2}
+    - anchor: {line: 3, character: 2}
+      active: {line: 3, character: 2}
+    - anchor: {line: 4, character: 2}
+      active: {line: 4, character: 2}

--- a/queries/markdown.scm
+++ b/queries/markdown.scm
@@ -39,3 +39,5 @@
   (#trim-end! @_.domain)
   (#insertion-delimiter! @collectionItem "\n")
 )
+
+(list) @collectionItem.iteration


### PR DESCRIPTION


## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet
