### PR TITLE
github: Create ADR discussion category form

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/architectural-decision-record.yml
+++ b/.github/DISCUSSION_TEMPLATE/architectural-decision-record.yml
@@ -1,0 +1,27 @@
+body:
+  - type: markdown
+    attributes:
+      value: |
+        You are submitting to our Architecture Decision Record.
+        Learn more about ADRs at <https://adr.github.io>, and discussion #1211.
+
+  - type: textarea
+    attributes:
+      label: Context
+      description: The issue motivating this decision, and any context that influences or constrains the decision.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Options considered
+
+  - type: textarea
+    attributes:
+      label: Decision
+      description: "The change that we're proposing or have agreed to implement."
+
+  - type: textarea
+    attributes:
+      label: Consequences
+      description: What becomes easier or more difficult to do and any risks introduced by the change that will need to be mitigated.


### PR DESCRIPTION
This codifies our ADR template (#1210) using [GitHub discussion category forms](https://docs.github.com/en/discussions/managing-discussions-for-your-community/creating-discussion-category-forms).

Note that this changes the heading levels (they'll all be `h3` I think), which means the **Options considered** heading will no longer be a subheading of the **Context**. This is probably fine – a lot of the other Markdown ADR templates have this section at the same level anyway.