### PR TITLE
keyboard: Have keyboard target follow selection if it moves

### DIFF
--- a/packages/common/src/ide/normalized/NormalizedIDE.ts
+++ b/packages/common/src/ide/normalized/NormalizedIDE.ts
@@ -47,6 +47,7 @@ export class NormalizedIDE extends PassthroughIDEBase {
         "experimental.hatStability",
       ),
       snippetsDir: getFixturePath("cursorless-snippets"),
+      keyboardTargetFollowsSelection: false,
     });
   }
 

--- a/packages/common/src/ide/types/Configuration.ts
+++ b/packages/common/src/ide/types/Configuration.ts
@@ -6,7 +6,11 @@ import { GetFieldType, Paths } from "./Paths";
 export type CursorlessConfiguration = {
   tokenHatSplittingMode: TokenHatSplittingMode;
   wordSeparators: string[];
-  experimental: { snippetsDir: string | undefined; hatStability: HatStability };
+  experimental: {
+    snippetsDir: string | undefined;
+    hatStability: HatStability;
+    keyboardTargetFollowsSelection: boolean;
+  };
   decorationDebounceDelayMs: number;
   commandHistory: boolean;
   debug: boolean;
@@ -26,6 +30,7 @@ export const CONFIGURATION_DEFAULTS: CursorlessConfiguration = {
   experimental: {
     snippetsDir: undefined,
     hatStability: HatStability.balanced,
+    keyboardTargetFollowsSelection: false,
   },
   commandHistory: false,
   debug: false,

--- a/packages/cursorless-engine/src/KeyboardTargetUpdater.ts
+++ b/packages/cursorless-engine/src/KeyboardTargetUpdater.ts
@@ -1,0 +1,44 @@
+import { Disposable } from "@cursorless/common";
+import { StoredTargetMap } from "./core/StoredTargets";
+import { ide } from "./singletons/ide.singleton";
+import { Debouncer } from "./core/Debouncer";
+import { PlainTarget } from "./processTargets/targets";
+
+export class KeyboardTargetUpdater {
+  private disposables: Disposable[] = [];
+
+  constructor(private storedTargets: StoredTargetMap) {
+    const debouncer = new Debouncer(() => this.updateKeyboardTarget());
+
+    this.disposables.push(
+      // An Event which fires when the selection in an editor has changed.
+      ide().onDidChangeTextEditorSelection(debouncer.run),
+
+      debouncer,
+    );
+  }
+
+  private updateKeyboardTarget() {
+    const activeEditor = ide().activeTextEditor;
+
+    if (activeEditor == null || this.storedTargets.get("keyboard") == null) {
+      return;
+    }
+
+    this.storedTargets.set(
+      "keyboard",
+      activeEditor.selections.map(
+        (selection) =>
+          new PlainTarget({
+            contentRange: selection,
+            editor: activeEditor,
+            isReversed: selection.isReversed,
+          }),
+      ),
+    );
+  }
+
+  dispose() {
+    this.disposables.forEach((disposable) => disposable.dispose());
+  }
+}

--- a/packages/cursorless-engine/src/KeyboardTargetUpdater.ts
+++ b/packages/cursorless-engine/src/KeyboardTargetUpdater.ts
@@ -1,21 +1,45 @@
 import { Disposable } from "@cursorless/common";
-import { StoredTargetMap } from "./core/StoredTargets";
-import { ide } from "./singletons/ide.singleton";
 import { Debouncer } from "./core/Debouncer";
+import { StoredTargetMap } from "./core/StoredTargets";
 import { PlainTarget } from "./processTargets/targets";
+import { ide } from "./singletons/ide.singleton";
 
 export class KeyboardTargetUpdater {
   private disposables: Disposable[] = [];
+  private selectionWatcherDisposable: Disposable | undefined;
+  private debouncer: Debouncer;
 
   constructor(private storedTargets: StoredTargetMap) {
-    const debouncer = new Debouncer(() => this.updateKeyboardTarget());
+    this.debouncer = new Debouncer(() => this.updateKeyboardTarget());
 
     this.disposables.push(
-      // An Event which fires when the selection in an editor has changed.
-      ide().onDidChangeTextEditorSelection(debouncer.run),
+      ide().configuration.onDidChangeConfiguration(() => this.maybeActivate()),
 
-      debouncer,
+      this.debouncer,
     );
+
+    this.maybeActivate();
+  }
+
+  maybeActivate(): void {
+    const isActive = ide().configuration.getOwnConfiguration(
+      "experimental.keyboardTargetFollowsSelection",
+    );
+
+    if (isActive) {
+      if (this.selectionWatcherDisposable == null) {
+        this.selectionWatcherDisposable = ide().onDidChangeTextEditorSelection(
+          this.debouncer.run,
+        );
+      }
+
+      return;
+    }
+
+    if (this.selectionWatcherDisposable != null) {
+      this.selectionWatcherDisposable.dispose();
+      this.selectionWatcherDisposable = undefined;
+    }
   }
 
   private updateKeyboardTarget() {
@@ -40,5 +64,6 @@ export class KeyboardTargetUpdater {
 
   dispose() {
     this.disposables.forEach((disposable) => disposable.dispose());
+    this.selectionWatcherDisposable?.dispose();
   }
 }

--- a/packages/cursorless-engine/src/cursorlessEngine.ts
+++ b/packages/cursorless-engine/src/cursorlessEngine.ts
@@ -30,6 +30,7 @@ import { ScopeSupportChecker } from "./scopeProviders/ScopeSupportChecker";
 import { ScopeSupportWatcher } from "./scopeProviders/ScopeSupportWatcher";
 import { injectIde } from "./singletons/ide.singleton";
 import { TreeSitter } from "./typings/TreeSitter";
+import { KeyboardTargetUpdater } from "./KeyboardTargetUpdater";
 
 export async function createCursorlessEngine(
   treeSitter: TreeSitter,
@@ -57,6 +58,8 @@ export async function createCursorlessEngine(
 
   const storedTargets = new StoredTargetMap();
 
+  const keyboardTargetUpdater = new KeyboardTargetUpdater(storedTargets);
+
   const languageDefinitions = new LanguageDefinitions(fileSystem, treeSitter);
   await languageDefinitions.init();
 
@@ -66,7 +69,13 @@ export async function createCursorlessEngine(
     talonSpokenForms,
   );
 
-  ide.disposeOnExit(rangeUpdater, languageDefinitions, hatTokenMap, debug);
+  ide.disposeOnExit(
+    rangeUpdater,
+    languageDefinitions,
+    hatTokenMap,
+    debug,
+    keyboardTargetUpdater,
+  );
 
   const commandRunnerDecorators: CommandRunnerDecorator[] = [];
 


### PR DESCRIPTION
- Fixes https://github.com/cursorless-dev/cursorless/issues/2421

This is experimental, and currently guarded by a hidden setting. To activate this behaviour, add the following to your vscode `settings.json`:

```json
  "cursorless.experimental.keyboardTargetFollowsSelection": true,
```

Note that it is debounced, so the pink highlight will lag slightly. We could change that but I was worried it might slow down cursor movement

## Checklist

- [-] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [-] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [-] I have not broken the cheatsheet
