### PR TITLE
Revert "Bump CI node version to 20 (#2217)"

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -45,7 +45,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -14,11 +14,11 @@ jobs:
     env:
       CURSORLESS_REPO_ROOT: ${{ github.workspace }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - run: corepack enable
-      - uses: actions/setup-node@v4
+      - uses: pnpm/action-setup@v2
+      - uses: actions/setup-node@v3
         with:
           node-version-file: package.json
           cache: pnpm
@@ -46,7 +46,7 @@ jobs:
     needs: publish-extension
     environment: production
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           token: ${{ secrets.CURSORLESS_BOT_TOKEN }}

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -14,12 +14,12 @@ jobs:
     name: Pre-commit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
-      - run: corepack enable
-      - uses: actions/setup-node@v4
+      - uses: pnpm/action-setup@v2
+      - uses: actions/setup-node@v3
         with:
           node-version-file: package.json
           cache: pnpm

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -12,9 +12,9 @@ jobs:
     env:
       CURSORLESS_REPO_ROOT: ${{ github.workspace }}
     steps:
-      - uses: actions/checkout@v4
-      - run: corepack enable
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v3
+      - uses: pnpm/action-setup@v2
+      - uses: actions/setup-node@v3
         with:
           node-version-file: package.json
           cache: pnpm

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,9 +27,9 @@ jobs:
       VSCODE_LOGS_DIR: ${{ github.workspace }}/artifacts/logs
       CURSORLESS_REPO_ROOT: ${{ github.workspace }}
     steps:
-      - uses: actions/checkout@v4
-      - run: corepack enable
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v3
+      - uses: pnpm/action-setup@v2
+      - uses: actions/setup-node@v3
         with:
           node-version-file: package.json
           cache: pnpm
@@ -55,19 +55,19 @@ jobs:
       - run: mv ${{ steps.createVsix.outputs.vsixPath }} cursorless-development.vsix
         if: runner.os == 'Linux' && matrix.vscode_version == 'stable'
       - name: Upload vsix
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         if: runner.os == 'Linux' && matrix.vscode_version == 'stable'
         with:
           name: vsix
           path: cursorless-development.vsix
       - name: Archive logs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: logs
           path: ${{ env.VSCODE_LOGS_DIR }}
         if: failure()
       - name: Archive dumps
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: dumps
           path: ${{ env.VSCODE_CRASH_DIR }}

--- a/cursorless-talon/.github/workflows/black.yml
+++ b/cursorless-talon/.github/workflows/black.yml
@@ -6,5 +6,5 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v2
       - uses: psf/black@stable


### PR DESCRIPTION
CI seems to be failing consistently on Windows on main. Strangely, it passed on main on the first run when #2217 merged, so this is a bit of a longshot, but seeing if reverting it fixes things

## Checklist

- [-] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [-] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [-] I have not broken the cheatsheet
