### PR TITLE
Fix keyboard broken by #2235

### DIFF
--- a/data/fixtures/recorded/fallback/takeToken2.yml
+++ b/data/fixtures/recorded/fallback/takeToken2.yml
@@ -1,0 +1,24 @@
+languageId: plaintext
+focusedElementType: textEditor
+command:
+  version: 7
+  spokenForm: take token
+  action:
+    name: setSelection
+    target:
+      type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: token}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: foo
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  marks: {}
+finalState:
+  documentContents: foo
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 3}

--- a/packages/common/src/FakeCommandServerApi.ts
+++ b/packages/common/src/FakeCommandServerApi.ts
@@ -10,7 +10,6 @@ export class FakeCommandServerApi implements CommandServerApi {
 
   constructor() {
     this.signals = { prePhrase: { getVersion: async () => null } };
-    this.focusedElementType = "textEditor";
   }
 
   async getFocusedElementType(): Promise<FocusedElementType | undefined> {

--- a/packages/common/src/types/CommandServerApi.ts
+++ b/packages/common/src/types/CommandServerApi.ts
@@ -9,7 +9,7 @@ export interface CommandServerApi {
   };
 }
 
-export type FocusedElementType = "textEditor" | "terminal";
+export type FocusedElementType = "textEditor" | "terminal" | "other";
 
 export interface InboundSignal {
   getVersion(): Promise<string | null>;

--- a/packages/common/src/types/TestCaseFixture.ts
+++ b/packages/common/src/types/TestCaseFixture.ts
@@ -15,7 +15,7 @@ interface TestCaseFixtureBase {
   /**
    * The type of element that is focused before the command is executed. If undefined default to text editor.
    */
-  focusedElementType?: FocusedElementType | "other";
+  focusedElementType?: FocusedElementType;
 
   /**
    * A list of marks to check in the case of navigation map test otherwise undefined

--- a/packages/cursorless-engine/src/core/getCommandFallback.ts
+++ b/packages/cursorless-engine/src/core/getCommandFallback.ts
@@ -14,10 +14,9 @@ export async function getCommandFallback(
   runAction: (actionDescriptor: ActionDescriptor) => Promise<ActionReturnValue>,
   command: CommandComplete,
 ): Promise<Fallback | null> {
-  if (
-    commandServerApi == null ||
-    (await commandServerApi.getFocusedElementType()) === "textEditor"
-  ) {
+  const focusedElementType = await commandServerApi?.getFocusedElementType();
+
+  if (focusedElementType == null || focusedElementType === "textEditor") {
     return null;
   }
 

--- a/packages/cursorless-engine/src/testCaseRecorder/TestCase.ts
+++ b/packages/cursorless-engine/src/testCaseRecorder/TestCase.ts
@@ -141,9 +141,9 @@ export class TestCase {
     const fixture: EnforceUndefined<TestCaseFixture> = {
       languageId: this.languageId,
       focusedElementType:
-        this.focusedElementType !== "textEditor"
-          ? this.focusedElementType ?? "other"
-          : undefined,
+        this.focusedElementType === "textEditor"
+          ? undefined
+          : this.focusedElementType,
       postEditorOpenSleepTimeMs: undefined,
       postCommandSleepTimeMs: undefined,
       command: this.command,

--- a/packages/cursorless-vscode-e2e/src/endToEndTestSetup.ts
+++ b/packages/cursorless-vscode-e2e/src/endToEndTestSetup.ts
@@ -28,7 +28,9 @@ export function endToEndTestSetup(suite: Mocha.Suite) {
     const title = this.test!.fullTitle();
     retryCount = title === previousTestTitle ? retryCount + 1 : 0;
     previousTestTitle = title;
-    ({ ide, injectIde } = (await getCursorlessApi()).testHelpers!);
+    const testHelpers = (await getCursorlessApi()).testHelpers!;
+    ({ ide, injectIde } = testHelpers);
+    testHelpers.commandServerApi.setFocusedElementType(undefined);
     spy = new SpyIDE(ide);
     injectIde(spy);
   });

--- a/packages/cursorless-vscode-e2e/src/suite/recorded.vscode.test.ts
+++ b/packages/cursorless-vscode-e2e/src/suite/recorded.vscode.test.ts
@@ -104,11 +104,7 @@ async function runTest(file: string, spyIde: SpyIDE) {
     // spyIde.clipboard.writeText(fixture.initialState.clipboard);
   }
 
-  commandServerApi.setFocusedElementType(
-    fixture.focusedElementType === "other"
-      ? undefined
-      : fixture.focusedElementType ?? "textEditor",
-  );
+  commandServerApi.setFocusedElementType(fixture.focusedElementType);
 
   // Ensure that the expected hats are present
   await hatTokenMap.allocateHats(


### PR DESCRIPTION
This was not caught by our tests because we mock away command server. Not sure how catch this sort of thing in our tests; it's one of the hazards of mocking

This PR introduces a more robust approach, where `undefined` means that we don't know which element is focused, either because there is no command server, or we have not been called by the command server

- See also https://github.com/pokey/command-server/pull/25

## Checklist

- [-] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [-] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [-] I have not broken the cheatsheet
