### PR TITLE
Remove unnecessary import of TextDecoder from util.

### DIFF
--- a/packages/cursorless-vscode/src/ide/vscode/hats/VscodeHatRenderer.ts
+++ b/packages/cursorless-vscode/src/ide/vscode/hats/VscodeHatRenderer.ts
@@ -24,7 +24,6 @@ import {
   defaultShapeAdjustments,
 } from "./shapeAdjustments";
 import { performPr1868ShapeUpdateInit } from "./performPr1868ShapeUpdateInit";
-import { TextDecoder } from "util";
 
 const CURSORLESS_HAT_SHAPES_SUFFIX = ".svg";
 
@@ -67,7 +66,7 @@ export default class VscodeHatRenderer {
   private lastSeenEnabledHatStyles: ExtendedHatStyleMap = {};
   private hatsDirWatcherDisposable?: vscode.Disposable;
   private hatShapeOverrides: Record<string, vscode.Uri> = {};
-  private decoder: TextDecoder = new TextDecoder("utf-8");
+  private decoder = new TextDecoder("utf-8");
 
   constructor(
     private vscodeApi: VscodeApi,


### PR DESCRIPTION

## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet
