### PR TITLE
Add proper jsonc comment support

### DIFF
--- a/packages/common/src/scopeSupportFacets/getLanguageScopeSupport.ts
+++ b/packages/common/src/scopeSupportFacets/getLanguageScopeSupport.ts
@@ -1,6 +1,7 @@
 import { htmlScopeSupport } from "./html";
 import { javaScopeSupport } from "./java";
 import { javascriptScopeSupport } from "./javascript";
+import { jsonScopeSupport } from "./json";
 import { pythonScopeSupport } from "./python";
 import { LanguageScopeSupportFacetMap } from "./scopeSupportFacets.types";
 import { talonScopeSupport } from "./talon";
@@ -10,18 +11,20 @@ export function getLanguageScopeSupport(
   languageId: string,
 ): LanguageScopeSupportFacetMap {
   switch (languageId) {
-    case "javascript":
-      return javascriptScopeSupport;
-    case "typescript":
-      return typescriptScopeSupport;
-    case "java":
-      return javaScopeSupport;
-    case "python":
-      return pythonScopeSupport;
     case "html":
       return htmlScopeSupport;
+    case "java":
+      return javaScopeSupport;
+    case "javascript":
+      return javascriptScopeSupport;
+    case "json":
+      return jsonScopeSupport;
+    case "python":
+      return pythonScopeSupport;
     case "talon":
       return talonScopeSupport;
+    case "typescript":
+      return typescriptScopeSupport;
   }
   throw Error(`Unsupported language: '${languageId}'`);
 }

--- a/packages/common/src/scopeSupportFacets/json.ts
+++ b/packages/common/src/scopeSupportFacets/json.ts
@@ -1,0 +1,13 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+
+import {
+  LanguageScopeSupportFacetMap,
+  ScopeSupportFacetLevel,
+} from "./scopeSupportFacets.types";
+
+const { supported } = ScopeSupportFacetLevel;
+
+export const jsonScopeSupport: LanguageScopeSupportFacetMap = {
+  "comment.line": supported,
+  "comment.block": supported,
+};

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/scopes/json/comment.block.scope
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/scopes/json/comment.block.scope
@@ -1,0 +1,16 @@
+/*
+  Hello world
+*/
+---
+
+[Content] =
+[Removal] =
+[Domain] = 0:0-2:2
+0| /*
+  >--
+1|   Hello world
+   -------------
+2| */
+   --<
+
+[Insertion delimiter] = "\n"

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/scopes/json/comment.line.scope
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/scopes/json/comment.line.scope
@@ -1,0 +1,10 @@
+// Hello world
+---
+
+[Content] =
+[Removal] =
+[Domain] = 0:0-0:14
+0| // Hello world
+  >--------------<
+
+[Insertion delimiter] = "\n"

--- a/queries/json.scm
+++ b/queries/json.scm
@@ -14,6 +14,12 @@
 ;;!  ^^^^^^^^
 (string) @string
 
+;;!! // aaa
+;;!  ^^^^^^
+;;!! /* aaa */
+;;!  ^^^^^^^^^
+(comment) @comment @textFragment
+
 ;;!! {"value": 0}
 ;;!   ^^^^^^^  ^
 ;;!   ----------

--- a/queries/jsonc.scm
+++ b/queries/jsonc.scm
@@ -1,4 +1,1 @@
 ;; import json.scm
-
-;; Currently not supported by our Tree sitter parser
-;; (comment) @comment @textFragment


### PR DESCRIPTION
After bumping tree-sitter-json in https://github.com/cursorless-dev/vscode-parse-tree/commit/5920905dcd80f35da18d560e4e475ad2c3b71bd7, the tree-sitter-json parser now has proper support for comments

Fwiw, that version also includes proper jsonl support, so it's no longer a hack

## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet
