### PR TITLE
add `grand` to cheatsheet

### DIFF
--- a/cursorless-talon/src/cheatsheet/sections/modifiers.py
+++ b/cursorless-talon/src/cheatsheet/sections/modifiers.py
@@ -22,6 +22,7 @@ def get_modifiers():
         "extendThroughStartOf",
         "extendThroughEndOf",
         "every",
+        "grand",
         "ancestor",
         "first",
         "last",
@@ -99,6 +100,16 @@ def get_modifiers():
                 {
                     "spokenForm": f"{complex_modifiers['every']} <scope>",
                     "description": "Every instance of <scope>",
+                },
+            ],
+        },
+        {
+            "id": "grand",
+            "type": "modifier",
+            "variations": [
+                {
+                    "spokenForm": f"{complex_modifiers['grand']} <scope>",
+                    "description": "parent scope of the containing <scope>",
                 },
             ],
         },


### PR DESCRIPTION
This is completely untested.  I can test it at some point once I get my cursorless dev stuff set up again, but I hope a more regular contributor can test it quickly.

## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [X] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [RED-FLAG-EMOJI] I have not broken the cheatsheet
