### PR TITLE
keyboard: Support "inside" and "bounds"

### DIFF
--- a/packages/cursorless-vscode-e2e/src/suite/keyboard/basic.vscode.test.ts
+++ b/packages/cursorless-vscode-e2e/src/suite/keyboard/basic.vscode.test.ts
@@ -63,6 +63,13 @@ const testCases: TestCase[] = [
     finalContent: "a +  + b",
   },
   {
+    name: "inside",
+    initialContent: "(aaa)",
+    // change inside air
+    keySequence: ["da", "mi", "c"],
+    finalContent: "()",
+  },
+  {
     name: "wrap",
     initialContent: "a",
     // round wrap air

--- a/packages/cursorless-vscode/src/keyboard/TokenTypes.ts
+++ b/packages/cursorless-vscode/src/keyboard/TokenTypes.ts
@@ -20,7 +20,7 @@ export interface SectionTypes {
   vscodeCommand: ModalVscodeCommandDescriptor;
   modifier: ModifierType;
 }
-type ModifierType = "nextPrev" | "every";
+type ModifierType = "nextPrev" | "every" | "interiorOnly" | "excludeInterior";
 export type MiscValue =
   | "combineColorAndShape"
   | "makeRange"
@@ -65,6 +65,7 @@ export interface TokenTypeValueMap {
   // modifier config section
   nextPrev: "nextPrev";
   every: "every";
+  simpleModifier: "interiorOnly" | "excludeInterior";
 
   digit: number;
 }

--- a/packages/cursorless-vscode/src/keyboard/getTokenTypeKeyMaps.ts
+++ b/packages/cursorless-vscode/src/keyboard/getTokenTypeKeyMaps.ts
@@ -68,6 +68,11 @@ export function getTokenTypeKeyMaps(
     // modifier config section
     every: config.getTokenKeyMap("every", "modifier", only("every")),
     nextPrev: config.getTokenKeyMap("nextPrev", "modifier", only("nextPrev")),
+    simpleModifier: config.getTokenKeyMap(
+      "simpleModifier",
+      "modifier",
+      only("interiorOnly", "excludeInterior"),
+    ),
 
     digit: Object.fromEntries(
       range(10).map((value) => [

--- a/packages/cursorless-vscode/src/keyboard/grammar/generated/grammar.ts
+++ b/packages/cursorless-vscode/src/keyboard/grammar/generated/grammar.ts
@@ -9,6 +9,7 @@ declare var simpleAction: any;
 declare var wrap: any;
 declare var pairedDelimiter: any;
 declare var vscodeCommand: any;
+declare var simpleModifier: any;
 declare var every: any;
 declare var nextPrev: any;
 declare var simpleScopeTypeType: any;
@@ -69,6 +70,7 @@ const grammar: Grammar = {
         command("performWrapActionOnTarget", ["actionDescriptor", "delimiter"])
         },
     {"name": "main", "symbols": [(keyboardLexer.has("vscodeCommand") ? {type: "vscodeCommand"} : vscodeCommand)], "postprocess": command("vscodeCommand", ["command"])},
+    {"name": "modifier", "symbols": [(keyboardLexer.has("simpleModifier") ? {type: "simpleModifier"} : simpleModifier)], "postprocess": capture({ type: $0 })},
     {"name": "modifier", "symbols": ["scopeType"], "postprocess": capture({ type: "containingScope", scopeType: $0 })},
     {"name": "modifier", "symbols": [(keyboardLexer.has("every") ? {type: "every"} : every), "scopeType"], "postprocess": capture({ type: "everyScope", scopeType: $1 })},
     {"name": "modifier$ebnf$1", "symbols": ["offset"], "postprocess": id},

--- a/packages/cursorless-vscode/src/keyboard/grammar/grammar.ne
+++ b/packages/cursorless-vscode/src/keyboard/grammar/grammar.ne
@@ -47,6 +47,9 @@ main -> %vscodeCommand {% command("vscodeCommand", ["command"]) %}
 
 # --------------------------- Modifiers ---------------------------
 
+# "inside", "bounds"
+modifier -> %simpleModifier {% capture({ type: $0 }) %}
+
 # "funk"
 modifier -> scopeType {% capture({ type: "containingScope", scopeType: $0 }) %}
 

--- a/packages/cursorless-vscode/src/keyboard/grammar/grammar.test.ts
+++ b/packages/cursorless-vscode/src/keyboard/grammar/grammar.test.ts
@@ -129,6 +129,17 @@ const testCases: TestCase[] = [
     },
   },
   {
+    tokens: [{ type: "simpleModifier", value: "excludeInterior" }],
+    expected: {
+      arg: {
+        modifier: {
+          type: "excludeInterior",
+        },
+      },
+      type: "modifyTarget",
+    },
+  },
+  {
     tokens: [
       {
         type: "vscodeCommand",

--- a/packages/cursorless-vscode/src/keyboard/keyboard-config.fixture.json
+++ b/packages/cursorless-vscode/src/keyboard/keyboard-config.fixture.json
@@ -67,7 +67,9 @@
   },
   "cursorless.experimental.keyboard.modal.keybindings.modifier": {
     "n": "nextPrev",
-    "*": "every"
+    "*": "every",
+    "mi": "interiorOnly",
+    "mb": "excludeInterior"
   },
   "cursorless.experimental.keyboard.modal.keybindings.vscodeCommand": {
     "va": "editor.action.addCommentLine",


### PR DESCRIPTION
- Fixes https://github.com/cursorless-dev/cursorless/issues/993

## Checklist

- [x] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [-] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [-] I have not broken the cheatsheet
