### PR TITLE
Make `Forbid TODOs` check into its own CI step

### DIFF
--- a/.github/workflows/forbid-todo.yml
+++ b/.github/workflows/forbid-todo.yml
@@ -1,0 +1,15 @@
+name: Forbid TODO
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  merge_group:
+    branches: [main]
+
+jobs:
+  forbid-todo:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Forbid TODO
+        run: ./scripts/forbid-todo.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,5 +72,3 @@ jobs:
           name: dumps
           path: ${{ env.VSCODE_CRASH_DIR }}
         if: failure()
-      - name: Forbid TODOs
-        run: ./scripts/forbid-todo.sh

--- a/scripts/forbid-todo.sh
+++ b/scripts/forbid-todo.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 # Find the string 'TODO' in all files tracked by git, excluding
 # this file
-TODOS_FOUND=$(git grep --color=always -nw TODO -- ':!scripts/forbid-todo.sh' || true)
+TODOS_FOUND=$(git grep --color=always -nw TODO -- ':!scripts/forbid-todo.sh' ':!.github/workflows/forbid-todo.yml' || true)
 
 if [ -n "$TODOS_FOUND" ]; then
   printf "\e[1;31mERROR: \e[0mTODOs found in codebase:\n"


### PR DESCRIPTION
- Fixes #2180

## Checklist

- [-] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [-] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [-] I have not broken the cheatsheet
