### PR TITLE
Allow toggle decorations to take a boolean argument

### DIFF
--- a/docs/user/customization.md
+++ b/docs/user/customization.md
@@ -119,7 +119,7 @@ While the hats are hidden, you will not be able to address any marks, eg `"take 
 
 If you'd like to map a voice command to toggle the hats, have a look at https://youtu.be/oWUJyDgz63k
 
-Using the command server you can also specify if the hat should be on or of with a true/false value
+Using the command server you can also specify if the hats should be on or of with a true/false value
 
 ```talon
 hats on:  user.run_rpc_command("cursorless.toggleDecorations", true)

--- a/docs/user/customization.md
+++ b/docs/user/customization.md
@@ -119,6 +119,13 @@ While the hats are hidden, you will not be able to address any marks, eg `"take 
 
 If you'd like to map a voice command to toggle the hats, have a look at https://youtu.be/oWUJyDgz63k
 
+Using the command server you can also specify if the hat should be on or of with a true/false value
+
+```talon
+hats on:  user.run_rpc_command("cursorless.toggleDecorations", true)
+hats off: user.run_rpc_command("cursorless.toggleDecorations", false)
+```
+
 ## Updating word separators
 
 The word separators are characters that defines the boundary between words in a identifier. eg `hello_world` is an identifier with two words separated by `_`. If you like to support other separators like `-` in `hello-world` that can be accomplished by changing the `cursorless.wordSeparators` setting. This setting is also language overridable.

--- a/packages/cursorless-vscode-e2e/src/suite/toggleDecorations.vscode.test.ts
+++ b/packages/cursorless-vscode-e2e/src/suite/toggleDecorations.vscode.test.ts
@@ -27,4 +27,14 @@ async function runTest() {
   await vscode.commands.executeCommand("cursorless.toggleDecorations");
   await hatTokenMap.allocateHats();
   assert((await hatTokenMap.getReadableMap(false)).getEntries().length !== 0);
+
+  // Check that hats disappear when turned off
+  await vscode.commands.executeCommand("cursorless.toggleDecorations", false);
+  await hatTokenMap.allocateHats();
+  assert((await hatTokenMap.getReadableMap(false)).getEntries().length === 0);
+
+  // Check that hats reappear when turned back on
+  await vscode.commands.executeCommand("cursorless.toggleDecorations", true);
+  await hatTokenMap.allocateHats();
+  assert((await hatTokenMap.getReadableMap(false)).getEntries().length !== 0);
 }

--- a/packages/cursorless-vscode/src/ide/vscode/hats/VscodeHats.ts
+++ b/packages/cursorless-vscode/src/ide/vscode/hats/VscodeHats.ts
@@ -58,8 +58,8 @@ export class VscodeHats implements Hats {
     await this.hatRenderer.init();
   }
 
-  toggle() {
-    this.isEnabled = !this.isEnabled;
+  toggle(isEnabled?: boolean) {
+    this.isEnabled = isEnabled ?? !this.isEnabled;
     this.isEnabledNotifier.notifyListeners(this.isEnabled);
   }
 


### PR DESCRIPTION
```talon
hats on:  user.run_rpc_command("cursorless.toggleDecorations", true)
hats off: user.run_rpc_command("cursorless.toggleDecorations", false)
```

Fixes #2462

## Checklist

- [x] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [x] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [/] I have not broken the cheatsheet
