### PR TITLE
Keyboard cursor customization

### DIFF
--- a/packages/cursorless-vscode/package.json
+++ b/packages/cursorless-vscode/package.json
@@ -861,6 +861,18 @@
           "description": "Directory containing snippets for use in Cursorless",
           "type": "string"
         },
+        "cursorless.experimental.keyboard.modal.cursorStyle": {
+          "description": "Color to use for the additional cursor when in keyboard mode",
+          "type": "string",
+          "enum": [
+            "line",
+            "block",
+            "underline",
+            "lineThin",
+            "blockOutline",
+            "underlineThin"
+          ]
+        },
         "cursorless.experimental.keyboard.modal.keybindings.action": {
           "description": "Define modal keybindings for actions",
           "type": "object",
@@ -877,7 +889,7 @@
                   "editNew",
                   "editNewLineAfter",
                   "editNewLineBefore",
-                  "executeCommand",
+                  "exiecuteCommand",
                   "extractVariable",
                   "findInDocument",
                   "findInWorkspace",

--- a/packages/cursorless-vscode/package.json
+++ b/packages/cursorless-vscode/package.json
@@ -862,7 +862,7 @@
           "type": "string"
         },
         "cursorless.experimental.keyboard.modal.cursorStyle": {
-          "description": "Controls the style of the additional cursor when in cursorless keyboard mode",
+          "description": "Controls cursor style when in Cursorless keyboard mode",
           "type": "string",
           "enum": [
             "line",
@@ -871,7 +871,8 @@
             "line-thin",
             "block-outline",
             "underline-thin"
-          ]
+          ],
+          "default": "block-outline"
         },
         "cursorless.experimental.keyboard.modal.keybindings.action": {
           "description": "Define modal keybindings for actions",

--- a/packages/cursorless-vscode/package.json
+++ b/packages/cursorless-vscode/package.json
@@ -862,15 +862,15 @@
           "type": "string"
         },
         "cursorless.experimental.keyboard.modal.cursorStyle": {
-          "description": "Color to use for the additional cursor when in keyboard mode",
+          "description": "Controls the style of the additional cursor when in cursorless keyboard mode",
           "type": "string",
           "enum": [
             "line",
             "block",
             "underline",
-            "lineThin",
-            "blockOutline",
-            "underlineThin"
+            "line-thin",
+            "block-outline",
+            "underline-thin"
           ]
         },
         "cursorless.experimental.keyboard.modal.keybindings.action": {

--- a/packages/cursorless-vscode/package.json
+++ b/packages/cursorless-vscode/package.json
@@ -889,7 +889,7 @@
                   "editNew",
                   "editNewLineAfter",
                   "editNewLineBefore",
-                  "exiecuteCommand",
+                  "executeCommand",
                   "extractVariable",
                   "findInDocument",
                   "findInWorkspace",

--- a/packages/cursorless-vscode/src/keyboard/KeyboardCommandsModal.ts
+++ b/packages/cursorless-vscode/src/keyboard/KeyboardCommandsModal.ts
@@ -106,7 +106,6 @@ export default class KeyboardCommandsModal {
     this.currentLayer = layer;
   }
 
-
   modeOn = async () => {
     if (this.isModeOn()) {
       return;

--- a/packages/cursorless-vscode/src/keyboard/KeyboardCommandsModal.ts
+++ b/packages/cursorless-vscode/src/keyboard/KeyboardCommandsModal.ts
@@ -120,7 +120,7 @@ export default class KeyboardCommandsModal {
     this.inputDisposable = this.keyboardHandler.pushListener({
       handleInput: this.handleInput,
       displayOptions: {
-        cursorStyle: this.keyboardConfig.cursorStyle, 
+        cursorStyle: this.keyboardConfig.cursorStyle,
         whenClauseContext: "cursorless.keyboard.modal.mode",
         statusBarText: "Listening...",
       },

--- a/packages/cursorless-vscode/src/keyboard/KeyboardCommandsModal.ts
+++ b/packages/cursorless-vscode/src/keyboard/KeyboardCommandsModal.ts
@@ -120,7 +120,7 @@ export default class KeyboardCommandsModal {
     this.inputDisposable = this.keyboardHandler.pushListener({
       handleInput: this.handleInput,
       displayOptions: {
-        cursorStyle: vscode.TextEditorCursorStyle.BlockOutline,
+        cursorStyle: this.keyboardConfig.cursorStyle, 
         whenClauseContext: "cursorless.keyboard.modal.mode",
         statusBarText: "Listening...",
       },

--- a/packages/cursorless-vscode/src/keyboard/KeyboardCommandsModal.ts
+++ b/packages/cursorless-vscode/src/keyboard/KeyboardCommandsModal.ts
@@ -106,6 +106,7 @@ export default class KeyboardCommandsModal {
     this.currentLayer = layer;
   }
 
+
   modeOn = async () => {
     if (this.isModeOn()) {
       return;
@@ -120,7 +121,7 @@ export default class KeyboardCommandsModal {
     this.inputDisposable = this.keyboardHandler.pushListener({
       handleInput: this.handleInput,
       displayOptions: {
-        cursorStyle: this.keyboardConfig.cursorStyle,
+        cursorStyle: this.keyboardConfig.getCursorStyle(),
         whenClauseContext: "cursorless.keyboard.modal.mode",
         statusBarText: "Listening...",
       },

--- a/packages/cursorless-vscode/src/keyboard/KeyboardConfig.ts
+++ b/packages/cursorless-vscode/src/keyboard/KeyboardConfig.ts
@@ -13,7 +13,6 @@ const LEGACY_PLURAL_SECTION_NAMES: Record<string, string> = {
 };
 
 export class KeyboardConfig {
-
   constructor(private vscodeApi: VscodeApi) {}
 
   getCursorStyle(): TextEditorCursorStyle {

--- a/packages/cursorless-vscode/src/keyboard/KeyboardConfig.ts
+++ b/packages/cursorless-vscode/src/keyboard/KeyboardConfig.ts
@@ -2,6 +2,7 @@ import { mapValues, pickBy } from "lodash";
 import { KeyMap, SectionName, TokenType } from "./TokenTypeHelpers";
 import { SectionTypes, TokenTypeValueMap } from "./TokenTypes";
 import { VscodeApi } from "@cursorless/vscode-common";
+import { TextEditorCursorStyle } from "vscode";
 
 const LEGACY_PLURAL_SECTION_NAMES: Record<string, string> = {
   action: "actions",
@@ -12,7 +13,29 @@ const LEGACY_PLURAL_SECTION_NAMES: Record<string, string> = {
 };
 
 export class KeyboardConfig {
-  constructor(private vscodeApi: VscodeApi) {}
+  cursorStyle: TextEditorCursorStyle;
+
+  constructor(private vscodeApi: VscodeApi) {
+    this.cursorStyle = this.getCursorStyle();
+  }
+
+  private getCursorStyle(): TextEditorCursorStyle {
+    
+    const mapper: Record<string, TextEditorCursorStyle> = {
+      line: TextEditorCursorStyle.Line,
+      block: TextEditorCursorStyle.Block,
+      underline: TextEditorCursorStyle.Underline,
+      lineThin: TextEditorCursorStyle.LineThin,
+      blockOutline: TextEditorCursorStyle.BlockOutline,
+      underlineThin: TextEditorCursorStyle.UnderlineThin,
+    };
+
+    const rawCursorStyle = this.vscodeApi.workspace
+      .getConfiguration("cursorless.experimental.keyboard.modal")
+      .get<keyof typeof mapper>("cursorStyle")!;
+
+    return mapper[rawCursorStyle] ?? TextEditorCursorStyle.BlockOutline;
+  }
 
   /**
    * Returns a keymap for a given config section that is intended to be further

--- a/packages/cursorless-vscode/src/keyboard/KeyboardConfig.ts
+++ b/packages/cursorless-vscode/src/keyboard/KeyboardConfig.ts
@@ -12,28 +12,32 @@ const LEGACY_PLURAL_SECTION_NAMES: Record<string, string> = {
   scope: "scopes",
 };
 
+/**
+ * Maps from the raw cursor style config value to the corresponding
+ * TextEditorCursorStyle enum value.
+ */
+const cursorStyleMap = {
+  line: TextEditorCursorStyle.Line,
+  block: TextEditorCursorStyle.Block,
+  underline: TextEditorCursorStyle.Underline,
+  ["line-thin"]: TextEditorCursorStyle.LineThin,
+  ["block-outline"]: TextEditorCursorStyle.BlockOutline,
+  ["underline-thin"]: TextEditorCursorStyle.UnderlineThin,
+} satisfies Record<string, TextEditorCursorStyle>;
+
 export class KeyboardConfig {
   constructor(private vscodeApi: VscodeApi) {}
 
   getCursorStyle(): TextEditorCursorStyle {
-    const mapper: Record<string, TextEditorCursorStyle> = {
-      line: TextEditorCursorStyle.Line,
-      block: TextEditorCursorStyle.Block,
-      underline: TextEditorCursorStyle.Underline,
-      // Disable lint to allow same names as editor.cursorStyle
-      // eslint-disable-next-line @typescript-eslint/naming-convention
-      "line-thin": TextEditorCursorStyle.LineThin,
-      // eslint-disable-next-line @typescript-eslint/naming-convention
-      "block-outline": TextEditorCursorStyle.BlockOutline,
-      // eslint-disable-next-line @typescript-eslint/naming-convention
-      "underline-thin": TextEditorCursorStyle.UnderlineThin,
-    };
-
     const rawCursorStyle = this.vscodeApi.workspace
       .getConfiguration("cursorless.experimental.keyboard.modal")
-      .get<keyof typeof mapper>("cursorStyle")!;
+      .get<keyof typeof cursorStyleMap>("cursorStyle");
 
-    return mapper[rawCursorStyle] ?? TextEditorCursorStyle.BlockOutline;
+    if (rawCursorStyle == null) {
+      return TextEditorCursorStyle.BlockOutline;
+    }
+
+    return cursorStyleMap[rawCursorStyle];
   }
 
   /**

--- a/packages/cursorless-vscode/src/keyboard/KeyboardConfig.ts
+++ b/packages/cursorless-vscode/src/keyboard/KeyboardConfig.ts
@@ -20,7 +20,7 @@ export class KeyboardConfig {
       line: TextEditorCursorStyle.Line,
       block: TextEditorCursorStyle.Block,
       underline: TextEditorCursorStyle.Underline,
-      // Disable linter to allow same names as VSCode Cursor Style values
+      // Disable lint to allow same names as editor.cursorStyle
       // eslint-disable-next-line @typescript-eslint/naming-convention
       "line-thin": TextEditorCursorStyle.LineThin,
       // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/packages/cursorless-vscode/src/keyboard/KeyboardConfig.ts
+++ b/packages/cursorless-vscode/src/keyboard/KeyboardConfig.ts
@@ -13,20 +13,21 @@ const LEGACY_PLURAL_SECTION_NAMES: Record<string, string> = {
 };
 
 export class KeyboardConfig {
-  cursorStyle: TextEditorCursorStyle;
 
-  constructor(private vscodeApi: VscodeApi) {
-    this.cursorStyle = this.getCursorStyle();
-  }
+  constructor(private vscodeApi: VscodeApi) {}
 
-  private getCursorStyle(): TextEditorCursorStyle {
+  getCursorStyle(): TextEditorCursorStyle {
     const mapper: Record<string, TextEditorCursorStyle> = {
       line: TextEditorCursorStyle.Line,
       block: TextEditorCursorStyle.Block,
       underline: TextEditorCursorStyle.Underline,
-      lineThin: TextEditorCursorStyle.LineThin,
-      blockOutline: TextEditorCursorStyle.BlockOutline,
-      underlineThin: TextEditorCursorStyle.UnderlineThin,
+      // Disable linter to allow same names as VSCode Cursor Style values
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      "line-thin": TextEditorCursorStyle.LineThin,
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      "block-outline": TextEditorCursorStyle.BlockOutline,
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      "underline-thin": TextEditorCursorStyle.UnderlineThin,
     };
 
     const rawCursorStyle = this.vscodeApi.workspace

--- a/packages/cursorless-vscode/src/keyboard/KeyboardConfig.ts
+++ b/packages/cursorless-vscode/src/keyboard/KeyboardConfig.ts
@@ -20,7 +20,6 @@ export class KeyboardConfig {
   }
 
   private getCursorStyle(): TextEditorCursorStyle {
-    
     const mapper: Record<string, TextEditorCursorStyle> = {
       line: TextEditorCursorStyle.Line,
       block: TextEditorCursorStyle.Block,


### PR DESCRIPTION
Addresses https://github.com/cursorless-dev/cursorless/issues/2401, the ability to have custom cursor styling exclusively when in cursorless keyboard mode.

Tried to follow the repo style as best as possible but please let me know if another way besides a record mapper is more idiomatic for TS.

## Checklist

- [/] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [x] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
    - _I could add docs in the visual a11y section but unclear if experimental keyboard support belongs there_
- [x] I have not broken the cheatsheet

## Example 
An image showing the cursor start out with a custom type, then change into `block` when keyboard mode is activated, thus adding more contrast.

![](https://github.com/cursorless-dev/cursorless/assets/70598503/b0dfd7bc-daa0-40bc-b052-20aed31c5d6e)