### PR TITLE
Make "inside" fall back to pair when the target doesn't have an interior

### DIFF
--- a/data/fixtures/recorded/implicitExpansion/clearBoundsToken.yml
+++ b/data/fixtures/recorded/implicitExpansion/clearBoundsToken.yml
@@ -16,4 +16,10 @@ initialState:
     - anchor: {line: 0, character: 1}
       active: {line: 0, character: 1}
   marks: {}
-thrownError: {name: NoContainingScopeError}
+finalState:
+  documentContents: aaa
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+    - anchor: {line: 0, character: 3}
+      active: {line: 0, character: 3}

--- a/data/fixtures/recorded/implicitExpansion/clearCoreToken.yml
+++ b/data/fixtures/recorded/implicitExpansion/clearCoreToken.yml
@@ -16,4 +16,8 @@ initialState:
     - anchor: {line: 0, character: 1}
       active: {line: 0, character: 1}
   marks: {}
-thrownError: {name: NoContainingScopeError}
+finalState:
+  documentContents: ()
+  selections:
+    - anchor: {line: 0, character: 1}
+      active: {line: 0, character: 1}

--- a/data/fixtures/recorded/implicitExpansion/squareSwitchFunk.yml
+++ b/data/fixtures/recorded/implicitExpansion/squareSwitchFunk.yml
@@ -22,4 +22,13 @@ initialState:
     - anchor: {line: 2, character: 7}
       active: {line: 2, character: 7}
   marks: {}
-thrownError: {name: NoContainingScopeError}
+finalState:
+  documentContents: |-
+    [
+      function myFunk() {
+        // aaa
+      }
+    ]
+  selections:
+    - anchor: {line: 2, character: 7}
+      active: {line: 2, character: 7}

--- a/data/fixtures/recorded/modifiers/changeBoundsValue.yml
+++ b/data/fixtures/recorded/modifiers/changeBoundsValue.yml
@@ -1,0 +1,32 @@
+languageId: typescript
+command:
+  version: 7
+  spokenForm: change bounds value
+  action:
+    name: clearAndSetSelection
+    target:
+      type: primitive
+      modifiers:
+        - {type: excludeInterior}
+        - type: containingScope
+          scopeType: {type: value}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    const aaa = {
+        bbb: "ccc ddd"
+    }
+  selections:
+    - anchor: {line: 1, character: 4}
+      active: {line: 1, character: 4}
+  marks: {}
+finalState:
+  documentContents: |-
+    const aaa = {
+        bbb: ccc ddd
+    }
+  selections:
+    - anchor: {line: 1, character: 9}
+      active: {line: 1, character: 9}
+    - anchor: {line: 1, character: 16}
+      active: {line: 1, character: 16}

--- a/data/fixtures/recorded/modifiers/changeInsideValue.yml
+++ b/data/fixtures/recorded/modifiers/changeInsideValue.yml
@@ -1,0 +1,30 @@
+languageId: typescript
+command:
+  version: 7
+  spokenForm: change inside value
+  action:
+    name: clearAndSetSelection
+    target:
+      type: primitive
+      modifiers:
+        - {type: interiorOnly}
+        - type: containingScope
+          scopeType: {type: value}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    const aaa = {
+        bbb: "ccc ddd"
+    }
+  selections:
+    - anchor: {line: 1, character: 4}
+      active: {line: 1, character: 4}
+  marks: {}
+finalState:
+  documentContents: |-
+    const aaa = {
+        bbb: ""
+    }
+  selections:
+    - anchor: {line: 1, character: 10}
+      active: {line: 1, character: 10}

--- a/packages/cursorless-engine/src/actions/Rewrap.ts
+++ b/packages/cursorless-engine/src/actions/Rewrap.ts
@@ -32,7 +32,11 @@ export default class Rewrap {
     right: string,
   ): Promise<ActionReturnValue> {
     const boundaryTargets = targets.flatMap((target) => {
-      const boundary = target.getBoundaryStrict();
+      const boundary = target.getBoundary();
+
+      if (boundary == null) {
+        throw Error("Target must have a boundary");
+      }
 
       if (boundary.length !== 2) {
         throw Error("Target must have an opening and closing delimiter");

--- a/packages/cursorless-engine/src/actions/Rewrap.ts
+++ b/packages/cursorless-engine/src/actions/Rewrap.ts
@@ -2,7 +2,6 @@ import { FlashStyle } from "@cursorless/common";
 import { RangeUpdater } from "../core/updateSelections/RangeUpdater";
 import { performEditsAndUpdateRanges } from "../core/updateSelections/updateSelections";
 import { ModifierStageFactory } from "../processTargets/ModifierStageFactory";
-import { containingSurroundingPairIfUntypedModifier } from "../processTargets/modifiers/commonContainingScopeIfUntypedModifiers";
 import { ide } from "../singletons/ide.singleton";
 import { Target } from "../typings/target.types";
 import {
@@ -11,12 +10,11 @@ import {
   runOnTargetsForEachEditor,
 } from "../util/targetUtils";
 import { ActionReturnValue } from "./actions.types";
+import { getContainingSurroundingPairIfNoBoundaryStage } from "../processTargets/modifiers/InteriorStage";
 
 export default class Rewrap {
   getFinalStages = () => [
-    this.modifierStageFactory.create(
-      containingSurroundingPairIfUntypedModifier,
-    ),
+    getContainingSurroundingPairIfNoBoundaryStage(this.modifierStageFactory),
   ];
 
   constructor(
@@ -32,11 +30,7 @@ export default class Rewrap {
     right: string,
   ): Promise<ActionReturnValue> {
     const boundaryTargets = targets.flatMap((target) => {
-      const boundary = target.getBoundary();
-
-      if (boundary == null) {
-        throw Error("Target must have a boundary");
-      }
+      const boundary = target.getBoundary()!;
 
       if (boundary.length !== 2) {
         throw Error("Target must have an opening and closing delimiter");

--- a/packages/cursorless-engine/src/processTargets/modifiers/ConditionalModifierStages.ts
+++ b/packages/cursorless-engine/src/processTargets/modifiers/ConditionalModifierStages.ts
@@ -60,6 +60,24 @@ export class ModifyIfUntypedStage extends ConditionalModifierBaseStage {
 }
 
 /**
+ * Runs {@link ModifyIfUntypedModifier.modifier} if the target has no explicit
+ * scope type, ie if {@link Target.hasExplicitScopeType} is `false`.
+ */
+export class ModifyIfConditionStage extends ConditionalModifierBaseStage {
+  constructor(
+    modifierStageFactory: ModifierStageFactory,
+    nestedModifier: Modifier,
+    private modificationCondition: (target: Target) => boolean,
+  ) {
+    super(modifierStageFactory, nestedModifier);
+  }
+
+  protected shouldModify(target: Target): boolean {
+    return this.modificationCondition(target);
+  }
+}
+
+/**
  * Runs {@link nestedModifier} if
  * - the target has no explicit scope type, ie if
  *   {@link Target.hasExplicitScopeType} is `false`, and

--- a/packages/cursorless-engine/src/processTargets/modifiers/ConditionalModifierStages.ts
+++ b/packages/cursorless-engine/src/processTargets/modifiers/ConditionalModifierStages.ts
@@ -60,8 +60,7 @@ export class ModifyIfUntypedStage extends ConditionalModifierBaseStage {
 }
 
 /**
- * Runs {@link ModifyIfUntypedModifier.modifier} if the target has no explicit
- * scope type, ie if {@link Target.hasExplicitScopeType} is `false`.
+ * Runs {@link nestedModifier} if {@link modificationCondition} returns `true`.
  */
 export class ModifyIfConditionStage extends ConditionalModifierBaseStage {
   constructor(

--- a/packages/cursorless-engine/src/processTargets/modifiers/InteriorStage.ts
+++ b/packages/cursorless-engine/src/processTargets/modifiers/InteriorStage.ts
@@ -5,32 +5,51 @@ import {
 import { Target } from "../../typings/target.types";
 import { ModifierStageFactory } from "../ModifierStageFactory";
 import { ModifierStage } from "../PipelineStages.types";
-import { containingSurroundingPairIfUntypedModifier } from "./commonContainingScopeIfUntypedModifiers";
 
 export class InteriorOnlyStage implements ModifierStage {
+  private containingSurroundingPairModifierStage: ModifierStage;
+
   constructor(
     private modifierStageFactory: ModifierStageFactory,
     private modifier: InteriorOnlyModifier,
-  ) {}
+  ) {
+    this.containingSurroundingPairModifierStage =
+      this.modifierStageFactory.create({
+        type: "containingScope",
+        scopeType: { type: "surroundingPair", delimiter: "any" },
+      });
+  }
 
   run(target: Target): Target[] {
-    return this.modifierStageFactory
-      .create(containingSurroundingPairIfUntypedModifier)
-      .run(target)
-      .flatMap((target) => target.getInteriorStrict());
+    return (
+      target.getInterior() ??
+      this.containingSurroundingPairModifierStage
+        .run(target)
+        .flatMap((target) => target.getInterior()!)
+    );
   }
 }
 
 export class ExcludeInteriorStage implements ModifierStage {
+  private containingSurroundingPairModifierStage: ModifierStage;
+
   constructor(
     private modifierStageFactory: ModifierStageFactory,
     private modifier: ExcludeInteriorModifier,
-  ) {}
+  ) {
+    this.containingSurroundingPairModifierStage =
+      this.modifierStageFactory.create({
+        type: "containingScope",
+        scopeType: { type: "surroundingPair", delimiter: "any" },
+      });
+  }
 
   run(target: Target): Target[] {
-    return this.modifierStageFactory
-      .create(containingSurroundingPairIfUntypedModifier)
-      .run(target)
-      .flatMap((target) => target.getBoundaryStrict());
+    return (
+      target.getInterior() ??
+      this.containingSurroundingPairModifierStage
+        .run(target)
+        .flatMap((target) => target.getBoundary()!)
+    );
   }
 }

--- a/packages/cursorless-engine/src/processTargets/modifiers/InteriorStage.ts
+++ b/packages/cursorless-engine/src/processTargets/modifiers/InteriorStage.ts
@@ -5,51 +5,66 @@ import {
 import { Target } from "../../typings/target.types";
 import { ModifierStageFactory } from "../ModifierStageFactory";
 import { ModifierStage } from "../PipelineStages.types";
+import { ModifyIfConditionStage } from "./ConditionalModifierStages";
 
 export class InteriorOnlyStage implements ModifierStage {
-  private containingSurroundingPairModifierStage: ModifierStage;
+  private containingSurroundingPairIfNoInteriorStage: ModifierStage;
 
   constructor(
     private modifierStageFactory: ModifierStageFactory,
     private modifier: InteriorOnlyModifier,
   ) {
-    this.containingSurroundingPairModifierStage =
-      this.modifierStageFactory.create({
-        type: "containingScope",
-        scopeType: { type: "surroundingPair", delimiter: "any" },
-      });
+    this.containingSurroundingPairIfNoInteriorStage =
+      getContainingSurroundingPairIfNoInteriorStage(this.modifierStageFactory);
   }
 
   run(target: Target): Target[] {
-    return (
-      target.getInterior() ??
-      this.containingSurroundingPairModifierStage
-        .run(target)
-        .flatMap((target) => target.getInterior()!)
-    );
+    return this.containingSurroundingPairIfNoInteriorStage
+      .run(target)
+      .flatMap((target) => target.getInterior()!);
   }
 }
 
 export class ExcludeInteriorStage implements ModifierStage {
-  private containingSurroundingPairModifierStage: ModifierStage;
+  private containingSurroundingPairIfNoBoundaryStage: ModifierStage;
 
   constructor(
     private modifierStageFactory: ModifierStageFactory,
     private modifier: ExcludeInteriorModifier,
   ) {
-    this.containingSurroundingPairModifierStage =
-      this.modifierStageFactory.create({
-        type: "containingScope",
-        scopeType: { type: "surroundingPair", delimiter: "any" },
-      });
+    this.containingSurroundingPairIfNoBoundaryStage =
+      getContainingSurroundingPairIfNoBoundaryStage(this.modifierStageFactory);
   }
 
   run(target: Target): Target[] {
-    return (
-      target.getInterior() ??
-      this.containingSurroundingPairModifierStage
-        .run(target)
-        .flatMap((target) => target.getBoundary()!)
-    );
+    return this.containingSurroundingPairIfNoBoundaryStage
+      .run(target)
+      .flatMap((target) => target.getBoundary()!);
   }
+}
+
+function getContainingSurroundingPairIfNoInteriorStage(
+  modifierStageFactory: ModifierStageFactory,
+): ModifierStage {
+  return new ModifyIfConditionStage(
+    modifierStageFactory,
+    {
+      type: "containingScope",
+      scopeType: { type: "surroundingPair", delimiter: "any" },
+    },
+    (target) => target.getInterior() == null,
+  );
+}
+
+export function getContainingSurroundingPairIfNoBoundaryStage(
+  modifierStageFactory: ModifierStageFactory,
+): ModifierStage {
+  return new ModifyIfConditionStage(
+    modifierStageFactory,
+    {
+      type: "containingScope",
+      scopeType: { type: "surroundingPair", delimiter: "any" },
+    },
+    (target) => target.getBoundary() == null,
+  );
 }

--- a/packages/cursorless-engine/src/processTargets/modifiers/ItemStage/getIterationScope.ts
+++ b/packages/cursorless-engine/src/processTargets/modifiers/ItemStage/getIterationScope.ts
@@ -28,7 +28,7 @@ export function getIterationScope(
       )
     ) {
       return {
-        range: surroundingTarget.getInteriorStrict()[0].contentRange,
+        range: surroundingTarget.getInterior()[0].contentRange,
         boundary: getBoundary(surroundingTarget),
       };
     }
@@ -107,7 +107,7 @@ function useInteriorOfSurroundingTarget(
 }
 
 function getBoundary(surroundingTarget: SurroundingPairTarget): [Range, Range] {
-  return surroundingTarget.getBoundaryStrict().map((t) => t.contentRange) as [
+  return surroundingTarget.getBoundary().map((t) => t.contentRange) as [
     Range,
     Range,
   ];

--- a/packages/cursorless-engine/src/processTargets/modifiers/commonContainingScopeIfUntypedModifiers.ts
+++ b/packages/cursorless-engine/src/processTargets/modifiers/commonContainingScopeIfUntypedModifiers.ts
@@ -8,19 +8,6 @@ import { Modifier } from "@cursorless/common";
 import type { Target } from "../../typings/target.types";
 
 /**
- * Expands the given target to the nearest containing surrounding pair if the
- * target has no explicit scope type, ie if {@link Target.hasExplicitScopeType}
- * is `false`.
- */
-export const containingSurroundingPairIfUntypedModifier: Modifier = {
-  type: "modifyIfUntyped",
-  modifier: {
-    type: "containingScope",
-    scopeType: { type: "surroundingPair", delimiter: "any" },
-  },
-};
-
-/**
  * Expands the given target to the nearest containing line if the target has no
  * explicit scope type, ie if {@link Target.hasExplicitScopeType} is `false`.
  */

--- a/packages/cursorless-engine/src/processTargets/modifiers/scopeTypeStages/BoundedNonWhitespaceStage.ts
+++ b/packages/cursorless-engine/src/processTargets/modifiers/scopeTypeStages/BoundedNonWhitespaceStage.ts
@@ -42,7 +42,7 @@ export class BoundedNonWhitespaceSequenceStage implements ModifierStage {
 
     const targets = paintTargets.flatMap((paintTarget) => {
       const contentRange = paintTarget.contentRange.intersection(
-        pairInfo.getInteriorStrict()[0].contentRange,
+        pairInfo.getInterior()[0].contentRange,
       );
 
       if (contentRange == null || contentRange.isEmpty) {

--- a/packages/cursorless-engine/src/processTargets/targets/BaseTarget.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/BaseTarget.ts
@@ -4,7 +4,6 @@ import type {
   TargetPlainObject,
 } from "@cursorless/common";
 import {
-  NoContainingScopeError,
   Range,
   Selection,
   TextEditor,
@@ -107,11 +106,11 @@ export abstract class BaseTarget<
     return this.cloneWith({ contentRange });
   }
 
-  getInteriorStrict(): Target[] {
-    throw new NoContainingScopeError("interior");
+  getInterior(): Target[] | undefined {
+    return undefined;
   }
-  getBoundaryStrict(): Target[] {
-    throw new NoContainingScopeError("boundary");
+  getBoundary(): Target[] | undefined {
+    return undefined;
   }
 
   private cloneWith(parameters: CloneWithParameters) {

--- a/packages/cursorless-engine/src/processTargets/targets/DocumentTarget.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/DocumentTarget.ts
@@ -22,7 +22,7 @@ export class DocumentTarget extends BaseTarget<CommonTargetParameters> {
     return this.contentRange;
   }
 
-  getInteriorStrict() {
+  getInterior() {
     return [
       // Use plain target instead of interior target since we want the same content and removal range for a document interior.
       new PlainTarget({

--- a/packages/cursorless-engine/src/processTargets/targets/ScopeTypeTarget.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/ScopeTypeTarget.ts
@@ -78,9 +78,9 @@ export class ScopeTypeTarget extends BaseTarget<ScopeTypeTargetParameters> {
     return undefined;
   }
 
-  getInteriorStrict() {
+  getInterior() {
     if (this.interiorRange_ == null) {
-      return super.getInteriorStrict();
+      return super.getInterior();
     }
     return [
       new InteriorTarget({

--- a/packages/cursorless-engine/src/processTargets/targets/SurroundingPairTarget.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/SurroundingPairTarget.ts
@@ -47,7 +47,7 @@ export class SurroundingPairTarget extends BaseTarget<SurroundingPairTargetParam
     return getTokenRemovalRange(this);
   }
 
-  getInteriorStrict() {
+  getInterior() {
     return [
       new InteriorTarget({
         editor: this.editor,
@@ -57,7 +57,7 @@ export class SurroundingPairTarget extends BaseTarget<SurroundingPairTargetParam
     ];
   }
 
-  getBoundaryStrict() {
+  getBoundary() {
     return this.boundary_.map(
       (contentRange) =>
         new TokenTarget({

--- a/packages/cursorless-engine/src/scopeProviders/getTargetRanges.ts
+++ b/packages/cursorless-engine/src/scopeProviders/getTargetRanges.ts
@@ -1,5 +1,4 @@
 import {
-  NoContainingScopeError,
   TargetRanges,
   toCharacterRange,
   toLineRange,
@@ -7,28 +6,6 @@ import {
 import { Target } from "../typings/target.types";
 
 export function getTargetRanges(target: Target): TargetRanges {
-  const interior = (() => {
-    try {
-      return target.getInteriorStrict().map(getTargetRanges);
-    } catch (error) {
-      if (error instanceof NoContainingScopeError) {
-        return undefined;
-      }
-      throw error;
-    }
-  })();
-
-  const boundary = (() => {
-    try {
-      return target.getBoundaryStrict().map(getTargetRanges);
-    } catch (error) {
-      if (error instanceof NoContainingScopeError) {
-        return undefined;
-      }
-      throw error;
-    }
-  })();
-
   return {
     contentRange: target.contentRange,
     removalRange: target.getRemovalRange(),
@@ -37,8 +14,8 @@ export function getTargetRanges(target: Target): TargetRanges {
       : toCharacterRange(target.getRemovalHighlightRange()),
     leadingDelimiter: getOptionalTarget(target.getLeadingDelimiterTarget()),
     trailingDelimiter: getOptionalTarget(target.getTrailingDelimiterTarget()),
-    interior,
-    boundary,
+    interior: target.getInterior()?.map(getTargetRanges),
+    boundary: target.getBoundary()?.map(getTargetRanges),
     insertionDelimiter: target.insertionDelimiter,
   };
 }

--- a/packages/cursorless-engine/src/typings/target.types.ts
+++ b/packages/cursorless-engine/src/typings/target.types.ts
@@ -132,8 +132,8 @@ export interface Target {
   /** Internal target that should be used for the that mark */
   readonly thatTarget: Target;
 
-  getInteriorStrict(): Target[];
-  getBoundaryStrict(): Target[];
+  getInterior(): Target[] | undefined;
+  getBoundary(): Target[] | undefined;
   /** The range of the delimiter before the content selection */
   getLeadingDelimiterTarget(): Target | undefined;
   /** The range of the delimiter after the content selection */


### PR DESCRIPTION
This one bit me a lot. See the test case for what now works. Basically "inside value" when value is a string is the most common one

## Checklist

- [x] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [-] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [-] I have not broken the cheatsheet
