### PR TITLE
isTesting versus ide.runMode

### DIFF
--- a/packages/common/src/testUtil/isTesting.ts
+++ b/packages/common/src/testUtil/isTesting.ts
@@ -1,1 +1,8 @@
-export const isTesting = () => process.env.CURSORLESS_TEST != null;
+import { IDE } from "../ide/types/ide.types";
+
+// we rely on the ide.runMode when running as a vscode extension
+// but we need an environment variable for other types of tests
+export const isTesting = (ide?: IDE) =>
+  ide?.runMode === "test" || process.env.CURSORLESS_TEST != null;
+
+export const isProduction = (ide: IDE) => ide.runMode === "production";

--- a/packages/cursorless-engine/src/actions/GenerateSnippet/GenerateSnippet.ts
+++ b/packages/cursorless-engine/src/actions/GenerateSnippet/GenerateSnippet.ts
@@ -1,4 +1,4 @@
-import { FlashStyle, isTesting, Range } from "@cursorless/common";
+import { FlashStyle, Range, isTesting } from "@cursorless/common";
 import { Offsets } from "../../processTargets/modifiers/surroundingPair/types";
 import { ide } from "../../singletons/ide.singleton";
 import { Target } from "../../typings/target.types";
@@ -220,7 +220,7 @@ export default class GenerateSnippet {
 
     const editableEditor = ide().getEditableTextEditor(editor);
 
-    if (isTesting()) {
+    if (isTesting(ide())) {
       // If we're testing, we just overwrite the current document
       await editableEditor.setSelections([
         editor.document.range.toSelection(false),

--- a/packages/cursorless-vscode/src/ide/vscode/VscodeEnabledHatStyleManager.ts
+++ b/packages/cursorless-vscode/src/ide/vscode/VscodeEnabledHatStyleManager.ts
@@ -1,13 +1,17 @@
-import { isTesting } from "@cursorless/common";
+import {
+  HatStyleInfo,
+  HatStyleMap,
+  Listener,
+  Notifier,
+  isTesting,
+} from "@cursorless/common";
 import { pickBy } from "lodash";
 import * as vscode from "vscode";
-import { HatStyleInfo, HatStyleMap } from "@cursorless/common";
-import { Listener, Notifier } from "@cursorless/common";
 import {
-  HatColor,
-  HatShape,
   HAT_COLORS,
   HAT_NON_DEFAULT_SHAPES,
+  HatColor,
+  HatShape,
   VscodeHatStyleName,
 } from "./hatStyles.types";
 

--- a/packages/cursorless-vscode/src/registerCommands.ts
+++ b/packages/cursorless-vscode/src/registerCommands.ts
@@ -35,7 +35,7 @@ export function registerCommands(
       try {
         return await commandApi.runCommandSafe(...args);
       } catch (e) {
-        if (!isTesting()) {
+        if (!isTesting(vscodeIde)) {
           const err = e as Error;
           console.error(err.stack);
           vscodeIde.handleCommandError(err);


### PR DESCRIPTION

## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet

I initially wanted to get rid of `isTesting()` entirely an only rely on `ide.runMode === "test"` and `ide.runMode === "production"` but it seems that some tests actually don't run as vscode extensions we need the `CURSORLESS_TEST` environment variable (see `launch.json`)

I thought about moving the `isTesting()` to `cursorless-engine` since it holds the ide and export that specific function to the rest of the world. However there is at least one instance of `isTesting()` in a package that doesn't import `cursorless-engine` (`packages\cursorless-vscode\src\ide\vscode\VscodeEnabledHatStyleManager.ts`) so we can't do that. 

That is why I came up with this following approach, even though I'm not entirely happy about it. I can't think about any better way, but at least I think it's better than the current way.  

it is all the more not ideal because for neovim I'm using `CURSORLESS_MODE` set to `development` or `test` to set the neovimIde.runMode since it's not given by vscode. consequently I'm never gonna use `isTesting()`. Consequently we could potentially move this one to vscode specific packages. 