### PR TITLE
Allow `.` in literal property names for use with facets

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -26,7 +26,17 @@
         "assertionStyle": "as"
       }
     ],
-    "@typescript-eslint/naming-convention": "warn",
+    "@typescript-eslint/naming-convention": [
+      "error",
+      {
+        "selector": ["objectLiteralProperty"],
+        "format": ["camelCase"],
+        "filter": {
+          "regex": "[.]",
+          "match": false
+        }
+      }
+    ],
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/no-inferrable-types": "off",
     "@typescript-eslint/no-non-null-assertion": "off",
@@ -68,7 +78,7 @@
       "files": ["*.tsx"],
       "rules": {
         "@typescript-eslint/naming-convention": [
-          "warn",
+          "error",
           {
             "selector": ["function"],
             "format": ["PascalCase", "camelCase"]

--- a/packages/common/src/scopeSupportFacets/c.ts
+++ b/packages/common/src/scopeSupportFacets/c.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
-
 import {
   LanguageScopeSupportFacetMap,
   ScopeSupportFacetLevel,

--- a/packages/common/src/scopeSupportFacets/clojure.ts
+++ b/packages/common/src/scopeSupportFacets/clojure.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
-
 import {
   LanguageScopeSupportFacetMap,
   ScopeSupportFacetLevel,

--- a/packages/common/src/scopeSupportFacets/cpp.ts
+++ b/packages/common/src/scopeSupportFacets/cpp.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
-
 import { cScopeSupport } from "./c";
 import {
   LanguageScopeSupportFacetMap,

--- a/packages/common/src/scopeSupportFacets/csharp.ts
+++ b/packages/common/src/scopeSupportFacets/csharp.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
-
 import {
   LanguageScopeSupportFacetMap,
   ScopeSupportFacetLevel,

--- a/packages/common/src/scopeSupportFacets/css.ts
+++ b/packages/common/src/scopeSupportFacets/css.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
-
 import {
   LanguageScopeSupportFacetMap,
   ScopeSupportFacetLevel,

--- a/packages/common/src/scopeSupportFacets/go.ts
+++ b/packages/common/src/scopeSupportFacets/go.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
-
 import {
   LanguageScopeSupportFacetMap,
   ScopeSupportFacetLevel,

--- a/packages/common/src/scopeSupportFacets/html.ts
+++ b/packages/common/src/scopeSupportFacets/html.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
-
 import {
   LanguageScopeSupportFacetMap,
   ScopeSupportFacetLevel,

--- a/packages/common/src/scopeSupportFacets/java.ts
+++ b/packages/common/src/scopeSupportFacets/java.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
-
 import {
   LanguageScopeSupportFacetMap,
   ScopeSupportFacetLevel,

--- a/packages/common/src/scopeSupportFacets/javascript.ts
+++ b/packages/common/src/scopeSupportFacets/javascript.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
-
 import {
   LanguageScopeSupportFacetMap,
   ScopeSupportFacetLevel,

--- a/packages/common/src/scopeSupportFacets/javascriptreact.ts
+++ b/packages/common/src/scopeSupportFacets/javascriptreact.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
-
 import { javascriptScopeSupport } from "./javascript";
 import {
   LanguageScopeSupportFacetMap,

--- a/packages/common/src/scopeSupportFacets/json.ts
+++ b/packages/common/src/scopeSupportFacets/json.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
-
 import {
   LanguageScopeSupportFacetMap,
   ScopeSupportFacetLevel,

--- a/packages/common/src/scopeSupportFacets/jsonc.ts
+++ b/packages/common/src/scopeSupportFacets/jsonc.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
-
 import { jsonScopeSupport } from "./json";
 import {
   LanguageScopeSupportFacetMap,

--- a/packages/common/src/scopeSupportFacets/jsonl.ts
+++ b/packages/common/src/scopeSupportFacets/jsonl.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
-
 import { jsonScopeSupport } from "./json";
 import {
   LanguageScopeSupportFacetMap,

--- a/packages/common/src/scopeSupportFacets/latex.ts
+++ b/packages/common/src/scopeSupportFacets/latex.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
-
 import {
   LanguageScopeSupportFacetMap,
   ScopeSupportFacetLevel,

--- a/packages/common/src/scopeSupportFacets/lua.ts
+++ b/packages/common/src/scopeSupportFacets/lua.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
-
 import {
   LanguageScopeSupportFacetMap,
   ScopeSupportFacetLevel,

--- a/packages/common/src/scopeSupportFacets/markdown.ts
+++ b/packages/common/src/scopeSupportFacets/markdown.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
-
 import {
   LanguageScopeSupportFacetMap,
   ScopeSupportFacetLevel,

--- a/packages/common/src/scopeSupportFacets/php.ts
+++ b/packages/common/src/scopeSupportFacets/php.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
-
 import {
   LanguageScopeSupportFacetMap,
   ScopeSupportFacetLevel,

--- a/packages/common/src/scopeSupportFacets/python.ts
+++ b/packages/common/src/scopeSupportFacets/python.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
-
 import {
   LanguageScopeSupportFacetMap,
   ScopeSupportFacetLevel,

--- a/packages/common/src/scopeSupportFacets/ruby.ts
+++ b/packages/common/src/scopeSupportFacets/ruby.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
-
 import {
   LanguageScopeSupportFacetMap,
   ScopeSupportFacetLevel,

--- a/packages/common/src/scopeSupportFacets/rust.ts
+++ b/packages/common/src/scopeSupportFacets/rust.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
-
 import {
   LanguageScopeSupportFacetMap,
   ScopeSupportFacetLevel,

--- a/packages/common/src/scopeSupportFacets/scala.ts
+++ b/packages/common/src/scopeSupportFacets/scala.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
-
 import {
   LanguageScopeSupportFacetMap,
   ScopeSupportFacetLevel,

--- a/packages/common/src/scopeSupportFacets/scm.ts
+++ b/packages/common/src/scopeSupportFacets/scm.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
-
 import {
   LanguageScopeSupportFacetMap,
   ScopeSupportFacetLevel,

--- a/packages/common/src/scopeSupportFacets/scopeSupportFacetInfos.ts
+++ b/packages/common/src/scopeSupportFacets/scopeSupportFacetInfos.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
-
 import {
   ScopeSupportFacet,
   ScopeSupportFacetInfo,

--- a/packages/common/src/scopeSupportFacets/scss.ts
+++ b/packages/common/src/scopeSupportFacets/scss.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
-
 import { cssScopeSupport } from "./css";
 import {
   LanguageScopeSupportFacetMap,

--- a/packages/common/src/scopeSupportFacets/talon.ts
+++ b/packages/common/src/scopeSupportFacets/talon.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
-
 import {
   LanguageScopeSupportFacetMap,
   ScopeSupportFacetLevel,

--- a/packages/common/src/scopeSupportFacets/typescript.ts
+++ b/packages/common/src/scopeSupportFacets/typescript.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
-
 import { javascriptCoreScopeSupport } from "./javascript";
 import {
   LanguageScopeSupportFacetMap,

--- a/packages/common/src/scopeSupportFacets/typescriptreact.ts
+++ b/packages/common/src/scopeSupportFacets/typescriptreact.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
-
 import { javascriptJsxScopeSupport } from "./javascript";
 import {
   LanguageScopeSupportFacetMap,

--- a/packages/common/src/scopeSupportFacets/xml.ts
+++ b/packages/common/src/scopeSupportFacets/xml.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
-
 import {
   LanguageScopeSupportFacetMap,
   ScopeSupportFacetLevel,

--- a/packages/common/src/scopeSupportFacets/yaml.ts
+++ b/packages/common/src/scopeSupportFacets/yaml.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
-
 import {
   LanguageScopeSupportFacetMap,
   ScopeSupportFacetLevel,

--- a/packages/cursorless-engine/src/generateSpokenForm/defaultSpokenForms/snippets.ts
+++ b/packages/cursorless-engine/src/generateSpokenForm/defaultSpokenForms/snippets.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
-
 import { InsertSnippetArg, WrapWithSnippetArg } from "@cursorless/common";
 import { NoSpokenFormError } from "../NoSpokenFormError";
 


### PR DESCRIPTION
- Fixes #2132



## Checklist

- [-] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [-] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [-] I have not broken the cheatsheet
