### PR TITLE
Attempt at regex for validation

### DIFF
--- a/packages/cursorless-engine/src/languages/TreeSitterQuery/validateQueryCaptures.test.ts
+++ b/packages/cursorless-engine/src/languages/TreeSitterQuery/validateQueryCaptures.test.ts
@@ -18,13 +18,13 @@ const testCases: { name: string; isOk: boolean; content: string }[] = [
     name: "Position captures",
     isOk: true,
     content:
-      "(if_statement) @statement.leading.startOf @statement.trailing.endOf",
+      "(if_statement) @statement.startOf @statement.leading.startOf @statement.trailing.endOf",
   },
   {
     name: "Range captures",
     isOk: true,
     content:
-      "(if_statement) @statement.removal.start @statement.interior.start.endOf",
+      "(if_statement) @statement.start @statement.start.endOf @statement.removal.start @statement.interior.start.endOf",
   },
   {
     name: "Dummy capture",
@@ -70,11 +70,6 @@ const testCases: { name: string; isOk: boolean; content: string }[] = [
     name: "Wildcard start",
     isOk: false,
     content: "(if_statement) @_.start",
-  },
-  {
-    name: "Leading start",
-    isOk: false,
-    content: "(if_statement) @statement.leading.start",
   },
   {
     name: "Text fragment removal",

--- a/packages/cursorless-engine/src/languages/TreeSitterQuery/validateQueryCaptures.test.ts
+++ b/packages/cursorless-engine/src/languages/TreeSitterQuery/validateQueryCaptures.test.ts
@@ -29,7 +29,13 @@ const testCases: { name: string; isOk: boolean; content: string }[] = [
   {
     name: "Dummy capture",
     isOk: true,
-    content: "(if_statement) @dummy",
+    content: "(if_statement) @dummy @_foo",
+  },
+  {
+    name: "No range dummy relationships",
+    isOk: false,
+    content:
+      "(if_statement) @dummy.start @_foo.start @dummy.startOf @_foo.startOf",
   },
   {
     name: "Text fragment",

--- a/packages/cursorless-engine/src/languages/TreeSitterQuery/validateQueryCaptures.ts
+++ b/packages/cursorless-engine/src/languages/TreeSitterQuery/validateQueryCaptures.ts
@@ -1,71 +1,24 @@
 import { showError, simpleScopeTypeTypes } from "@cursorless/common";
 import { ide } from "../../singletons/ide.singleton";
 
-const wildcard = "_";
-const textFragment = "textFragment";
-const dummy = "dummy";
-const captureNames = [wildcard, ...simpleScopeTypeTypes];
+function oneOfRegex(...values: string[]): string {
+  return `(${values.join("|")})`;
+}
 
-const positionRelationships = ["prefix", "leading", "trailing"];
-const positionSuffixes = ["startOf", "endOf"];
-
-const rangeRelationships = [
+const rangeRelationships = oneOfRegex(
   "domain",
   "removal",
   "interior",
+  "prefix",
+  "leading",
+  "trailing",
   "iteration",
   "iteration.domain",
-];
-const rangeSuffixes = [
-  "start",
-  "end",
-  "start.startOf",
-  "start.endOf",
-  "end.startOf",
-  "end.endOf",
-];
-
-const allowedCaptures = new Set<string>();
-
-allowedCaptures.add(dummy);
-allowedCaptures.add(textFragment);
-
-for (const suffix of rangeSuffixes) {
-  allowedCaptures.add(`${textFragment}.${suffix}`);
-}
-
-for (const captureName of captureNames) {
-  // Wildcard is not allowed by itself without a relationship
-  if (captureName !== wildcard) {
-    // eg: statement
-    allowedCaptures.add(captureName);
-
-    // eg: statement.start | statement.start.endOf
-    for (const suffix of rangeSuffixes) {
-      allowedCaptures.add(`${captureName}.${suffix}`);
-    }
-  }
-
-  for (const relationship of positionRelationships) {
-    // eg: statement.leading
-    allowedCaptures.add(`${captureName}.${relationship}`);
-
-    for (const suffix of positionSuffixes) {
-      // eg: statement.leading.endOf
-      allowedCaptures.add(`${captureName}.${relationship}.${suffix}`);
-    }
-  }
-
-  for (const relationship of rangeRelationships) {
-    // eg: statement.domain
-    allowedCaptures.add(`${captureName}.${relationship}`);
-
-    for (const suffix of rangeSuffixes) {
-      // eg: statement.domain.start | statement.domain.start.endOf
-      allowedCaptures.add(`${captureName}.${relationship}.${suffix}`);
-    }
-  }
-}
+);
+const baseScopeTypeRegex = oneOfRegex(...simpleScopeTypeTypes);
+const scopeTypeRegex = `${baseScopeTypeRegex}(\\.${rangeRelationships})?|_\\.${rangeRelationships}`;
+const baseRegex = `(textFragment|${scopeTypeRegex})(\\.start|\\.end)?(\\.startOf|\\.endOf)?`;
+const regex = new RegExp(`^${oneOfRegex("_\\w+", "dummy", baseRegex)}$`);
 
 // Not a comment. ie line is not starting with `;;`
 // Capture starts with `@` and is followed by words and/or dots
@@ -79,7 +32,7 @@ export function validateQueryCaptures(file: string, rawQuery: string): void {
   for (const match of matches) {
     const captureName = match[1];
 
-    if (!allowedCaptures.has(captureName)) {
+    if (!regex.test(captureName)) {
       const lineNumber = match.input!.slice(0, match.index!).split("\n").length;
       errors.push(`${file}(${lineNumber}) invalid capture '@${captureName}'.`);
     }


### PR DESCRIPTION
Certainly a lot less code. Also allows things like `statement.startOf`, which should be allowed I think. We have zero-width captures, eg for name of start tag with react fragments

## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet
