### PR TITLE
enable user.cursorless tag for "neovim" app

### DIFF
--- a/cursorless-talon/src/apps/cursorless_neovim.py
+++ b/cursorless-talon/src/apps/cursorless_neovim.py
@@ -1,0 +1,9 @@
+from talon import Context
+
+ctx = Context()
+
+ctx.matches = r"""
+app: neovim
+"""
+
+ctx.tags = ["user.cursorless"]


### PR DESCRIPTION

## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet

Pushing this file only to allow others to beta test the already packaged cursorless for neovim from https://github.com/hands-free-vim/talon.nvim/tree/beta without having to add the file manually.

Note that the app is "neovim" so it won't trigger any side effect with community which uses the "vim" app only. And the "neovim" app is only defined in https://github.com/hands-free-vim/neovim-talon so it is safe to merge now imho.