### PR TITLE
Add support for `yield` statements for `"value"` in Python

### DIFF
--- a/packages/common/src/scopeSupportFacets/python.ts
+++ b/packages/common/src/scopeSupportFacets/python.ts
@@ -10,6 +10,7 @@ const { supported, supportedLegacy, notApplicable } = ScopeSupportFacetLevel;
 export const pythonScopeSupport: LanguageScopeSupportFacetMap = {
   "name.foreach": supported,
   "value.foreach": supported,
+  "value.yield": supported,
 
   "argument.actual": supportedLegacy,
   "argument.actual.iteration": supportedLegacy,

--- a/packages/common/src/scopeSupportFacets/scopeSupportFacetInfos.ts
+++ b/packages/common/src/scopeSupportFacets/scopeSupportFacetInfos.ts
@@ -289,6 +289,10 @@ export const scopeSupportFacetInfos: Record<
     description: "Value (RHS) of a field in a class / interface",
     scopeType: "value",
   },
+  "value.yield": {
+    description: "Value of a yield statement",
+    scopeType: "value",
+  },
 
   "type.assignment": {
     description: "Type of variable in an assignment",

--- a/packages/common/src/scopeSupportFacets/scopeSupportFacets.types.ts
+++ b/packages/common/src/scopeSupportFacets/scopeSupportFacets.types.ts
@@ -76,6 +76,7 @@ const scopeSupportFacets = [
   "value.return",
   "value.return.lambda",
   "value.field",
+  "value.yield",
 
   "type.assignment",
   "type.formalParameter",

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/scopes/python/value.yield.scope
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/scopes/python/value.yield.scope
@@ -1,0 +1,21 @@
+def aaa():
+    yield bbb
+---
+
+[Content] = 1:10-1:13
+1|     yield bbb
+            >---<
+
+[Removal] = 1:9-1:13
+1|     yield bbb
+           >----<
+
+[Leading delimiter] = 1:9-1:10
+1|     yield bbb
+           >-<
+
+[Domain] = 1:4-1:13
+1|     yield bbb
+      >---------<
+
+[Insertion delimiter] = " "

--- a/queries/python.scm
+++ b/queries/python.scm
@@ -142,6 +142,18 @@
   (_) @value
 ) @_.domain
 
+;;!! yield 1
+;;!        ^
+;;!       xx
+;;!  -------
+;;
+;; NOTE: in tree-sitter, both "yield" and the "1" are children of `yield` but
+;; "yield" is anonymous whereas "1" is named node, so no need to exclude
+;; explicitly
+(yield
+  (_) @value
+) @_.domain
+
 ;;!! lambda str: len(str) > 0
 ;;!              ^^^^^^^^^^^^
 ;;!  ------------------------


### PR DESCRIPTION
Fixes #2214

## Checklist

- [x] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [-] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [-] I have not broken the cheatsheet
