### PR TITLE
Attempt to make macOS CI more robust

### DIFF
--- a/packages/cursorless-vscode-e2e/src/suite/scopeProvider/assertCalledWithScopeInfo.ts
+++ b/packages/cursorless-vscode-e2e/src/suite/scopeProvider/assertCalledWithScopeInfo.ts
@@ -8,7 +8,7 @@ export async function assertCalledWithScopeInfo<T extends ScopeTypeInfo>(
   fake: sinon.SinonSpy<[scopeInfos: T[]], void>,
   ...expectedScopeInfos: T[]
 ) {
-  await sleepWithBackoff(25);
+  await sleepWithBackoff(100);
   sinon.assert.called(fake);
 
   for (const expectedScopeInfo of expectedScopeInfos) {
@@ -26,7 +26,7 @@ export async function assertCalledWithoutScopeInfo<T extends ScopeTypeInfo>(
   fake: sinon.SinonSpy<[scopeInfos: T[]], void>,
   ...scopeTypes: ScopeType[]
 ) {
-  await sleepWithBackoff(25);
+  await sleepWithBackoff(100);
   sinon.assert.called(fake);
 
   for (const scopeType of scopeTypes) {

--- a/packages/cursorless-vscode-e2e/src/suite/scopeProvider/runCustomRegexScopeInfoTest.ts
+++ b/packages/cursorless-vscode-e2e/src/suite/scopeProvider/runCustomRegexScopeInfoTest.ts
@@ -8,7 +8,6 @@ import { getCursorlessApi, openNewEditor } from "@cursorless/vscode-common";
 import { stat, unlink, writeFile } from "fs/promises";
 import * as sinon from "sinon";
 import { commands } from "vscode";
-import { sleepWithBackoff } from "../../endToEndTestSetup";
 import {
   assertCalledWithScopeInfo,
   assertCalledWithoutScopeInfo,
@@ -35,14 +34,12 @@ export async function runCustomRegexScopeInfoTest() {
       cursorlessTalonStateJsonPath,
       JSON.stringify(spokenFormJsonContents),
     );
-    await sleepWithBackoff(50);
     await assertCalledWithScopeInfo(fake, unsupported);
 
     await openNewEditor(contents);
     await assertCalledWithScopeInfo(fake, present);
 
     await unlink(cursorlessTalonStateJsonPath);
-    await sleepWithBackoff(100);
     await assertCalledWithoutScopeInfo(fake, scopeType);
   } finally {
     disposable.dispose();

--- a/packages/cursorless-vscode-e2e/src/suite/scopeProvider/runCustomSpokenFormScopeInfoTest.ts
+++ b/packages/cursorless-vscode-e2e/src/suite/scopeProvider/runCustomSpokenFormScopeInfoTest.ts
@@ -3,7 +3,6 @@ import { ScopeTypeInfo, sleep } from "@cursorless/common";
 import * as sinon from "sinon";
 import { assertCalledWithScopeInfo } from "./assertCalledWithScopeInfo";
 import { stat, unlink, writeFile } from "fs/promises";
-import { sleepWithBackoff } from "../../endToEndTestSetup";
 
 /**
  * Tests that the scope provider correctly reports custom spoken forms
@@ -31,7 +30,6 @@ export async function runCustomSpokenFormScopeInfoTest() {
       cursorlessTalonStateJsonPath,
       JSON.stringify(spokenFormJsonContents),
     );
-    await sleepWithBackoff(50);
     await assertCalledWithScopeInfo(
       fake,
       subjectCustom,
@@ -43,7 +41,6 @@ export async function runCustomSpokenFormScopeInfoTest() {
     );
 
     await unlink(cursorlessTalonStateJsonPath);
-    await sleepWithBackoff(100);
     await assertCalledWithScopeInfo(
       fake,
       roundStandard,


### PR DESCRIPTION
Just tuned / cleaned up the sleeps for our custom spoken forms tests. Mac tests passed 3 times in a row, which seems unlikely by chance given current unreliability, so I'd be tempted to ship it. Tempted to mock filesystem to make it faster / more robust, but that's work, and gives us slightly less confidence

## Checklist

- [-] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [-] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [-] I have not broken the cheatsheet
