### PR TITLE
Stop using `backspace` for `remove` action; tweak maps

### DIFF
--- a/docs/user/experimental/keyboard/modal.md
+++ b/docs/user/experimental/keyboard/modal.md
@@ -29,18 +29,12 @@ Paste the following into your [VSCode `keybindings.json`](https://code.visualstu
         "key": "escape",
         "command": "cursorless.keyboard.escape",
         "when": "cursorless.keyboard.listening && editorTextFocus && !suggestWidgetMultipleSuggestions && !suggestWidgetVisible"
-    },
-    {
-        "key": "backspace",
-        "command": "cursorless.keyboard.targeted.runActionOnTarget",
-        "args": "remove",
-        "when": "cursorless.keyboard.modal.mode && editorTextFocus"
     }
 ```
 
 Any keybindings that use modifier keys should go in `keybindings.json` as well, with a `"when": "cursorless.keyboard.modal.mode` clause.
 
-The above allows you to press `ctrl-c` to switch to Cursorless mode, `escape` to exit Cursorless mode, and `backspace` to issue the delete action while in Cursorless mode.
+The above allows you to press `ctrl-c` to switch to Cursorless mode and `escape` to exit Cursorless mode.
 
 If you're already in Cursorless mode, pressing `ctrl-c` again will target the current selection, which is useful if you have moved the cursor using your mouse while in Cursorless mode, and want to target your new cursor position.
 
@@ -86,7 +80,8 @@ To bind keys that do not have modifiers (eg just pressing `a`), add entries like
     "ac": "copyToClipboard",
     "ax": "cutToClipboard",
     "ap": "pasteFromClipboard",
-    "ad": "followLink"
+    "ad": "followLink",
+    "aw": "remove",
   },
   "cursorless.experimental.keyboard.modal.keybindings.color": {
     "d": "default",

--- a/packages/cursorless-vscode-e2e/src/suite/keyboard/basic.vscode.test.ts
+++ b/packages/cursorless-vscode-e2e/src/suite/keyboard/basic.vscode.test.ts
@@ -31,7 +31,7 @@ const testCases: TestCase[] = [
     name: "every",
     initialContent: "a a\nb b\n",
     // change every token air
-    keySequence: ["da", "x", "st", "c"],
+    keySequence: ["da", "*", "st", "c"],
     finalContent: " \nb b\n",
   },
   {

--- a/packages/cursorless-vscode/src/keyboard/keyboard-config.fixture.json
+++ b/packages/cursorless-vscode/src/keyboard/keyboard-config.fixture.json
@@ -20,24 +20,25 @@
   },
   "cursorless.experimental.keyboard.modal.keybindings.action": {
     "at": "setSelection",
-    "ah": { "actionId": "setSelectionBefore", "exitCursorlessMode": true },
-    "al": { "actionId": "setSelectionAfter", "exitCursorlessMode": true },
-    "aO": { "actionId": "editNewLineBefore", "exitCursorlessMode": true },
+    "ah": "setSelectionBefore",
+    "al": "setSelectionAfter",
+    "ai": { "actionId": "editNewLineBefore", "exitCursorlessMode": true },
     "ao": { "actionId": "editNewLineAfter", "exitCursorlessMode": true },
-    "k": "insertCopyBefore",
-    "j": "insertCopyAfter",
+    "ak": "insertCopyBefore",
+    "aj": "insertCopyAfter",
     "au": "replaceWithTarget",
     "am": "moveToTarget",
     "c": { "actionId": "clearAndSetSelection", "exitCursorlessMode": true },
     "as": "swapTargets",
     "af": "foldRegion",
-    "ak": "insertEmptyLineBefore",
-    "aj": "insertEmptyLineAfter",
-    "ai": "insertEmptyLinesAround",
+    "aI": "insertEmptyLineBefore",
+    "aO": "insertEmptyLineAfter",
+    "aU": "insertEmptyLinesAround",
     "ac": "copyToClipboard",
     "ax": "cutToClipboard",
     "ap": "pasteFromClipboard",
     "ad": "followLink",
+    "x": "remove",
     "aw": "wrap"
   },
   "cursorless.experimental.keyboard.modal.keybindings.color": {
@@ -66,7 +67,7 @@
   },
   "cursorless.experimental.keyboard.modal.keybindings.modifier": {
     "n": "nextPrev",
-    "x": "every"
+    "*": "every"
   },
   "cursorless.experimental.keyboard.modal.keybindings.vscodeCommand": {
     "va": "editor.action.addCommentLine",


### PR DESCRIPTION
This broke when we reworked our keyboard actions setup. It's also not properly integrated with new keyboard parser. If we wanted to support special keys like `backspace` with our keyboard parser, we should define a VSCode command that sends a keyboard token to our parser, and map `backspace` to that

We also add `remove` to default config, and tweak some maps while we're there

## Checklist

- [-] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [x] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [-] I have not broken the cheatsheet
