### PR TITLE
refactor: make the text editor edit() interface better for neovim

### DIFF
--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -35,6 +35,7 @@ export * from "./types/RangeExpansionBehavior";
 export * from "./types/InputBoxOptions";
 export * from "./types/Position";
 export * from "./types/Range";
+export * from "./types/Edit";
 export * from "./types/RevealLineAt";
 export * from "./types/Selection";
 export * from "./types/TextDocument";

--- a/packages/common/src/types/Edit.ts
+++ b/packages/common/src/types/Edit.ts
@@ -1,0 +1,18 @@
+import { Range } from "..";
+
+/** Represent a single edit/change in the document */
+export interface Edit {
+  range: Range;
+  text: string;
+
+  /**
+   * If this edit is an insertion, ie the range has zero length, then this
+   * field can be set to `true` to indicate that any adjacent empty selection
+   * should *not* be shifted to the right, as would normally happen with an
+   * insertion. This is equivalent to the
+   * [distinction](https://code.visualstudio.com/api/references/vscode-api#TextEditorEdit)
+   * in a vscode edit builder between doing a replace with an empty range
+   * versus doing an insert.
+   */
+  isReplace?: boolean;
+}

--- a/packages/common/src/types/TextEditor.ts
+++ b/packages/common/src/types/TextEditor.ts
@@ -1,10 +1,10 @@
 import type {
+  Edit,
   Position,
   Range,
   RevealLineAt,
   Selection,
   TextDocument,
-  TextEditorEdit,
   TextEditorOptions,
 } from "..";
 
@@ -81,18 +81,11 @@ export interface EditableTextEditor extends TextEditor {
   /**
    * Perform an edit on the document associated with this text editor.
    *
-   * The given callback-function is invoked with an {@link TextEditorEdit edit-builder} which must
-   * be used to make edits. Note that the edit-builder is only valid while the
-   * callback executes.
-   *
-   * @param callback A function which can create edits using an {@link TextEditorEdit edit-builder}.
-   * @param options The undo/redo behavior around this edit. By default, undo stops will be created before and after this edit.
+   * @param edits the list of edits that need to be applied to the document
+   *        (note that the implementation might need to sort them in reverse order)
    * @return A promise that resolves with a value indicating if the edits could be applied.
    */
-  edit(
-    callback: (editBuilder: TextEditorEdit) => void,
-    options?: { undoStopBefore: boolean; undoStopAfter: boolean },
-  ): Promise<boolean>;
+  edit(edits: Edit[]): Promise<boolean>;
 
   /**
    * Edit a new new notebook cell above.

--- a/packages/cursorless-engine/src/actions/BreakLine.ts
+++ b/packages/cursorless-engine/src/actions/BreakLine.ts
@@ -1,9 +1,14 @@
-import { FlashStyle, Position, Range, TextEditor } from "@cursorless/common";
+import {
+  Edit,
+  FlashStyle,
+  Position,
+  Range,
+  TextEditor,
+} from "@cursorless/common";
 import { flatten, zip } from "lodash";
 import type { RangeUpdater } from "../core/updateSelections/RangeUpdater";
 import { performEditsAndUpdateRanges } from "../core/updateSelections/updateSelections";
 import { ide } from "../singletons/ide.singleton";
-import { Edit } from "../typings/Types";
 import { Target } from "../typings/target.types";
 import { flashTargets, runOnTargetsForEachEditor } from "../util/targetUtils";
 import type { ActionReturnValue } from "./actions.types";

--- a/packages/cursorless-engine/src/actions/JoinLines.ts
+++ b/packages/cursorless-engine/src/actions/JoinLines.ts
@@ -1,13 +1,12 @@
-import { FlashStyle, Range, TextEditor } from "@cursorless/common";
+import { Edit, FlashStyle, Range, TextEditor } from "@cursorless/common";
+import { range as iterRange, map, pairwise } from "itertools";
 import { flatten, zip } from "lodash";
 import type { RangeUpdater } from "../core/updateSelections/RangeUpdater";
 import { performEditsAndUpdateRanges } from "../core/updateSelections/updateSelections";
 import { ide } from "../singletons/ide.singleton";
-import { Edit } from "../typings/Types";
 import { Target } from "../typings/target.types";
 import { flashTargets, runOnTargetsForEachEditor } from "../util/targetUtils";
 import type { ActionReturnValue } from "./actions.types";
-import { range as iterRange, map, pairwise } from "itertools";
 
 export default class JoinLines {
   constructor(private rangeUpdater: RangeUpdater) {

--- a/packages/cursorless-engine/src/actions/Wrap.ts
+++ b/packages/cursorless-engine/src/actions/Wrap.ts
@@ -1,4 +1,5 @@
 import {
+  Edit,
   FlashStyle,
   RangeExpansionBehavior,
   Selection,
@@ -10,7 +11,6 @@ import {
   performEditsAndUpdateFullSelectionInfos,
 } from "../core/updateSelections/updateSelections";
 import { ide } from "../singletons/ide.singleton";
-import { Edit } from "../typings/Types";
 import { Target } from "../typings/target.types";
 import { FullSelectionInfo } from "../typings/updateSelections";
 import { setSelectionsWithoutFocusingEditor } from "../util/setSelectionsAndFocusEditor";

--- a/packages/cursorless-engine/src/core/updateSelections/RangeUpdater.ts
+++ b/packages/cursorless-engine/src/core/updateSelections/RangeUpdater.ts
@@ -1,12 +1,12 @@
 import type {
   Disposable,
+  Edit,
   TextDocument,
   TextDocumentChangeEvent,
   TextDocumentContentChangeEvent,
 } from "@cursorless/common";
 import { pull } from "lodash";
 import { ide } from "../../singletons/ide.singleton";
-import type { Edit } from "../../typings/Types";
 import {
   ExtendedTextDocumentChangeEvent,
   FullRangeInfo,

--- a/packages/cursorless-engine/src/core/updateSelections/updateSelections.ts
+++ b/packages/cursorless-engine/src/core/updateSelections/updateSelections.ts
@@ -1,12 +1,12 @@
 import {
-  RangeExpansionBehavior,
+  Edit,
   EditableTextEditor,
   Range,
+  RangeExpansionBehavior,
   Selection,
   TextDocument,
 } from "@cursorless/common";
 import { flatten } from "lodash";
-import { Edit } from "../../typings/Types";
 import {
   FullSelectionInfo,
   SelectionInfo,

--- a/packages/cursorless-engine/src/typings/Types.ts
+++ b/packages/cursorless-engine/src/typings/Types.ts
@@ -1,4 +1,4 @@
-import type { Range, Selection, TextEditor } from "@cursorless/common";
+import type { Edit, Range, Selection, TextEditor } from "@cursorless/common";
 import type { SyntaxNode } from "web-tree-sitter";
 
 export interface SelectionWithEditor {
@@ -71,23 +71,6 @@ export type SelectionExtractor = (
   editor: TextEditor,
   nodes: SyntaxNode,
 ) => SelectionWithContext;
-
-/** Represent a single edit/change in the document */
-export interface Edit {
-  range: Range;
-  text: string;
-
-  /**
-   * If this edit is an insertion, ie the range has zero length, then this
-   * field can be set to `true` to indicate that any adjacent empty selection
-   * should *not* be shifted to the right, as would normally happen with an
-   * insertion. This is equivalent to the
-   * [distinction](https://code.visualstudio.com/api/references/vscode-api#TextEditorEdit)
-   * in a vscode edit builder between doing a replace with an empty range
-   * versus doing an insert.
-   */
-  isReplace?: boolean;
-}
 
 export interface EditWithRangeUpdater extends Edit {
   /**

--- a/packages/cursorless-engine/src/util/performDocumentEdits.ts
+++ b/packages/cursorless-engine/src/util/performDocumentEdits.ts
@@ -1,6 +1,5 @@
-import { EditableTextEditor } from "@cursorless/common";
+import { Edit, EditableTextEditor } from "@cursorless/common";
 import { RangeUpdater } from "../core/updateSelections/RangeUpdater";
-import { Edit } from "../typings/Types";
 
 export async function performDocumentEdits(
   rangeUpdater: RangeUpdater,
@@ -12,17 +11,7 @@ export async function performDocumentEdits(
     edits.filter((edit) => edit.isReplace),
   );
 
-  const wereEditsApplied = await editor.edit((editBuilder) => {
-    edits.forEach(({ range, text, isReplace }) => {
-      if (text === "") {
-        editBuilder.delete(range);
-      } else if (range.isEmpty && !isReplace) {
-        editBuilder.insert(range.start, text);
-      } else {
-        editBuilder.replace(range, text);
-      }
-    });
-  });
+  const wereEditsApplied = await editor.edit(edits);
 
   deregister();
 

--- a/packages/cursorless-vscode/src/ide/vscode/VscodeTextEditorImpl.ts
+++ b/packages/cursorless-vscode/src/ide/vscode/VscodeTextEditorImpl.ts
@@ -1,5 +1,6 @@
 import {
   BreakpointDescriptor,
+  Edit,
   EditableTextEditor,
   Position,
   Range,
@@ -8,7 +9,6 @@ import {
   sleep,
   TextDocument,
   TextEditor,
-  TextEditorEdit,
   TextEditorOptions,
 } from "@cursorless/common";
 import {
@@ -84,11 +84,8 @@ export class VscodeTextEditorImpl implements EditableTextEditor {
     return vscodeRevealLine(this, lineNumber, at);
   }
 
-  public edit(
-    callback: (editBuilder: TextEditorEdit) => void,
-    options?: { undoStopBefore: boolean; undoStopAfter: boolean },
-  ): Promise<boolean> {
-    return vscodeEdit(this.editor, callback, options);
+  public edit(edits: Edit[]): Promise<boolean> {
+    return vscodeEdit(this.editor, edits);
   }
 
   public focus(): Promise<void> {


### PR DESCRIPTION

## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet

` 7189 passing (5m)` all tests passing.


Just marking it as a draft PR for now until I confirm from neovim side that this is good interface.