### PR TITLE
enforce new selection for "remove" action

### DIFF
--- a/packages/cursorless-engine/src/actions/InsertCopy.ts
+++ b/packages/cursorless-engine/src/actions/InsertCopy.ts
@@ -72,7 +72,7 @@ class InsertCopy implements SimpleAction {
     const editableEditor = ide().getEditableTextEditor(editor);
 
     const [
-      updatedEditorSelections,
+      updatedCursorSelections,
       updatedContentSelections,
       updatedEditSelections,
     ]: Selection[][] = await performEditsAndUpdateSelectionsWithBehavior(
@@ -86,7 +86,7 @@ class InsertCopy implements SimpleAction {
       ([edit, selection]) => edit!.updateRange(selection!),
     );
 
-    setSelectionsWithoutFocusingEditor(editableEditor, updatedEditorSelections);
+    setSelectionsWithoutFocusingEditor(editableEditor, updatedCursorSelections);
     const primarySelection = editor.selections[0];
 
     if (

--- a/packages/cursorless-engine/src/actions/Remove.ts
+++ b/packages/cursorless-engine/src/actions/Remove.ts
@@ -40,12 +40,10 @@ export default class Delete implements SimpleAction {
     const edits = targets.map((target) => target.constructRemovalEdit());
 
     const cursorSelections = editor.selections;
-    const editSelections = edits.map(
-      ({ range }) => new Selection(range.start, range.end),
-    );
+    const editSelections = edits.map(({ range }) => range.toSelection(false));
     const editableEditor = ide().getEditableTextEditor(editor);
 
-    const [updatedEditorSelections, updatedEditSelections]: Selection[][] =
+    const [updatedCursorSelections, updatedEditSelections]: Selection[][] =
       await performEditsAndUpdateSelections(
         this.rangeUpdater,
         editableEditor,
@@ -55,7 +53,7 @@ export default class Delete implements SimpleAction {
 
     await setSelectionsWithoutFocusingEditor(
       editableEditor,
-      updatedEditorSelections,
+      updatedCursorSelections,
     );
 
     return zip(targets, updatedEditSelections).map(

--- a/packages/cursorless-engine/src/actions/Remove.ts
+++ b/packages/cursorless-engine/src/actions/Remove.ts
@@ -1,12 +1,7 @@
-import {
-  FlashStyle,
-  RangeExpansionBehavior,
-  Selection,
-  TextEditor,
-} from "@cursorless/common";
+import { FlashStyle, Selection, TextEditor } from "@cursorless/common";
 import { flatten, zip } from "lodash";
 import { RangeUpdater } from "../core/updateSelections/RangeUpdater";
-import { performEditsAndUpdateSelectionsWithBehavior } from "../core/updateSelections/updateSelections";
+import { performEditsAndUpdateSelections } from "../core/updateSelections/updateSelections";
 import { RawSelectionTarget } from "../processTargets/targets";
 import { ide } from "../singletons/ide.singleton";
 import { Target } from "../typings/target.types";
@@ -44,18 +39,14 @@ export default class Delete implements SimpleAction {
   private async runForEditor(editor: TextEditor, targets: Target[]) {
     const edits = targets.map((target) => target.constructRemovalEdit());
 
-    const cursorSelections = { selections: editor.selections };
-    const editSelections = {
-      selections: edits.map(
-        ({ range }) => new Selection(range.start, range.end),
-      ),
-      rangeBehavior: RangeExpansionBehavior.closedClosed,
-    };
-
+    const cursorSelections = editor.selections;
+    const editSelections = edits.map(
+      ({ range }) => new Selection(range.start, range.end),
+    );
     const editableEditor = ide().getEditableTextEditor(editor);
 
     const [updatedEditorSelections, updatedEditSelections]: Selection[][] =
-      await performEditsAndUpdateSelectionsWithBehavior(
+      await performEditsAndUpdateSelections(
         this.rangeUpdater,
         editableEditor,
         edits,


### PR DESCRIPTION

## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet

From debugging the vscode cursorless extension, it seems the selection is automatically updated by vscode itself when dealing with the "remove" action while calling editBuilder.delete() (TextEditorEdit). 

However it is not the case for neovim so it was using the old selection.

I fixed it so cursorless always enforce selection for that "remove" action. Tested on neovim and vscode.