### PR TITLE
typescript: Support "value" for type alias

### DIFF
--- a/data/fixtures/scopes/typescript.core/value.typeAlias.scope
+++ b/data/fixtures/scopes/typescript.core/value.typeAlias.scope
@@ -1,0 +1,20 @@
+type Aaa = Bbb;
+---
+
+[Content] = 0:11-0:14
+             >---<
+0| type Aaa = Bbb;
+
+[Removal] = 0:10-0:14
+            >----<
+0| type Aaa = Bbb;
+
+[Leading delimiter] = 0:10-0:11
+            >-<
+0| type Aaa = Bbb;
+
+[Domain] = 0:0-0:15
+  >---------------<
+0| type Aaa = Bbb;
+
+[Insertion delimiter] = " "

--- a/data/fixtures/scopes/typescript.core/value.typeAlias2.scope
+++ b/data/fixtures/scopes/typescript.core/value.typeAlias2.scope
@@ -1,0 +1,20 @@
+export type Aaa = Bbb;
+---
+
+[Content] = 0:18-0:21
+                    >---<
+0| export type Aaa = Bbb;
+
+[Removal] = 0:17-0:21
+                   >----<
+0| export type Aaa = Bbb;
+
+[Leading delimiter] = 0:17-0:18
+                   >-<
+0| export type Aaa = Bbb;
+
+[Domain] = 0:0-0:22
+  >----------------------<
+0| export type Aaa = Bbb;
+
+[Insertion delimiter] = " "

--- a/packages/common/src/scopeSupportFacets/scopeSupportFacetInfos.ts
+++ b/packages/common/src/scopeSupportFacets/scopeSupportFacetInfos.ts
@@ -376,6 +376,10 @@ export const scopeSupportFacetInfos: Record<
     scopeType: "value",
     isIteration: true,
   },
+  "value.typeAlias": {
+    description: "Value of a type alias declaration",
+    scopeType: "value",
+  },
 
   "type.variable": {
     description: "Type of variable in a variable declaration",

--- a/packages/common/src/scopeSupportFacets/scopeSupportFacets.types.ts
+++ b/packages/common/src/scopeSupportFacets/scopeSupportFacets.types.ts
@@ -95,6 +95,7 @@ const scopeSupportFacets = [
   "value.resource.iteration",
   "value.argument.formal",
   "value.argument.formal.iteration",
+  "value.typeAlias",
 
   "type.variable",
   "type.formalParameter",

--- a/packages/common/src/scopeSupportFacets/typescript.ts
+++ b/packages/common/src/scopeSupportFacets/typescript.ts
@@ -19,5 +19,6 @@ export const typescriptScopeSupport: LanguageScopeSupportFacetMap = {
   "type.alias": supported,
   "name.field": supported,
   "value.field": supported,
+  "value.typeAlias": supported,
   "type.cast": supported,
 };

--- a/queries/typescript.core.scm
+++ b/queries/typescript.core.scm
@@ -85,6 +85,18 @@
   ";"? @_.domain.end
 )
 
+(
+  (type_alias_declaration
+    value: (_) @value
+  ) @_.domain
+  (#not-parent-type? @_.domain export_statement)
+)
+(export_statement
+  (type_alias_declaration
+    value: (_) @value
+  )
+) @_.domain
+
 [
   (interface_declaration)
   (object_type)


### PR DESCRIPTION
I wouldn't say I feel super strongly, but it looked like "value" to my brain so I tried to use "value" here

## Checklist

- [x] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [-] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [-] I have not broken the cheatsheet
