### PR TITLE
Don't clobber keyboard target after executing action

### DIFF
--- a/packages/cursorless-vscode-e2e/src/suite/keyboard/basic.vscode.test.ts
+++ b/packages/cursorless-vscode-e2e/src/suite/keyboard/basic.vscode.test.ts
@@ -70,7 +70,7 @@ const testCases: TestCase[] = [
     finalContent: "(a)",
   },
   {
-    name: "reset keyboard target",
+    name: "preserve keyboard target",
     initialContent: "a\n",
     // round wrap air; round wrap <keyboard target>
     keySequence: ["da", "aw", "wp", "aw", "wp"],

--- a/packages/cursorless-vscode-e2e/src/suite/keyboard/basic.vscode.test.ts
+++ b/packages/cursorless-vscode-e2e/src/suite/keyboard/basic.vscode.test.ts
@@ -69,6 +69,13 @@ const testCases: TestCase[] = [
     keySequence: ["da", "aw", "wp"],
     finalContent: "(a)",
   },
+  {
+    name: "reset keyboard target",
+    initialContent: "a\n",
+    // round wrap air; round wrap <keyboard target>
+    keySequence: ["da", "aw", "wp", "aw", "wp"],
+    finalContent: "((a))\n",
+  },
 ];
 
 suite("Basic keyboard test", async function () {

--- a/packages/cursorless-vscode/src/keyboard/KeyboardCommandsTargeted.ts
+++ b/packages/cursorless-vscode/src/keyboard/KeyboardCommandsTargeted.ts
@@ -261,6 +261,18 @@ export default class KeyboardCommandsTargeted {
       // For some Cursorless actions, it is more convenient if we automatically
       // exit modal mode
       await this.modal.modeOff();
+    } else {
+      // If we're not exiting cursorless mode, preserve the keyboard mark
+      // FIXME: Better to just not clobber the keyboard mark on each action?
+      await executeCursorlessCommand({
+        name: "private.setKeyboardTarget",
+        target: {
+          type: "primitive",
+          mark: {
+            type: "that",
+          },
+        },
+      });
     }
 
     return returnValue;


### PR DESCRIPTION


## Checklist

- [x] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [-] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [-] I have not broken the cheatsheet
