### PR TITLE
Convert VscodeHatRendered to use vscode.workspace.fs

### DIFF
--- a/packages/cursorless-vscode/src/ide/vscode/hats/VscodeHatRenderer.ts
+++ b/packages/cursorless-vscode/src/ide/vscode/hats/VscodeHatRenderer.ts
@@ -24,7 +24,7 @@ import {
   defaultShapeAdjustments,
 } from "./shapeAdjustments";
 import { performPr1868ShapeUpdateInit } from "./performPr1868ShapeUpdateInit";
-import { TextDecoder } from 'util';
+import { TextDecoder } from "util";
 
 const CURSORLESS_HAT_SHAPES_SUFFIX = ".svg";
 
@@ -78,7 +78,7 @@ export default class VscodeHatRenderer {
   ) {
     extensionContext.subscriptions.push(this);
 
-    this.decoder = new TextDecoder('utf-8');
+    this.decoder = new TextDecoder("utf-8");
     this.recomputeDecorations = this.recomputeDecorations.bind(this);
 
     this.disposables.push(
@@ -136,10 +136,13 @@ export default class VscodeHatRenderer {
     if (hatsDir) {
       await this.updateShapeOverrides(hatsDir);
 
-      fs.access(hatsDir).then(() =>
-        this.hatsDirWatcherDisposable = watchDir(hatsDir, () =>
-          this.updateShapeOverrides(hatsDir),
-        ))
+      fs.access(hatsDir)
+        .then(
+          () =>
+            (this.hatsDirWatcherDisposable = watchDir(hatsDir, () =>
+              this.updateShapeOverrides(hatsDir),
+            )),
+        )
         .catch(() => console.error("cannot watch hatsDir " + hatsDir));
     } else {
       this.hatShapeOverrides = {};
@@ -154,8 +157,8 @@ export default class VscodeHatRenderer {
     for (const file of files) {
       const name = path.basename(file, CURSORLESS_HAT_SHAPES_SUFFIX);
       this.hatShapeOverrides[name] = vscode.Uri.from({
-        scheme: 'file',
-        path: file
+        scheme: "file",
+        path: file,
       });
     }
 
@@ -213,36 +216,42 @@ export default class VscodeHatRenderer {
     );
 
     const hatSvgMap = Object.fromEntries(
-      await Promise.all(HAT_SHAPES.map(async (shape) => {
-        const { sizeAdjustment = 0, verticalOffset = 0 } =
-          defaultShapeAdjustments[shape];
+      await Promise.all(
+        HAT_SHAPES.map(async (shape) => {
+          const { sizeAdjustment = 0, verticalOffset = 0 } =
+            defaultShapeAdjustments[shape];
 
-        const {
-          sizeAdjustment: userIndividualSizeAdjustment = 0,
-          verticalOffset: userIndividualVerticalOffset = 0,
-        } = userIndividualAdjustments[shape] ?? {};
+          const {
+            sizeAdjustment: userIndividualSizeAdjustment = 0,
+            verticalOffset: userIndividualVerticalOffset = 0,
+          } = userIndividualAdjustments[shape] ?? {};
 
-        const scaleFactor =
-          1 +
-          (sizeAdjustment + userSizeAdjustment + userIndividualSizeAdjustment) /
+          const scaleFactor =
+            1 +
+            (sizeAdjustment +
+              userSizeAdjustment +
+              userIndividualSizeAdjustment) /
+              100;
+
+          const finalVerticalOffsetEm =
+            (verticalOffset +
+              userVerticalOffset +
+              userIndividualVerticalOffset) /
             100;
 
-        const finalVerticalOffsetEm =
-          (verticalOffset + userVerticalOffset + userIndividualVerticalOffset) /
-          100;
-
-        return [
-          shape,
-          await this.processSvg(
-            this.fontMeasurements,
+          return [
             shape,
-            scaleFactor,
-            defaultShapeAdjustments[shape].strokeFactor ?? 1,
-            finalVerticalOffsetEm,
-          ),
-        ];
-      }),
-    ));
+            await this.processSvg(
+              this.fontMeasurements,
+              shape,
+              scaleFactor,
+              defaultShapeAdjustments[shape].strokeFactor ?? 1,
+              finalVerticalOffsetEm,
+            ),
+          ];
+        }),
+      ),
+    );
 
     this.decorationMap = Object.fromEntries(
       Object.entries(this.enabledHatStyles.hatStyleMap).map(
@@ -379,7 +388,7 @@ export default class VscodeHatRenderer {
    * @param hatVerticalOffsetEm How far off top of characters should hats be
    * @returns An object with the new SVG and its measurements
    */
- private async processSvg(
+  private async processSvg(
     fontMeasurements: FontMeasurements,
     shape: HatShape,
     scaleFactor: number,
@@ -388,10 +397,15 @@ export default class VscodeHatRenderer {
   ): Promise<SvgInfo | null> {
     const iconPath =
       this.hatShapeOverrides[shape] ??
-      vscode.Uri.joinPath(this.extensionContext.extensionUri,
-        "images", "hats", `${shape}.svg`,
+      vscode.Uri.joinPath(
+        this.extensionContext.extensionUri,
+        "images",
+        "hats",
+        `${shape}.svg`,
       );
-    const rawSvg = this.decoder.decode(await vscode.workspace.fs.readFile(iconPath));
+    const rawSvg = this.decoder.decode(
+      await vscode.workspace.fs.readFile(iconPath),
+    );
     const { characterWidth, characterHeight, fontSize } = fontMeasurements;
 
     if (!this.checkSvg(shape, rawSvg)) {

--- a/packages/cursorless-vscode/src/ide/vscode/hats/VscodeHatRenderer.ts
+++ b/packages/cursorless-vscode/src/ide/vscode/hats/VscodeHatRenderer.ts
@@ -142,7 +142,7 @@ export default class VscodeHatRenderer {
           this.updateShapeOverrides(hatsDir),
         );
       } catch (e) {
-        console.error("cannot watch hatsDir " + hatsDir);
+        console.error("cannot watch hatsDir", hatsDir, e);
       }
     } else {
       this.hatShapeOverrides = {};

--- a/packages/cursorless-vscode/src/ide/vscode/hats/VscodeHatRenderer.ts
+++ b/packages/cursorless-vscode/src/ide/vscode/hats/VscodeHatRenderer.ts
@@ -136,14 +136,14 @@ export default class VscodeHatRenderer {
     if (hatsDir) {
       await this.updateShapeOverrides(hatsDir);
 
-      fs.access(hatsDir)
-        .then(
-          () =>
-            (this.hatsDirWatcherDisposable = watchDir(hatsDir, () =>
-              this.updateShapeOverrides(hatsDir),
-            )),
-        )
-        .catch(() => console.error("cannot watch hatsDir " + hatsDir));
+      try {
+        fs.access(hatsDir);
+        this.hatsDirWatcherDisposable = watchDir(hatsDir, () =>
+          this.updateShapeOverrides(hatsDir),
+        );
+      } catch (e) {
+        console.error("cannot watch hatsDir " + hatsDir);
+      }
     } else {
       this.hatShapeOverrides = {};
       await this.recomputeDecorations();

--- a/packages/cursorless-vscode/src/ide/vscode/hats/VscodeHatRenderer.ts
+++ b/packages/cursorless-vscode/src/ide/vscode/hats/VscodeHatRenderer.ts
@@ -24,6 +24,7 @@ import {
   defaultShapeAdjustments,
 } from "./shapeAdjustments";
 import { performPr1868ShapeUpdateInit } from "./performPr1868ShapeUpdateInit";
+import { TextDecoder } from 'util';
 
 const CURSORLESS_HAT_SHAPES_SUFFIX = ".svg";
 
@@ -65,7 +66,8 @@ export default class VscodeHatRenderer {
   private notifier: Notifier<[]> = new Notifier();
   private lastSeenEnabledHatStyles: ExtendedHatStyleMap = {};
   private hatsDirWatcherDisposable?: vscode.Disposable;
-  private hatShapeOverrides: Record<string, string> = {};
+  private hatShapeOverrides: Record<string, vscode.Uri> = {};
+  private decoder: TextDecoder;
 
   constructor(
     private vscodeApi: VscodeApi,
@@ -76,6 +78,7 @@ export default class VscodeHatRenderer {
   ) {
     extensionContext.subscriptions.push(this);
 
+    this.decoder = new TextDecoder('utf-8');
     this.recomputeDecorations = this.recomputeDecorations.bind(this);
 
     this.disposables.push(
@@ -150,7 +153,10 @@ export default class VscodeHatRenderer {
 
     for (const file of files) {
       const name = path.basename(file, CURSORLESS_HAT_SHAPES_SUFFIX);
-      this.hatShapeOverrides[name] = file;
+      this.hatShapeOverrides[name] = vscode.Uri.from({
+        scheme: 'file',
+        path: file
+      });
     }
 
     await this.recomputeDecorations();
@@ -382,13 +388,10 @@ export default class VscodeHatRenderer {
   ): Promise<SvgInfo | null> {
     const iconPath =
       this.hatShapeOverrides[shape] ??
-      path.join(
-        this.extensionContext.extensionPath,
-        "images",
-        "hats",
-        `${shape}.svg`,
+      vscode.Uri.joinPath(this.extensionContext.extensionUri,
+        "images", "hats", `${shape}.svg`,
       );
-    const rawSvg = await fs.readFile(iconPath, "utf8");
+    const rawSvg = this.decoder.decode(await vscode.workspace.fs.readFile(iconPath));
     const { characterWidth, characterHeight, fontSize } = fontMeasurements;
 
     if (!this.checkSvg(shape, rawSvg)) {

--- a/packages/cursorless-vscode/src/ide/vscode/hats/VscodeHatRenderer.ts
+++ b/packages/cursorless-vscode/src/ide/vscode/hats/VscodeHatRenderer.ts
@@ -7,7 +7,7 @@ import {
 } from "@cursorless/common";
 import { VscodeApi } from "@cursorless/vscode-common";
 import { cloneDeep, isEqual } from "lodash";
-import * as fs from "node:fs";
+import * as fs from "fs/promises";
 import * as path from "node:path";
 import * as vscode from "vscode";
 import { vscodeGetConfigurationString } from "../VscodeConfiguration";
@@ -133,11 +133,11 @@ export default class VscodeHatRenderer {
     if (hatsDir) {
       await this.updateShapeOverrides(hatsDir);
 
-      if (fs.existsSync(hatsDir)) {
+      fs.access(hatsDir).then(() =>
         this.hatsDirWatcherDisposable = watchDir(hatsDir, () =>
           this.updateShapeOverrides(hatsDir),
-        );
-      }
+        ))
+        .catch(() => console.error("cannot watch hatsDir " + hatsDir));
     } else {
       this.hatShapeOverrides = {};
       await this.recomputeDecorations();
@@ -207,7 +207,7 @@ export default class VscodeHatRenderer {
     );
 
     const hatSvgMap = Object.fromEntries(
-      HAT_SHAPES.map((shape) => {
+      await Promise.all(HAT_SHAPES.map(async (shape) => {
         const { sizeAdjustment = 0, verticalOffset = 0 } =
           defaultShapeAdjustments[shape];
 
@@ -227,7 +227,7 @@ export default class VscodeHatRenderer {
 
         return [
           shape,
-          this.processSvg(
+          await this.processSvg(
             this.fontMeasurements,
             shape,
             scaleFactor,
@@ -236,7 +236,7 @@ export default class VscodeHatRenderer {
           ),
         ];
       }),
-    );
+    ));
 
     this.decorationMap = Object.fromEntries(
       Object.entries(this.enabledHatStyles.hatStyleMap).map(
@@ -373,13 +373,13 @@ export default class VscodeHatRenderer {
    * @param hatVerticalOffsetEm How far off top of characters should hats be
    * @returns An object with the new SVG and its measurements
    */
-  private processSvg(
+ private async processSvg(
     fontMeasurements: FontMeasurements,
     shape: HatShape,
     scaleFactor: number,
     strokeFactor: number,
     hatVerticalOffsetEm: number,
-  ): SvgInfo | null {
+  ): Promise<SvgInfo | null> {
     const iconPath =
       this.hatShapeOverrides[shape] ??
       path.join(
@@ -388,7 +388,7 @@ export default class VscodeHatRenderer {
         "hats",
         `${shape}.svg`,
       );
-    const rawSvg = fs.readFileSync(iconPath, "utf8");
+    const rawSvg = await fs.readFile(iconPath, "utf8");
     const { characterWidth, characterHeight, fontSize } = fontMeasurements;
 
     if (!this.checkSvg(shape, rawSvg)) {

--- a/packages/cursorless-vscode/src/ide/vscode/hats/VscodeHatRenderer.ts
+++ b/packages/cursorless-vscode/src/ide/vscode/hats/VscodeHatRenderer.ts
@@ -67,7 +67,7 @@ export default class VscodeHatRenderer {
   private lastSeenEnabledHatStyles: ExtendedHatStyleMap = {};
   private hatsDirWatcherDisposable?: vscode.Disposable;
   private hatShapeOverrides: Record<string, vscode.Uri> = {};
-  private decoder: TextDecoder = new TextDecoder("utf-8");;
+  private decoder: TextDecoder = new TextDecoder("utf-8");
 
   constructor(
     private vscodeApi: VscodeApi,

--- a/packages/cursorless-vscode/src/ide/vscode/hats/VscodeHatRenderer.ts
+++ b/packages/cursorless-vscode/src/ide/vscode/hats/VscodeHatRenderer.ts
@@ -67,7 +67,7 @@ export default class VscodeHatRenderer {
   private lastSeenEnabledHatStyles: ExtendedHatStyleMap = {};
   private hatsDirWatcherDisposable?: vscode.Disposable;
   private hatShapeOverrides: Record<string, vscode.Uri> = {};
-  private decoder: TextDecoder;
+  private decoder: TextDecoder = new TextDecoder("utf-8");;
 
   constructor(
     private vscodeApi: VscodeApi,
@@ -78,7 +78,6 @@ export default class VscodeHatRenderer {
   ) {
     extensionContext.subscriptions.push(this);
 
-    this.decoder = new TextDecoder("utf-8");
     this.recomputeDecorations = this.recomputeDecorations.bind(this);
 
     this.disposables.push(

--- a/packages/cursorless-vscode/src/ide/vscode/hats/VscodeHatRenderer.ts
+++ b/packages/cursorless-vscode/src/ide/vscode/hats/VscodeHatRenderer.ts
@@ -137,7 +137,7 @@ export default class VscodeHatRenderer {
       await this.updateShapeOverrides(hatsDir);
 
       try {
-        fs.access(hatsDir);
+        await fs.access(hatsDir);
         this.hatsDirWatcherDisposable = watchDir(hatsDir, () =>
           this.updateShapeOverrides(hatsDir),
         );


### PR DESCRIPTION
This is part of porting Cursorless to work in the web environment.

This is a re-roll of https://github.com/cursorless-dev/cursorless/pull/2153 which I messed up with bad git-fu.

## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet
