### PR TITLE
pokey's keyboard improvements

### DIFF
--- a/cursorless-talon/src/spoken_forms.py
+++ b/cursorless-talon/src/spoken_forms.py
@@ -115,7 +115,11 @@ def update():
     )
 
     disposables = [
-        handle_csv("actions.csv"),
+        handle_csv(
+            "actions.csv",
+            extra_allowed_values=["private.setImplicitTarget"],
+            default_list_name="simple_action",
+        ),
         handle_csv("target_connectives.csv"),
         handle_csv("modifiers.csv"),
         handle_csv("positions.csv"),

--- a/packages/common/src/StoredTargetKey.ts
+++ b/packages/common/src/StoredTargetKey.ts
@@ -3,5 +3,6 @@ export const storedTargetKeys = [
   "source",
   "instanceReference",
   "implicit",
+  "keyboard",
 ] as const;
 export type StoredTargetKey = (typeof storedTargetKeys)[number];

--- a/packages/common/src/StoredTargetKey.ts
+++ b/packages/common/src/StoredTargetKey.ts
@@ -1,0 +1,6 @@
+export const storedTargetKeys = [
+  "that",
+  "source",
+  "instanceReference",
+] as const;
+export type StoredTargetKey = (typeof storedTargetKeys)[number];

--- a/packages/common/src/StoredTargetKey.ts
+++ b/packages/common/src/StoredTargetKey.ts
@@ -2,5 +2,6 @@ export const storedTargetKeys = [
   "that",
   "source",
   "instanceReference",
+  "implicit",
 ] as const;
 export type StoredTargetKey = (typeof storedTargetKeys)[number];

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -98,3 +98,4 @@ export * from "./scopeSupportFacets/scopeSupportFacets.types";
 export * from "./scopeSupportFacets/scopeSupportFacetInfos";
 export * from "./scopeSupportFacets/textualScopeSupportFacetInfos";
 export * from "./scopeSupportFacets/getLanguageScopeSupport";
+export * from "./StoredTargetKey";

--- a/packages/common/src/testUtil/TestCaseSnapshot.ts
+++ b/packages/common/src/testUtil/TestCaseSnapshot.ts
@@ -1,3 +1,4 @@
+import { StoredTargetKey } from "../StoredTargetKey";
 import {
   RangePlainObject,
   SelectionPlainObject,
@@ -5,7 +6,11 @@ import {
   TargetPlainObject,
 } from "../util/toPlainObject";
 
-export type TestCaseSnapshot = {
+type MarkKeys = {
+  [K in `${StoredTargetKey}Mark`]?: TargetPlainObject[];
+};
+
+export interface TestCaseSnapshot extends MarkKeys {
   documentContents: string;
   selections: SelectionPlainObject[];
   clipboard?: string;
@@ -13,17 +18,13 @@ export type TestCaseSnapshot = {
   // https://github.com/cursorless-dev/cursorless/issues/160
   visibleRanges?: RangePlainObject[];
   marks?: SerializedMarks;
-  thatMark?: TargetPlainObject[];
-  sourceMark?: TargetPlainObject[];
-  instanceReferenceMark?: TargetPlainObject[];
   timeOffsetSeconds?: number;
 
   /**
    * Extra information about the snapshot. Must be json serializable
    */
   metadata?: unknown;
-};
-
+}
 export type ExtraSnapshotField = keyof TestCaseSnapshot;
 export type ExcludableSnapshotField = keyof TestCaseSnapshot;
 

--- a/packages/common/src/types/command/ActionDescriptor.ts
+++ b/packages/common/src/types/command/ActionDescriptor.ts
@@ -50,6 +50,7 @@ const simpleActionNames = [
   "toggleLineComment",
   "unfoldRegion",
   "private.setImplicitTarget",
+  "private.setKeyboardTarget",
   "private.showParseTree",
   "private.getTargets",
 ] as const;

--- a/packages/common/src/types/command/ActionDescriptor.ts
+++ b/packages/common/src/types/command/ActionDescriptor.ts
@@ -49,6 +49,7 @@ const simpleActionNames = [
   "toggleLineBreakpoint",
   "toggleLineComment",
   "unfoldRegion",
+  "private.setImplicitTarget",
   "private.showParseTree",
   "private.getTargets",
 ] as const;

--- a/packages/cursorless-engine/src/actions/Actions.ts
+++ b/packages/cursorless-engine/src/actions/Actions.ts
@@ -33,7 +33,7 @@ import Remove from "./Remove";
 import Replace from "./Replace";
 import Rewrap from "./Rewrap";
 import { ScrollToBottom, ScrollToCenter, ScrollToTop } from "./Scroll";
-import { SetInstanceReference } from "./SetInstanceReference";
+import { SetSpecialTarget } from "./SetSpecialTarget";
 import {
   SetSelection,
   SetSelectionAfter,
@@ -134,7 +134,10 @@ export class Actions implements ActionRecord {
   scrollToBottom = new ScrollToBottom();
   scrollToCenter = new ScrollToCenter();
   scrollToTop = new ScrollToTop();
-  ["experimental.setInstanceReference"] = new SetInstanceReference();
+  ["private.setImplicitTarget"] = new SetSpecialTarget("implicit");
+  ["experimental.setInstanceReference"] = new SetSpecialTarget(
+    "instanceReference",
+  );
   setSelection = new SetSelection();
   setSelectionAfter = new SetSelectionAfter();
   setSelectionBefore = new SetSelectionBefore();

--- a/packages/cursorless-engine/src/actions/Actions.ts
+++ b/packages/cursorless-engine/src/actions/Actions.ts
@@ -135,6 +135,7 @@ export class Actions implements ActionRecord {
   scrollToCenter = new ScrollToCenter();
   scrollToTop = new ScrollToTop();
   ["private.setImplicitTarget"] = new SetSpecialTarget("implicit");
+  ["private.setKeyboardTarget"] = new SetSpecialTarget("keyboard");
   ["experimental.setInstanceReference"] = new SetSpecialTarget(
     "instanceReference",
   );

--- a/packages/cursorless-engine/src/actions/SetSpecialTarget.ts
+++ b/packages/cursorless-engine/src/actions/SetSpecialTarget.ts
@@ -1,15 +1,18 @@
+import { StoredTargetKey } from "@cursorless/common";
 import { Target } from "../typings/target.types";
 import { SimpleAction, ActionReturnValue } from "./actions.types";
 
-export class SetInstanceReference implements SimpleAction {
-  constructor() {
+export class SetSpecialTarget implements SimpleAction {
+  noAutomaticTokenExpansion = true;
+
+  constructor(private key: StoredTargetKey) {
     this.run = this.run.bind(this);
   }
 
   async run(targets: Target[]): Promise<ActionReturnValue> {
     return {
       thatTargets: targets,
-      instanceReferenceTargets: targets,
+      [`${this.key}Targets`]: targets,
     };
   }
 }

--- a/packages/cursorless-engine/src/actions/actions.types.ts
+++ b/packages/cursorless-engine/src/actions/actions.types.ts
@@ -52,6 +52,11 @@ export interface ActionReturnValue {
    * to determine either the range for "every", or the start point for "next"
    */
   instanceReferenceTargets?: Target[];
+
+  /**
+   * A list of targets that become the start of the pipeline when the mark is ommitted.
+   */
+  implicitTargets?: Target[];
 }
 
 export interface SimpleAction {
@@ -62,6 +67,13 @@ export interface SimpleAction {
    * @param args Extra args to command
    */
   getFinalStages?(): ModifierStage[];
+
+  /**
+   * If `true`, don't perform automatic token expansion for "<action> this" with
+   * empty cursor. Used for actions like `setImplicitTarget` that are just
+   * loading up the pipeline.
+   */
+  noAutomaticTokenExpansion?: boolean;
 }
 
 /**

--- a/packages/cursorless-engine/src/core/StoredTargets.ts
+++ b/packages/cursorless-engine/src/core/StoredTargets.ts
@@ -11,6 +11,8 @@ export class StoredTargetMap {
   private notifier = new Notifier<[StoredTargetKey, Target[] | undefined]>();
 
   set(key: StoredTargetKey, targets: Target[] | undefined) {
+    // TODO: Figure out how to set a target to undefined
+    // Maybe need separate command?
     this.targetMap.set(key, targets);
     this.notifier.notifyListeners(key, targets);
   }

--- a/packages/cursorless-engine/src/core/StoredTargets.ts
+++ b/packages/cursorless-engine/src/core/StoredTargets.ts
@@ -1,6 +1,6 @@
+import { Notifier } from "@cursorless/common";
 import { Target } from "../typings/target.types";
-
-export type StoredTargetKey = "that" | "source" | "instanceReference";
+import { StoredTargetKey, storedTargetKeys } from "@cursorless/common";
 
 /**
  * Used to store targets between commands.  This is used by marks like `that`
@@ -8,12 +8,24 @@ export type StoredTargetKey = "that" | "source" | "instanceReference";
  */
 export class StoredTargetMap {
   private targetMap: Map<StoredTargetKey, Target[] | undefined> = new Map();
+  private notifier = new Notifier<[StoredTargetKey, Target[] | undefined]>();
 
   set(key: StoredTargetKey, targets: Target[] | undefined) {
     this.targetMap.set(key, targets);
+    this.notifier.notifyListeners(key, targets);
   }
 
   get(key: StoredTargetKey) {
     return this.targetMap.get(key);
+  }
+
+  onStoredTargets(
+    callback: (key: StoredTargetKey, targets: Target[] | undefined) => void,
+  ) {
+    for (const key of storedTargetKeys) {
+      callback(key, this.get(key));
+    }
+
+    return this.notifier.registerListener(callback);
   }
 }

--- a/packages/cursorless-engine/src/core/commandRunner/CommandRunnerImpl.ts
+++ b/packages/cursorless-engine/src/core/commandRunner/CommandRunnerImpl.ts
@@ -18,6 +18,7 @@ import { selectionToStoredTarget } from "./selectionToStoredTarget";
 export class CommandRunnerImpl implements CommandRunner {
   private inferenceContext: InferenceContext;
   private finalStages: ModifierStage[] = [];
+  private noAutomaticTokenExpansion: boolean | undefined;
 
   constructor(
     private debug: Debug,
@@ -53,6 +54,7 @@ export class CommandRunnerImpl implements CommandRunner {
       sourceSelections: newSourceSelections,
       sourceTargets: newSourceTargets,
       instanceReferenceTargets: newInstanceReferenceTargets,
+      implicitTargets: newImplicitTargets,
     } = await this.runAction(action);
 
     this.storedTargets.set(
@@ -64,6 +66,7 @@ export class CommandRunnerImpl implements CommandRunner {
       constructStoredTarget(newSourceTargets, newSourceSelections),
     );
     this.storedTargets.set("instanceReference", newInstanceReferenceTargets);
+    this.storedTargets.set("implicit", newImplicitTargets);
 
     return returnValue;
   }
@@ -179,6 +182,8 @@ export class CommandRunnerImpl implements CommandRunner {
       default: {
         const action = this.actions[actionDescriptor.name];
         this.finalStages = action.getFinalStages?.() ?? [];
+        this.noAutomaticTokenExpansion =
+          action.noAutomaticTokenExpansion ?? false;
         return action.run(this.getTargets(actionDescriptor.target));
       }
     }
@@ -191,7 +196,10 @@ export class CommandRunnerImpl implements CommandRunner {
       partialTargetsDescriptor,
     );
 
-    return this.pipelineRunner.run(targetDescriptor, this.finalStages);
+    return this.pipelineRunner.run(targetDescriptor, {
+      actionFinalStages: this.finalStages,
+      noAutomaticTokenExpansion: this.noAutomaticTokenExpansion,
+    });
   }
 
   private getDestinations(

--- a/packages/cursorless-engine/src/core/inferFullTargetDescriptor.ts
+++ b/packages/cursorless-engine/src/core/inferFullTargetDescriptor.ts
@@ -104,7 +104,7 @@ function inferPrimitiveTarget(
     (shouldInferPreviousMark(target)
       ? getPreviousMark(previousTargets)
       : null) ?? {
-      type: "cursor",
+      type: "implicit",
     };
 
   const modifiers =

--- a/packages/cursorless-engine/src/generateSpokenForm/defaultSpokenForms/actions.ts
+++ b/packages/cursorless-engine/src/generateSpokenForm/defaultSpokenForms/actions.ts
@@ -58,6 +58,7 @@ export const actions = {
   joinLines: "join",
 
   ["private.showParseTree"]: "parse tree",
+  ["private.setImplicitTarget"]: "implicit",
   ["experimental.setInstanceReference"]: "from",
 
   editNew: null,

--- a/packages/cursorless-engine/src/generateSpokenForm/defaultSpokenForms/actions.ts
+++ b/packages/cursorless-engine/src/generateSpokenForm/defaultSpokenForms/actions.ts
@@ -66,6 +66,7 @@ export const actions = {
   getText: null,
   replace: null,
   ["private.getTargets"]: null,
+  ["private.setKeyboardTarget"]: null,
 
   // These actions are implemented talon-side, usually using `getText` followed
   // by some other action.

--- a/packages/cursorless-engine/src/generateSpokenForm/defaultSpokenForms/modifiers.ts
+++ b/packages/cursorless-engine/src/generateSpokenForm/defaultSpokenForms/modifiers.ts
@@ -2,28 +2,7 @@ import { CompositeKeyMap } from "@cursorless/common";
 import { SpeakableSurroundingPairName } from "../../spokenForms/SpokenFormType";
 import { SpokenFormComponentMap } from "../getSpokenFormComponentMap";
 import { CustomizableSpokenFormComponentForType } from "../SpokenFormComponent";
-
-const surroundingPairsDelimiters: Record<
-  SpeakableSurroundingPairName,
-  [string, string] | null
-> = {
-  curlyBrackets: ["{", "}"],
-  angleBrackets: ["<", ">"],
-  escapedDoubleQuotes: ['\\"', '\\"'],
-  escapedSingleQuotes: ["\\'", "\\'"],
-  escapedParentheses: ["\\(", "\\)"],
-  escapedSquareBrackets: ["\\[", "\\]"],
-  doubleQuotes: ['"', '"'],
-  parentheses: ["(", ")"],
-  backtickQuotes: ["`", "`"],
-  squareBrackets: ["[", "]"],
-  singleQuotes: ["'", "'"],
-  whitespace: [" ", " "],
-
-  any: null,
-  string: null,
-  collectionBoundary: null,
-};
+import { surroundingPairsDelimiters } from "./surroundingPairsDelimiters";
 
 const surroundingPairDelimiterToName = new CompositeKeyMap<
   [string, string],

--- a/packages/cursorless-engine/src/generateSpokenForm/defaultSpokenForms/surroundingPairsDelimiters.ts
+++ b/packages/cursorless-engine/src/generateSpokenForm/defaultSpokenForms/surroundingPairsDelimiters.ts
@@ -1,0 +1,23 @@
+import { SpeakableSurroundingPairName } from "../../spokenForms/SpokenFormType";
+
+export const surroundingPairsDelimiters: Record<
+  SpeakableSurroundingPairName,
+  [string, string] | null
+> = {
+  curlyBrackets: ["{", "}"],
+  angleBrackets: ["<", ">"],
+  escapedDoubleQuotes: ['\\"', '\\"'],
+  escapedSingleQuotes: ["\\'", "\\'"],
+  escapedParentheses: ["\\(", "\\)"],
+  escapedSquareBrackets: ["\\[", "\\]"],
+  doubleQuotes: ['"', '"'],
+  parentheses: ["(", ")"],
+  backtickQuotes: ["`", "`"],
+  squareBrackets: ["[", "]"],
+  singleQuotes: ["'", "'"],
+  whitespace: [" ", " "],
+
+  any: null,
+  string: null,
+  collectionBoundary: null,
+};

--- a/packages/cursorless-engine/src/generateSpokenForm/generateSpokenForm.ts
+++ b/packages/cursorless-engine/src/generateSpokenForm/generateSpokenForm.ts
@@ -104,6 +104,7 @@ export class SpokenFormGenerator {
       case "replace":
       case "executeCommand":
       case "private.getTargets":
+      case "private.setKeyboardTarget":
         throw new NoSpokenFormError(`Action '${action.name}'`);
 
       case "replaceWithTarget":

--- a/packages/cursorless-engine/src/index.ts
+++ b/packages/cursorless-engine/src/index.ts
@@ -5,4 +5,5 @@ export * from "./testCaseRecorder/TestCaseRecorder";
 export * from "./core/StoredTargets";
 export * from "./typings/TreeSitter";
 export * from "./cursorlessEngine";
+export * from "./generateSpokenForm/defaultSpokenForms/surroundingPairsDelimiters";
 export * from "./api/CursorlessEngineApi";

--- a/packages/cursorless-engine/src/processTargets/MarkStageFactory.ts
+++ b/packages/cursorless-engine/src/processTargets/MarkStageFactory.ts
@@ -1,6 +1,11 @@
 import { Mark } from "../typings/TargetDescriptor";
 import { MarkStage } from "./PipelineStages.types";
 
+export interface MarkStageFactoryOpts {
+  /** If there is an `instance` modifier downstream in the pipeline */
+  isForInstance: boolean;
+}
+
 export interface MarkStageFactory {
-  create(mark: Mark): MarkStage;
+  create(mark: Mark, opts: MarkStageFactoryOpts): MarkStage;
 }

--- a/packages/cursorless-engine/src/processTargets/MarkStageFactoryImpl.ts
+++ b/packages/cursorless-engine/src/processTargets/MarkStageFactoryImpl.ts
@@ -2,7 +2,7 @@ import { ReadOnlyHatMap } from "@cursorless/common";
 import { TargetPipelineRunner } from ".";
 import { StoredTargetMap } from "..";
 import { Mark } from "../typings/TargetDescriptor";
-import { MarkStageFactory } from "./MarkStageFactory";
+import { MarkStageFactory, MarkStageFactoryOpts } from "./MarkStageFactory";
 import { MarkStage } from "./PipelineStages.types";
 import { CursorStage } from "./marks/CursorStage";
 import { DecoratedSymbolStage } from "./marks/DecoratedSymbolStage";
@@ -12,6 +12,7 @@ import { NothingStage } from "./marks/NothingStage";
 import { RangeMarkStage } from "./marks/RangeMarkStage";
 import { StoredTargetStage } from "./marks/StoredTargetStage";
 import { TargetMarkStage } from "./marks/TargetMarkStage";
+import { ImplicitMarkStage } from "./marks/ImplicitMarkStage";
 
 export class MarkStageFactoryImpl implements MarkStageFactory {
   private targetPipelineRunner!: TargetPipelineRunner;
@@ -27,10 +28,12 @@ export class MarkStageFactoryImpl implements MarkStageFactory {
     this.create = this.create.bind(this);
   }
 
-  create(mark: Mark): MarkStage {
+  create(mark: Mark, opts: MarkStageFactoryOpts): MarkStage {
     switch (mark.type) {
       case "cursor":
         return new CursorStage(mark);
+      case "implicit":
+        return new ImplicitMarkStage(this, opts, this.storedTargets);
       case "that":
       case "source":
         return new StoredTargetStage(this.storedTargets, mark.type);
@@ -39,7 +42,7 @@ export class MarkStageFactoryImpl implements MarkStageFactory {
       case "lineNumber":
         return new LineNumberStage(mark);
       case "range":
-        return new RangeMarkStage(this, mark);
+        return new RangeMarkStage(this, opts, mark);
       case "nothing":
         return new NothingStage(mark);
       case "target":

--- a/packages/cursorless-engine/src/processTargets/marks/ImplicitMarkStage.ts
+++ b/packages/cursorless-engine/src/processTargets/marks/ImplicitMarkStage.ts
@@ -1,0 +1,27 @@
+import type { Target } from "../../typings/target.types";
+import type { MarkStage } from "../PipelineStages.types";
+import { MarkStageFactory, MarkStageFactoryOpts } from "../MarkStageFactory";
+import { StoredTargetMap } from "../..";
+
+export class ImplicitMarkStage implements MarkStage {
+  private cursorMarkStage: MarkStage;
+
+  constructor(
+    markStageFactory: MarkStageFactory,
+    private opts: MarkStageFactoryOpts,
+    private storedTargets: StoredTargetMap,
+  ) {
+    this.cursorMarkStage = markStageFactory.create(
+      { type: "cursor" },
+      { isForInstance: this.opts.isForInstance },
+    );
+  }
+
+  run(): Target[] {
+    if (this.opts.isForInstance) {
+      return this.cursorMarkStage.run();
+    }
+
+    return this.storedTargets.get("implicit") ?? this.cursorMarkStage.run();
+  }
+}

--- a/packages/cursorless-engine/src/processTargets/marks/RangeMarkStage.ts
+++ b/packages/cursorless-engine/src/processTargets/marks/RangeMarkStage.ts
@@ -1,18 +1,25 @@
 import { RangeMark } from "@cursorless/common";
 import { Target } from "../../typings/target.types";
-import { MarkStageFactory } from "../MarkStageFactory";
+import { MarkStageFactory, MarkStageFactoryOpts } from "../MarkStageFactory";
 import { MarkStage } from "../PipelineStages.types";
 import { targetsToContinuousTarget } from "../TargetPipelineRunner";
 
 export class RangeMarkStage implements MarkStage {
   constructor(
     private markStageFactory: MarkStageFactory,
+    private opts: MarkStageFactoryOpts,
     private mark: RangeMark,
   ) {}
 
   run(): Target[] {
-    const anchorStage = this.markStageFactory.create(this.mark.anchor);
-    const activeStage = this.markStageFactory.create(this.mark.active);
+    const anchorStage = this.markStageFactory.create(
+      this.mark.anchor,
+      this.opts,
+    );
+    const activeStage = this.markStageFactory.create(
+      this.mark.active,
+      this.opts,
+    );
     const anchorTargets = anchorStage.run();
     const activeTargets = activeStage.run();
 

--- a/packages/cursorless-engine/src/processTargets/marks/StoredTargetStage.ts
+++ b/packages/cursorless-engine/src/processTargets/marks/StoredTargetStage.ts
@@ -1,4 +1,5 @@
-import { StoredTargetKey, StoredTargetMap } from "../../core/StoredTargets";
+import { StoredTargetMap } from "../../core/StoredTargets";
+import { StoredTargetKey } from "@cursorless/common";
 import { Target } from "../../typings/target.types";
 import { MarkStage } from "../PipelineStages.types";
 

--- a/packages/cursorless-engine/src/processTargets/modifiers/InstanceStage.ts
+++ b/packages/cursorless-engine/src/processTargets/modifiers/InstanceStage.ts
@@ -75,9 +75,7 @@ export class InstanceStage implements ModifierStage {
     target: Target,
     { direction, offset, length }: RelativeScopeModifier,
   ): Target[] {
-    const referenceTargets = this.storedTargets.get("instanceReference") ?? [
-      target,
-    ];
+    const referenceTargets = this.getStoredTargets() ?? [target];
 
     return referenceTargets.flatMap((referenceTarget) => {
       const { editor } = referenceTarget;
@@ -104,14 +102,20 @@ export class InstanceStage implements ModifierStage {
     });
   }
 
+  private getStoredTargets() {
+    return (
+      this.storedTargets.get("instanceReference") ??
+      this.storedTargets.get("implicit")
+    );
+  }
+
   private getEveryRanges({
     editor: targetEditor,
   }: Target): readonly (readonly [TextEditor, Range])[] {
     return (
-      this.storedTargets
-        .get("instanceReference")
-        ?.map(({ editor, contentRange }) => [editor, contentRange] as const) ??
-      ([[targetEditor, targetEditor.document.range]] as const)
+      this.getStoredTargets()?.map(
+        ({ editor, contentRange }) => [editor, contentRange] as const,
+      ) ?? ([[targetEditor, targetEditor.document.range]] as const)
     );
   }
 

--- a/packages/cursorless-engine/src/testUtil/takeSnapshot.ts
+++ b/packages/cursorless-engine/src/testUtil/takeSnapshot.ts
@@ -11,7 +11,8 @@ import {
   TestCaseSnapshot,
   TextEditor,
 } from "@cursorless/common";
-import type { StoredTargetMap } from "../core/StoredTargets";
+import { type StoredTargetMap } from "../core/StoredTargets";
+import { storedTargetKeys } from "@cursorless/common";
 
 export async function takeSnapshot(
   storedTargets: StoredTargetMap | undefined,
@@ -45,26 +46,12 @@ export async function takeSnapshot(
     snapshot.visibleRanges = editor.visibleRanges.map(rangeToPlainObject);
   }
 
-  const thatMarkTargets = storedTargets?.get("that");
-  if (thatMarkTargets != null && !excludeFields.includes("thatMark")) {
-    snapshot.thatMark = thatMarkTargets.map((target) => target.toPlainObject());
-  }
-
-  const sourceMarkTargets = storedTargets?.get("source");
-  if (sourceMarkTargets != null && !excludeFields.includes("sourceMark")) {
-    snapshot.sourceMark = sourceMarkTargets.map((target) =>
-      target.toPlainObject(),
-    );
-  }
-
-  const instanceReferenceMarkTargets = storedTargets?.get("instanceReference");
-  if (
-    instanceReferenceMarkTargets != null &&
-    !excludeFields.includes("instanceReferenceMark")
-  ) {
-    snapshot.instanceReferenceMark = instanceReferenceMarkTargets.map(
-      (target) => target.toPlainObject(),
-    );
+  for (const storedTargetKey of storedTargetKeys) {
+    const targets = storedTargets?.get(storedTargetKey);
+    const key = `${storedTargetKey}Mark` as const;
+    if (targets != null && !excludeFields.includes(key)) {
+      snapshot[key] = targets.map((target) => target.toPlainObject());
+    }
   }
 
   if (extraFields.includes("timeOffsetSeconds")) {

--- a/packages/cursorless-engine/src/typings/TargetDescriptor.ts
+++ b/packages/cursorless-engine/src/typings/TargetDescriptor.ts
@@ -6,7 +6,11 @@ import {
   ScopeType,
 } from "@cursorless/common";
 
-export type Mark = PartialMark | TargetMark;
+export interface ImplicitMark {
+  type: "implicit";
+}
+
+export type Mark = PartialMark | TargetMark | ImplicitMark;
 
 export interface PrimitiveTargetDescriptor {
   type: "primitive";

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/actions/activeLine.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/actions/activeLine.yml
@@ -1,0 +1,41 @@
+languageId: plaintext
+command:
+  version: 6
+  spokenForm: implicit line
+  action:
+    name: private.setImplicitTarget
+    target:
+      type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: line}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    aaa bbb aaa
+    aaa
+  selections:
+    - anchor: {line: 0, character: 3}
+      active: {line: 0, character: 3}
+  marks: {}
+finalState:
+  documentContents: |-
+    aaa bbb aaa
+    aaa
+  selections:
+    - anchor: {line: 0, character: 3}
+      active: {line: 0, character: 3}
+  thatMark:
+    - type: LineTarget
+      contentRange:
+        start: {line: 0, character: 0}
+        end: {line: 0, character: 11}
+      isReversed: false
+      hasExplicitRange: true
+  implicitMark:
+    - type: LineTarget
+      contentRange:
+        start: {line: 0, character: 0}
+        end: {line: 0, character: 11}
+      isReversed: false
+      hasExplicitRange: true

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/actions/activeThis.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/actions/activeThis.yml
@@ -1,0 +1,35 @@
+languageId: plaintext
+command:
+  version: 6
+  spokenForm: implicit this
+  action:
+    name: private.setImplicitTarget
+    target:
+      type: primitive
+      mark: {type: cursor}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: aaa bbb
+  selections:
+    - anchor: {line: 0, character: 7}
+      active: {line: 0, character: 7}
+  marks: {}
+finalState:
+  documentContents: aaa bbb
+  selections:
+    - anchor: {line: 0, character: 7}
+      active: {line: 0, character: 7}
+  thatMark:
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 7}
+        end: {line: 0, character: 7}
+      isReversed: false
+      hasExplicitRange: false
+  implicitMark:
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 7}
+        end: {line: 0, character: 7}
+      isReversed: false
+      hasExplicitRange: false

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/actions/changeNextInstanceChar.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/actions/changeNextInstanceChar.yml
@@ -1,0 +1,42 @@
+languageId: plaintext
+command:
+  version: 6
+  spokenForm: change next instance char
+  action:
+    name: clearAndSetSelection
+    target:
+      type: primitive
+      modifiers:
+        - type: relativeScope
+          scopeType: {type: instance}
+          offset: 1
+          length: 1
+          direction: forward
+        - type: containingScope
+          scopeType: {type: character}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: aba aaa
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  marks: {}
+  instanceReferenceMark:
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 0}
+        end: {line: 0, character: 0}
+      isReversed: false
+      hasExplicitRange: false
+finalState:
+  documentContents: ba aaa
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  thatMark:
+    - type: RawSelectionTarget
+      contentRange:
+        start: {line: 0, character: 0}
+        end: {line: 0, character: 0}
+      isReversed: false
+      hasExplicitRange: true

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/actions/changePreviousChar.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/actions/changePreviousChar.yml
@@ -1,0 +1,40 @@
+languageId: plaintext
+command:
+  version: 6
+  spokenForm: change previous char
+  action:
+    name: clearAndSetSelection
+    target:
+      type: primitive
+      modifiers:
+        - type: relativeScope
+          scopeType: {type: character}
+          offset: 1
+          length: 1
+          direction: backward
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: aaa bbb
+  selections:
+    - anchor: {line: 0, character: 7}
+      active: {line: 0, character: 7}
+  marks: {}
+  implicitMark:
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 7}
+        end: {line: 0, character: 7}
+      isReversed: false
+      hasExplicitRange: false
+finalState:
+  documentContents: aaa bb
+  selections:
+    - anchor: {line: 0, character: 5}
+      active: {line: 0, character: 5}
+  thatMark:
+    - type: RawSelectionTarget
+      contentRange:
+        start: {line: 0, character: 5}
+        end: {line: 0, character: 5}
+      isReversed: false
+      hasExplicitRange: true

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/actions/fromThis.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/actions/fromThis.yml
@@ -1,0 +1,35 @@
+languageId: plaintext
+command:
+  version: 6
+  spokenForm: from this
+  action:
+    name: experimental.setInstanceReference
+    target:
+      type: primitive
+      mark: {type: cursor}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: aba aaa
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  marks: {}
+finalState:
+  documentContents: aba aaa
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  thatMark:
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 0}
+        end: {line: 0, character: 0}
+      isReversed: false
+      hasExplicitRange: false
+  instanceReferenceMark:
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 0}
+        end: {line: 0, character: 0}
+      isReversed: false
+      hasExplicitRange: false

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/marks/swapTokenWithNextToken.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/marks/swapTokenWithNextToken.yml
@@ -1,0 +1,40 @@
+languageId: plaintext
+command:
+  version: 6
+  spokenForm: swap token with next token
+  action:
+    name: swapTargets
+    target1:
+      type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: token}
+    target2:
+      type: primitive
+      modifiers:
+        - type: relativeScope
+          scopeType: {type: token}
+          offset: 1
+          length: 1
+          direction: forward
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |
+    aaa bbb ccc
+  selections:
+    - anchor: {line: 1, character: 0}
+      active: {line: 1, character: 0}
+  marks: {}
+  implicitMark:
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 0}
+        end: {line: 0, character: 3}
+      isReversed: false
+      hasExplicitRange: false
+finalState:
+  documentContents: |
+    bbb aaa ccc
+  selections:
+    - anchor: {line: 1, character: 0}
+      active: {line: 1, character: 0}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/modifiers/instance/changeEveryInstance.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/modifiers/instance/changeEveryInstance.yml
@@ -1,0 +1,36 @@
+languageId: plaintext
+command:
+  version: 6
+  spokenForm: change every instance
+  action:
+    name: clearAndSetSelection
+    target:
+      type: primitive
+      modifiers:
+        - type: everyScope
+          scopeType: {type: instance}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    aaa bbb aaa
+    aaa
+  selections:
+    - anchor: {line: 0, character: 3}
+      active: {line: 0, character: 3}
+  marks: {}
+  implicitMark:
+    - type: LineTarget
+      contentRange:
+        start: {line: 0, character: 0}
+        end: {line: 0, character: 11}
+      isReversed: false
+      hasExplicitRange: true
+finalState:
+  documentContents: |2-
+     bbb 
+    aaa
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+    - anchor: {line: 0, character: 5}
+      active: {line: 0, character: 5}

--- a/packages/cursorless-vscode-e2e/src/suite/keyboard/basic.vscode.test.ts
+++ b/packages/cursorless-vscode-e2e/src/suite/keyboard/basic.vscode.test.ts
@@ -32,6 +32,20 @@ const testCases: TestCase[] = [
     keySequence: "da;x;st;c",
     finalContent: "b b",
   },
+  {
+    name: "three",
+    initialContent: "a b c d e\n",
+    // change three tokens bat
+    keySequence: "db;3;st;c",
+    finalContent: "a  e",
+  },
+  {
+    name: "three backwards",
+    initialContent: "a b c d e\n",
+    // change three tokens backwards drum
+    keySequence: "dd;-3;st;c",
+    finalContent: "a  e",
+  },
 ];
 
 suite("Basic keyboard test", async function () {

--- a/packages/cursorless-vscode-e2e/src/suite/keyboard/basic.vscode.test.ts
+++ b/packages/cursorless-vscode-e2e/src/suite/keyboard/basic.vscode.test.ts
@@ -46,6 +46,20 @@ const testCases: TestCase[] = [
     keySequence: "dd;-3;st;c",
     finalContent: "a  e",
   },
+  {
+    name: "pair parens",
+    initialContent: "a + (b + c) + d",
+    // change parens bat
+    keySequence: "db;wp;c",
+    finalContent: "a +  + d",
+  },
+  {
+    name: "pair string",
+    initialContent: 'a + "w" + b',
+    // change parens bat
+    keySequence: "dw;wj;c",
+    finalContent: "a +  + b",
+  },
 ];
 
 suite("Basic keyboard test", async function () {

--- a/packages/cursorless-vscode-e2e/src/suite/keyboard/basic.vscode.test.ts
+++ b/packages/cursorless-vscode-e2e/src/suite/keyboard/basic.vscode.test.ts
@@ -21,8 +21,16 @@ const testCases: TestCase[] = [
   {
     name: "and",
     initialContent: "x T y\n",
+    // change plex and yank
     keySequence: "dx;fa;dy;c",
     finalContent: "T",
+  },
+  {
+    name: "every",
+    initialContent: "a a\nb b\n",
+    // change every token air
+    keySequence: "da;x;st;c",
+    finalContent: "b b",
   },
 ];
 
@@ -99,7 +107,7 @@ async function sequence(t: TestCase) {
   await hatTokenMap.allocateHats();
   editor.selection = new vscode.Selection(1, 0, 1, 0);
   await vscode.commands.executeCommand("cursorless.keyboard.modal.modeOn");
-  await typeText(t.keySequence.replace(/;/, ""));
+  await typeText(t.keySequence.replaceAll(";", ""));
   assert.equal(editor.document.getText().trim(), t.finalContent);
 }
 

--- a/packages/cursorless-vscode-e2e/src/suite/keyboard/basic.vscode.test.ts
+++ b/packages/cursorless-vscode-e2e/src/suite/keyboard/basic.vscode.test.ts
@@ -60,6 +60,13 @@ const testCases: TestCase[] = [
     keySequence: "dw;wj;c",
     finalContent: "a +  + b",
   },
+  {
+    name: "wrap",
+    initialContent: "a",
+    // round wrap air
+    keySequence: "da;aw;wp",
+    finalContent: "(a)",
+  },
 ];
 
 suite("Basic keyboard test", async function () {

--- a/packages/cursorless-vscode-e2e/src/suite/recorded.vscode.test.ts
+++ b/packages/cursorless-vscode-e2e/src/suite/recorded.vscode.test.ts
@@ -18,6 +18,7 @@ import {
   splitKey,
   SpyIDE,
   spyIDERecordedValuesToPlainObject,
+  storedTargetKeys,
   TestCaseFixtureLegacy,
   TextEditor,
   TokenHat,
@@ -89,15 +90,10 @@ async function runTest(file: string, spyIde: SpyIDE) {
 
   editor.selections = fixture.initialState.selections.map(createSelection);
 
-  setStoredTarget(editor, "that", fixture.initialState.thatMark);
-
-  setStoredTarget(editor, "source", fixture.initialState.sourceMark);
-
-  setStoredTarget(
-    editor,
-    "instanceReference",
-    fixture.initialState.instanceReferenceMark,
-  );
+  for (const storedTargetKey of storedTargetKeys) {
+    const key = `${storedTargetKey}Mark` as const;
+    setStoredTarget(editor, storedTargetKey, fixture.initialState[key]);
+  }
 
   if (fixture.initialState.clipboard) {
     vscode.env.clipboard.writeText(fixture.initialState.clipboard);
@@ -162,16 +158,11 @@ async function runTest(file: string, spyIde: SpyIDE) {
     excludeFields.push("clipboard");
   }
 
-  if (fixture.finalState?.thatMark == null) {
-    excludeFields.push("thatMark");
-  }
-
-  if (fixture.finalState?.sourceMark == null) {
-    excludeFields.push("sourceMark");
-  }
-
-  if (fixture.finalState?.instanceReferenceMark == null) {
-    excludeFields.push("instanceReferenceMark");
+  for (const storedTargetKey of storedTargetKeys) {
+    const key = `${storedTargetKey}Mark` as const;
+    if (fixture.finalState?.[key] == null) {
+      excludeFields.push(key);
+    }
   }
 
   // FIXME Visible ranges are not asserted, see:

--- a/packages/cursorless-vscode/src/constructTestHelpers.ts
+++ b/packages/cursorless-vscode/src/constructTestHelpers.ts
@@ -7,12 +7,12 @@ import {
   NormalizedIDE,
   ScopeProvider,
   SerializedMarks,
+  StoredTargetKey,
   TargetPlainObject,
   TestCaseSnapshot,
   TextEditor,
 } from "@cursorless/common";
 import {
-  StoredTargetKey,
   StoredTargetMap,
   plainObjectToTarget,
   takeSnapshot,

--- a/packages/cursorless-vscode/src/extension.ts
+++ b/packages/cursorless-vscode/src/extension.ts
@@ -49,6 +49,7 @@ import { StatusBarItem } from "./StatusBarItem";
 import { vscodeApi } from "./vscodeApi";
 import { mkdir } from "fs/promises";
 import { TestCaseRecorder } from "@cursorless/cursorless-engine";
+import { storedTargetHighlighter } from "./storedTargetHighlighter";
 
 /**
  * Extension entrypoint called by VSCode on Cursorless startup.
@@ -121,6 +122,8 @@ export async function activate(
     customSpokenFormGenerator,
     commandServerApi != null,
   );
+
+  context.subscriptions.push(storedTargetHighlighter(vscodeIDE, storedTargets));
 
   registerCommands(
     context,

--- a/packages/cursorless-vscode/src/keyboard/KeyboardCommandHandler.ts
+++ b/packages/cursorless-vscode/src/keyboard/KeyboardCommandHandler.ts
@@ -106,6 +106,19 @@ export class KeyboardCommandHandler {
       scopeType,
     });
   }
+
+  targetRelativeInclusiveScope({
+    offset,
+    scopeType,
+  }: TargetRelativeInclusiveScopeArg) {
+    this.targeted.targetModifier({
+      type: "relativeScope",
+      offset: 0,
+      direction: offset?.direction ?? "forward",
+      length: offset?.number ?? 1,
+      scopeType,
+    });
+  }
 }
 
 interface DecoratedMarkArg {
@@ -117,6 +130,10 @@ interface DecoratedMarkArg {
 interface TargetRelativeExclusiveScopeArg {
   offset: Offset;
   length: number | null;
+  scopeType: ScopeType;
+}
+interface TargetRelativeInclusiveScopeArg {
+  offset: Offset;
   scopeType: ScopeType;
 }
 

--- a/packages/cursorless-vscode/src/keyboard/KeyboardCommandHandler.ts
+++ b/packages/cursorless-vscode/src/keyboard/KeyboardCommandHandler.ts
@@ -89,6 +89,10 @@ export class KeyboardCommandHandler {
     this.targeted.modifyTargetContainingScope(arg);
   }
 
+  targetEveryScopeType(arg: { scopeType: ScopeType }) {
+    this.targeted.modifyTargetContainingScope({ ...arg, type: "everyScope" });
+  }
+
   targetRelativeExclusiveScope({
     offset,
     length,

--- a/packages/cursorless-vscode/src/keyboard/KeyboardCommandHandler.ts
+++ b/packages/cursorless-vscode/src/keyboard/KeyboardCommandHandler.ts
@@ -1,9 +1,10 @@
-import { ScopeType } from "@cursorless/common";
+import { ScopeType, SurroundingPairName } from "@cursorless/common";
 import * as vscode from "vscode";
 import { HatColor, HatShape } from "../ide/vscode/hatStyles.types";
 import { SimpleKeyboardActionType } from "./KeyboardActionType";
 import KeyboardCommandsTargeted from "./KeyboardCommandsTargeted";
 import { ModalVscodeCommandDescriptor } from "./TokenTypes";
+import { surroundingPairsDelimiters } from "@cursorless/cursorless-engine";
 
 /**
  * This class defines the keyboard commands available to our modal keyboard
@@ -82,11 +83,20 @@ export class KeyboardCommandHandler {
   }: {
     actionName: SimpleKeyboardActionType;
   }) {
-    this.targeted.performActionOnTarget(actionName);
+    this.targeted.performSimpleActionOnTarget(actionName);
   }
 
   modifyTargetContainingScope(arg: { scopeType: ScopeType }) {
     this.targeted.modifyTargetContainingScope(arg);
+  }
+  performWrapActionOnTarget({ delimiter }: { delimiter: SurroundingPairName }) {
+    const [left, right] = surroundingPairsDelimiters[delimiter]!;
+    this.targeted.performActionOnTarget((target) => ({
+      name: "wrapWithPairedDelimiter",
+      target,
+      left,
+      right,
+    }));
   }
 
   targetEveryScopeType(arg: { scopeType: ScopeType }) {

--- a/packages/cursorless-vscode/src/keyboard/KeyboardCommandHandler.ts
+++ b/packages/cursorless-vscode/src/keyboard/KeyboardCommandHandler.ts
@@ -38,6 +38,13 @@ export class KeyboardCommandHandler {
     });
   }
 
+  targetDecoratedMarkAppend({ decoratedMark }: DecoratedMarkArg) {
+    this.targeted.targetDecoratedMark({
+      ...decoratedMark,
+      mode: "append",
+    });
+  }
+
   async vscodeCommand({
     command: commandInfo,
   }: {

--- a/packages/cursorless-vscode/src/keyboard/KeyboardCommandsTargeted.ts
+++ b/packages/cursorless-vscode/src/keyboard/KeyboardCommandsTargeted.ts
@@ -170,17 +170,6 @@ export default class KeyboardCommandsTargeted {
       },
     });
 
-  private highlightTarget = () =>
-    executeCursorlessCommand({
-      name: "highlight",
-      target: {
-        type: "primitive",
-        mark: {
-          type: "that",
-        },
-      },
-    });
-
   /**
    * Performs action {@link name} on the current target
    * @param name The action to run
@@ -259,8 +248,6 @@ export default class KeyboardCommandsTargeted {
     });
     const returnValue = await executeCursorlessCommand(action);
 
-    await this.highlightTarget();
-
     if (EXIT_CURSORLESS_MODE_ACTIONS.includes(action.name)) {
       // For some Cursorless actions, it is more convenient if we automatically
       // exit modal mode
@@ -304,8 +291,6 @@ export default class KeyboardCommandsTargeted {
         commandArgs: args,
       },
     });
-
-    await this.highlightTarget();
 
     if (exitCursorlessMode) {
       // For some Cursorless actions, it is more convenient if we automatically

--- a/packages/cursorless-vscode/src/keyboard/TokenTypes.ts
+++ b/packages/cursorless-vscode/src/keyboard/TokenTypes.ts
@@ -18,7 +18,7 @@ export interface SectionTypes {
   vscodeCommand: ModalVscodeCommandDescriptor;
   modifier: ModifierType;
 }
-type ModifierType = "nextPrev";
+type ModifierType = "nextPrev" | "every";
 type MiscValue =
   | "combineColorAndShape"
   | "makeRange"
@@ -60,6 +60,7 @@ export interface TokenTypeValueMap {
 
   // modifier config section
   nextPrev: "nextPrev";
+  every: "every";
 
   digit: number;
 }

--- a/packages/cursorless-vscode/src/keyboard/TokenTypes.ts
+++ b/packages/cursorless-vscode/src/keyboard/TokenTypes.ts
@@ -25,7 +25,8 @@ type MiscValue =
   | "makeRange"
   | "makeList"
   | "forward"
-  | "backward";
+  | "backward"
+  | "wrap"; // TODO: move wrap somewhere out of misc
 
 /**
  * Maps from token type used in parser to the type of values that the token type
@@ -53,6 +54,7 @@ export interface TokenTypeValueMap {
 
   // action config section
   simpleAction: SimpleKeyboardActionType;
+  wrap: "wrap";
 
   // misc config section
   makeRange: "makeRange";

--- a/packages/cursorless-vscode/src/keyboard/TokenTypes.ts
+++ b/packages/cursorless-vscode/src/keyboard/TokenTypes.ts
@@ -1,4 +1,4 @@
-import { SimpleScopeTypeType } from "@cursorless/common";
+import { SimpleScopeTypeType, SurroundingPairName } from "@cursorless/common";
 import { HatColor, HatShape } from "../ide/vscode/hatStyles.types";
 import {
   KeyboardActionType,
@@ -14,6 +14,7 @@ export interface SectionTypes {
   color: HatColor;
   misc: MiscValue;
   scope: SimpleScopeTypeType;
+  pairedDelimiter: SurroundingPairName;
   shape: HatShape;
   vscodeCommand: ModalVscodeCommandDescriptor;
   modifier: ModifierType;
@@ -48,6 +49,7 @@ export interface TokenTypeValueMap {
   color: HatColor;
   shape: HatShape;
   vscodeCommand: ModalVscodeCommandDescriptor;
+  pairedDelimiter: SurroundingPairName;
 
   // action config section
   simpleAction: SimpleKeyboardActionType;

--- a/packages/cursorless-vscode/src/keyboard/TokenTypes.ts
+++ b/packages/cursorless-vscode/src/keyboard/TokenTypes.ts
@@ -54,6 +54,7 @@ export interface TokenTypeValueMap {
 
   // misc config section
   makeRange: "makeRange";
+  makeList: "makeList";
   combineColorAndShape: "combineColorAndShape";
   direction: "forward" | "backward";
 

--- a/packages/cursorless-vscode/src/keyboard/getTokenTypeKeyMaps.ts
+++ b/packages/cursorless-vscode/src/keyboard/getTokenTypeKeyMaps.ts
@@ -36,6 +36,7 @@ export function getTokenTypeKeyMaps(
     color: config.getTokenKeyMap("color"),
     shape: config.getTokenKeyMap("shape"),
     vscodeCommand: config.getTokenKeyMap("vscodeCommand"),
+    pairedDelimiter: config.getTokenKeyMap("pairedDelimiter"),
 
     // action config section
     simpleAction: config.getTokenKeyMap(

--- a/packages/cursorless-vscode/src/keyboard/getTokenTypeKeyMaps.ts
+++ b/packages/cursorless-vscode/src/keyboard/getTokenTypeKeyMaps.ts
@@ -44,6 +44,7 @@ export function getTokenTypeKeyMaps(
       "action",
       simpleKeyboardActionNames,
     ),
+    wrap: config.getTokenKeyMap("wrap", "misc", ["wrap"]),
 
     // misc config section
     makeRange: config.getTokenKeyMap("makeRange", "misc", ["makeRange"]),

--- a/packages/cursorless-vscode/src/keyboard/getTokenTypeKeyMaps.ts
+++ b/packages/cursorless-vscode/src/keyboard/getTokenTypeKeyMaps.ts
@@ -58,6 +58,7 @@ export function getTokenTypeKeyMaps(
     ]),
 
     // modifier config section
+    every: config.getTokenKeyMap("every", "modifier", ["every"]),
     nextPrev: config.getTokenKeyMap("nextPrev", "modifier", ["nextPrev"]),
 
     digit: Object.fromEntries(

--- a/packages/cursorless-vscode/src/keyboard/getTokenTypeKeyMaps.ts
+++ b/packages/cursorless-vscode/src/keyboard/getTokenTypeKeyMaps.ts
@@ -46,6 +46,7 @@ export function getTokenTypeKeyMaps(
 
     // misc config section
     makeRange: config.getTokenKeyMap("makeRange", "misc", ["makeRange"]),
+    makeList: config.getTokenKeyMap("makeList", "misc", ["makeList"]),
     combineColorAndShape: config.getTokenKeyMap(
       "combineColorAndShape",
       "misc",

--- a/packages/cursorless-vscode/src/keyboard/grammar/generated/grammar.ts
+++ b/packages/cursorless-vscode/src/keyboard/grammar/generated/grammar.ts
@@ -4,6 +4,7 @@
 // @ts-ignore
 function id(d: any[]): any { return d[0]; }
 declare var makeRange: any;
+declare var makeList: any;
 declare var nextPrev: any;
 declare var simpleAction: any;
 declare var vscodeCommand: any;
@@ -50,6 +51,9 @@ const grammar: Grammar = {
     {"name": "main", "symbols": ["decoratedMark"], "postprocess": command("targetDecoratedMarkReplace", ["decoratedMark"])},
     {"name": "main", "symbols": [(keyboardLexer.has("makeRange") ? {type: "makeRange"} : makeRange), "decoratedMark"], "postprocess": 
         command("targetDecoratedMarkExtend", [_, "decoratedMark"])
+        },
+    {"name": "main", "symbols": [(keyboardLexer.has("makeList") ? {type: "makeList"} : makeList), "decoratedMark"], "postprocess": 
+        command("targetDecoratedMarkAppend", [_, "decoratedMark"])
         },
     {"name": "main", "symbols": ["scopeType"], "postprocess": command("modifyTargetContainingScope", ["scopeType"])},
     {"name": "main$ebnf$1", "symbols": ["offset"], "postprocess": id},

--- a/packages/cursorless-vscode/src/keyboard/grammar/generated/grammar.ts
+++ b/packages/cursorless-vscode/src/keyboard/grammar/generated/grammar.ts
@@ -10,6 +10,7 @@ declare var nextPrev: any;
 declare var simpleAction: any;
 declare var vscodeCommand: any;
 declare var simpleScopeTypeType: any;
+declare var pairedDelimiter: any;
 declare var color: any;
 declare var shape: any;
 declare var combineColorAndShape: any;
@@ -74,6 +75,9 @@ const grammar: Grammar = {
     {"name": "main", "symbols": [(keyboardLexer.has("simpleAction") ? {type: "simpleAction"} : simpleAction)], "postprocess": command("performSimpleActionOnTarget", ["actionName"])},
     {"name": "main", "symbols": [(keyboardLexer.has("vscodeCommand") ? {type: "vscodeCommand"} : vscodeCommand)], "postprocess": command("vscodeCommand", ["command"])},
     {"name": "scopeType", "symbols": [(keyboardLexer.has("simpleScopeTypeType") ? {type: "simpleScopeTypeType"} : simpleScopeTypeType)], "postprocess": capture("type")},
+    {"name": "scopeType", "symbols": [(keyboardLexer.has("pairedDelimiter") ? {type: "pairedDelimiter"} : pairedDelimiter)], "postprocess": 
+        ([delimiter]) => ({ type: "surroundingPair", delimiter })
+        },
     {"name": "decoratedMark", "symbols": [(keyboardLexer.has("color") ? {type: "color"} : color)], "postprocess": capture("color")},
     {"name": "decoratedMark", "symbols": [(keyboardLexer.has("shape") ? {type: "shape"} : shape)], "postprocess": capture("shape")},
     {"name": "decoratedMark", "symbols": [(keyboardLexer.has("combineColorAndShape") ? {type: "combineColorAndShape"} : combineColorAndShape), (keyboardLexer.has("color") ? {type: "color"} : color), (keyboardLexer.has("shape") ? {type: "shape"} : shape)], "postprocess": capture(_, "color", "shape")},

--- a/packages/cursorless-vscode/src/keyboard/grammar/generated/grammar.ts
+++ b/packages/cursorless-vscode/src/keyboard/grammar/generated/grammar.ts
@@ -8,9 +8,10 @@ declare var makeList: any;
 declare var every: any;
 declare var nextPrev: any;
 declare var simpleAction: any;
+declare var wrap: any;
+declare var pairedDelimiter: any;
 declare var vscodeCommand: any;
 declare var simpleScopeTypeType: any;
-declare var pairedDelimiter: any;
 declare var color: any;
 declare var shape: any;
 declare var combineColorAndShape: any;
@@ -73,6 +74,9 @@ const grammar: Grammar = {
         command("targetRelativeInclusiveScope", ["offset", "scopeType"])
         },
     {"name": "main", "symbols": [(keyboardLexer.has("simpleAction") ? {type: "simpleAction"} : simpleAction)], "postprocess": command("performSimpleActionOnTarget", ["actionName"])},
+    {"name": "main", "symbols": [(keyboardLexer.has("wrap") ? {type: "wrap"} : wrap), (keyboardLexer.has("pairedDelimiter") ? {type: "pairedDelimiter"} : pairedDelimiter)], "postprocess": 
+        command("performWrapActionOnTarget", [_, "delimiter"])
+        },
     {"name": "main", "symbols": [(keyboardLexer.has("vscodeCommand") ? {type: "vscodeCommand"} : vscodeCommand)], "postprocess": command("vscodeCommand", ["command"])},
     {"name": "scopeType", "symbols": [(keyboardLexer.has("simpleScopeTypeType") ? {type: "simpleScopeTypeType"} : simpleScopeTypeType)], "postprocess": capture("type")},
     {"name": "scopeType", "symbols": [(keyboardLexer.has("pairedDelimiter") ? {type: "pairedDelimiter"} : pairedDelimiter)], "postprocess": 

--- a/packages/cursorless-vscode/src/keyboard/grammar/generated/grammar.ts
+++ b/packages/cursorless-vscode/src/keyboard/grammar/generated/grammar.ts
@@ -68,6 +68,9 @@ const grammar: Grammar = {
           ["offset", _, "length", "scopeType"],
         )
         },
+    {"name": "main", "symbols": ["offset", "scopeType"], "postprocess": 
+        command("targetRelativeInclusiveScope", ["offset", "scopeType"])
+        },
     {"name": "main", "symbols": [(keyboardLexer.has("simpleAction") ? {type: "simpleAction"} : simpleAction)], "postprocess": command("performSimpleActionOnTarget", ["actionName"])},
     {"name": "main", "symbols": [(keyboardLexer.has("vscodeCommand") ? {type: "vscodeCommand"} : vscodeCommand)], "postprocess": command("vscodeCommand", ["command"])},
     {"name": "scopeType", "symbols": [(keyboardLexer.has("simpleScopeTypeType") ? {type: "simpleScopeTypeType"} : simpleScopeTypeType)], "postprocess": capture("type")},

--- a/packages/cursorless-vscode/src/keyboard/grammar/generated/grammar.ts
+++ b/packages/cursorless-vscode/src/keyboard/grammar/generated/grammar.ts
@@ -5,6 +5,7 @@
 function id(d: any[]): any { return d[0]; }
 declare var makeRange: any;
 declare var makeList: any;
+declare var every: any;
 declare var nextPrev: any;
 declare var simpleAction: any;
 declare var vscodeCommand: any;
@@ -56,6 +57,7 @@ const grammar: Grammar = {
         command("targetDecoratedMarkAppend", [_, "decoratedMark"])
         },
     {"name": "main", "symbols": ["scopeType"], "postprocess": command("modifyTargetContainingScope", ["scopeType"])},
+    {"name": "main", "symbols": [(keyboardLexer.has("every") ? {type: "every"} : every), "scopeType"], "postprocess": command("targetEveryScopeType", [_, "scopeType"])},
     {"name": "main$ebnf$1", "symbols": ["offset"], "postprocess": id},
     {"name": "main$ebnf$1", "symbols": [], "postprocess": () => null},
     {"name": "main$ebnf$2", "symbols": ["number"], "postprocess": id},

--- a/packages/cursorless-vscode/src/keyboard/grammar/grammar.ne
+++ b/packages/cursorless-vscode/src/keyboard/grammar/grammar.ne
@@ -47,6 +47,9 @@ main -> %vscodeCommand {% command("vscodeCommand", ["command"]) %}
 
 # ========================== Captures =========================
 scopeType -> %simpleScopeTypeType {% capture("type") %}
+scopeType -> %pairedDelimiter {%
+  ([delimiter]) => ({ type: "surroundingPair", delimiter })
+%}
 
 decoratedMark ->
     %color {% capture("color") %}

--- a/packages/cursorless-vscode/src/keyboard/grammar/grammar.ne
+++ b/packages/cursorless-vscode/src/keyboard/grammar/grammar.ne
@@ -14,6 +14,11 @@ main -> %makeRange decoratedMark {%
   command("targetDecoratedMarkExtend", [_, "decoratedMark"])
 %}
 
+# "and air"
+main -> %makeList decoratedMark {%
+  command("targetDecoratedMarkAppend", [_, "decoratedMark"])
+%}
+
 # "funk"
 main -> scopeType {% command("modifyTargetContainingScope", ["scopeType"]) %}
 

--- a/packages/cursorless-vscode/src/keyboard/grammar/grammar.ne
+++ b/packages/cursorless-vscode/src/keyboard/grammar/grammar.ne
@@ -34,6 +34,11 @@ main -> offset:? %nextPrev number:? scopeType {%
   )
 %}
 
+# "three funks [backward]"
+main -> offset scopeType {%
+  command("targetRelativeInclusiveScope", ["offset", "scopeType"])
+%}
+
 # "chuck"
 main -> %simpleAction {% command("performSimpleActionOnTarget", ["actionName"]) %}
 

--- a/packages/cursorless-vscode/src/keyboard/grammar/grammar.ne
+++ b/packages/cursorless-vscode/src/keyboard/grammar/grammar.ne
@@ -22,6 +22,9 @@ main -> %makeList decoratedMark {%
 # "funk"
 main -> scopeType {% command("modifyTargetContainingScope", ["scopeType"]) %}
 
+# "every funk"
+main -> %every scopeType {% command("targetEveryScopeType", [_, "scopeType"]) %}
+
 # "[third] next [two] funks"
 # "[third] previous [two] funks"
 main -> offset:? %nextPrev number:? scopeType {%

--- a/packages/cursorless-vscode/src/keyboard/grammar/grammar.ne
+++ b/packages/cursorless-vscode/src/keyboard/grammar/grammar.ne
@@ -42,6 +42,11 @@ main -> offset scopeType {%
 # "chuck"
 main -> %simpleAction {% command("performSimpleActionOnTarget", ["actionName"]) %}
 
+# "round wrap"
+main -> %wrap %pairedDelimiter {%
+  command("performWrapActionOnTarget", [_, "delimiter"])
+%}
+
 # Custom vscode command
 main -> %vscodeCommand {% command("vscodeCommand", ["command"]) %}
 

--- a/packages/cursorless-vscode/src/keyboard/keyboard-config.fixture.json
+++ b/packages/cursorless-vscode/src/keyboard/keyboard-config.fixture.json
@@ -79,5 +79,21 @@
       "keepChangedSelection": true,
       "exitCursorlessMode": true
     }
+  },
+  "cursorless.experimental.keyboard.modal.keybindings.pairedDelimiter": {
+    "wl": "angleBrackets",
+    "wt": "backtickQuotes",
+    "wb": "curlyBrackets",
+    "wd": "doubleQuotes",
+    "wwd": "escapedDoubleQuotes",
+    "wwp": "escapedParentheses",
+    "wws": "escapedSquareBrackets",
+    "wwq": "escapedSingleQuotes",
+    "wp": "parentheses",
+    "wq": "singleQuotes",
+    "ws": "squareBrackets",
+    "wg": "string",
+    "wj": "any",
+    "wk": "collectionBoundary"
   }
 }

--- a/packages/cursorless-vscode/src/keyboard/keyboard-config.fixture.json
+++ b/packages/cursorless-vscode/src/keyboard/keyboard-config.fixture.json
@@ -64,7 +64,8 @@
     "-": "backward"
   },
   "cursorless.experimental.keyboard.modal.keybindings.modifier": {
-    "n": "nextPrev"
+    "n": "nextPrev",
+    "x": "every"
   },
   "cursorless.experimental.keyboard.modal.keybindings.vscodeCommand": {
     "va": "editor.action.addCommentLine",

--- a/packages/cursorless-vscode/src/keyboard/keyboard-config.fixture.json
+++ b/packages/cursorless-vscode/src/keyboard/keyboard-config.fixture.json
@@ -61,7 +61,8 @@
     "fx": "combineColorAndShape",
     "fk": "makeRange",
     "fa": "makeList",
-    "-": "backward"
+    "-": "backward",
+    "aw": "wrap"
   },
   "cursorless.experimental.keyboard.modal.keybindings.modifier": {
     "n": "nextPrev",

--- a/packages/cursorless-vscode/src/keyboard/keyboard-config.fixture.json
+++ b/packages/cursorless-vscode/src/keyboard/keyboard-config.fixture.json
@@ -60,6 +60,7 @@
   "cursorless.experimental.keyboard.modal.keybindings.misc": {
     "fx": "combineColorAndShape",
     "fk": "makeRange",
+    "fa": "makeList",
     "-": "backward"
   },
   "cursorless.experimental.keyboard.modal.keybindings.modifier": {

--- a/packages/cursorless-vscode/src/storedTargetHighlighter.ts
+++ b/packages/cursorless-vscode/src/storedTargetHighlighter.ts
@@ -1,0 +1,75 @@
+import { StoredTargetKey, groupBy, toCharacterRange } from "@cursorless/common";
+import { StoredTargetMap } from "@cursorless/cursorless-engine";
+import {
+  ScopeRangeType,
+  ScopeVisualizerColorConfig,
+} from "@cursorless/vscode-common";
+import { VscodeIDE } from "./ide/vscode/VscodeIDE";
+import { VscodeFancyRangeHighlighter } from "./ide/vscode/VSCodeScopeVisualizer/VscodeFancyRangeHighlighter";
+import { getColorsFromConfig } from "./ide/vscode/VSCodeScopeVisualizer/getColorsFromConfig";
+import { mapValues } from "lodash";
+import { usingSetting } from "./usingSetting";
+
+const targetColorMap: Partial<Record<StoredTargetKey, ScopeRangeType>> = {
+  instanceReference: "domain",
+};
+
+/**
+ * Constructs the stored target highlighter and listens for changes to stored
+ * targets, highlighting them in the editor.
+ * @param ide The ide object
+ * @param storedTargets Keeps track of stored targets
+ * @returns A disposable that disposes of the stored target highlighter
+ */
+export function storedTargetHighlighter(
+  ide: VscodeIDE,
+  storedTargets: StoredTargetMap,
+) {
+  return usingSetting<ScopeVisualizerColorConfig>(
+    "cursorless.scopeVisualizer",
+    "colors",
+    (colorConfig) => {
+      const highlighters = mapValues(targetColorMap, (type) =>
+        type == null
+          ? undefined
+          : new VscodeFancyRangeHighlighter(
+              getColorsFromConfig(colorConfig, type),
+            ),
+      );
+
+      const storedTargetsDisposable = storedTargets.onStoredTargets(
+        (key, targets) => {
+          const highlighter = highlighters[key];
+
+          if (highlighter == null) {
+            return;
+          }
+
+          const editorRangeMap = groupBy(
+            targets ?? [],
+            ({ editor }) => editor.id,
+          );
+
+          ide.visibleTextEditors.forEach((editor) => {
+            highlighter.setRanges(
+              editor,
+              (editorRangeMap.get(editor.id) ?? []).map(({ contentRange }) =>
+                toCharacterRange(contentRange),
+              ),
+            );
+          });
+        },
+      );
+
+      return {
+        dispose: () => {
+          for (const highlighter of Object.values(highlighters)) {
+            highlighter?.dispose();
+          }
+
+          storedTargetsDisposable.dispose();
+        },
+      };
+    },
+  );
+}

--- a/packages/cursorless-vscode/src/storedTargetHighlighter.ts
+++ b/packages/cursorless-vscode/src/storedTargetHighlighter.ts
@@ -13,6 +13,7 @@ import { usingSetting } from "./usingSetting";
 const targetColorMap: Partial<Record<StoredTargetKey, ScopeRangeType>> = {
   implicit: "content",
   instanceReference: "domain",
+  keyboard: "content",
 };
 
 /**

--- a/packages/cursorless-vscode/src/storedTargetHighlighter.ts
+++ b/packages/cursorless-vscode/src/storedTargetHighlighter.ts
@@ -11,6 +11,7 @@ import { mapValues } from "lodash";
 import { usingSetting } from "./usingSetting";
 
 const targetColorMap: Partial<Record<StoredTargetKey, ScopeRangeType>> = {
+  implicit: "content",
   instanceReference: "domain",
 };
 

--- a/packages/cursorless-vscode/src/usingSetting.ts
+++ b/packages/cursorless-vscode/src/usingSetting.ts
@@ -1,0 +1,38 @@
+import { vscodeApi } from "./vscodeApi";
+import { Disposable } from "@cursorless/common";
+
+/**
+ * Watches for changes to a setting and calls a factory function whenever the
+ * setting changes, disposing of any disposables created by the factory. On the
+ * initial call, the factory function is called immediately.
+ *
+ * @param section The section of the setting
+ * @param setting The setting
+ * @param factory A function that takes the setting value and returns a disposable
+ * @returns A disposable that disposes of the setting listener and any disposables created by the factory
+ */
+export function usingSetting<T>(
+  section: string,
+  setting: string,
+  factory: (value: T) => Disposable,
+): Disposable {
+  const fullFactory = () =>
+    factory(vscodeApi.workspace.getConfiguration(section).get<T>(setting)!);
+
+  let disposable = fullFactory();
+  const configurationDisposable = vscodeApi.workspace.onDidChangeConfiguration(
+    ({ affectsConfiguration }) => {
+      if (affectsConfiguration(`${section}.${setting}`)) {
+        disposable.dispose();
+        disposable = fullFactory();
+      }
+    },
+  );
+
+  return {
+    dispose: () => {
+      disposable.dispose();
+      configurationDisposable.dispose();
+    },
+  };
+}


### PR DESCRIPTION
Replay of #2156, but it builds. And has tests.

- Highlight instanceReference
- Add `implicit` special target
- Add keyboard special target
- Add "and" support to keyboard
- add tests for "and"
- Add every keyboard interface
- add tests for keyboard every
- Add three funks to keyboard
- add tests for three funks
- Add paired delimiters to keyboard
- add tests for paired delimiters
- keyboard hacky attempt at pair wrap
- add pair wrap keyboard tests
- tweaks



## Checklist

- [x] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [-] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [-] I have not broken the cheatsheet
