### PR TITLE
{grand, every} rephrasings for clarity and consistency

### DIFF
--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -207,22 +207,22 @@ And here is a table of the spoken forms:
 
 ##### `"every"`
 
-The command `"every"` can be used to select a syntactic element and all of its matching siblings.
+The modifier `"every"` can be used to select a syntactic element and all of its matching siblings.
 
 - `"take every key air"`
 - `"take every funk air"`
 - `"take every key"` (if cursor is currently within a key)
 
-For example, the command `take every key [blue] air` will select every key in the map/object/dict including the token with a blue hat over the letter 'a'.
+For example, the command `"take every key [blue] air"` will select every key in the map/object/dict including the token with a blue hat over the letter 'a'.
 
 ##### `"grand"`
 
-The command `"grand"` can be used to select the grand parent of the containing syntactic element.
+The modifier `"grand"` can be used to select the parent of the containing syntactic element.
 
 - `"take grand statement air"`
 - `"take grand funk air"`
 
-For example, the command `take grand statement [blue] air` will select that parent statement of the statement containing the token with a blue hat over the letter 'a'.
+For example, the command `"take grand statement [blue] air"` will select that parent statement of the statement containing the token with a blue hat over the letter 'a'.
 
 ##### Sub-token modifiers
 


### PR DESCRIPTION
Related discussion: https://talonvoice.slack.com/archives/C026KPTJE6T/p1708813018817909


## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [X] I have not broken the cheatsheet
