### PR TITLE
Fix bug with go text fragment

### DIFF
--- a/data/fixtures/scopes/go/textFragment.comment.line.scope
+++ b/data/fixtures/scopes/go/textFragment.comment.line.scope
@@ -1,0 +1,10 @@
+// foo
+---
+
+[Content] =
+[Removal] =
+[Domain] = 0:0-0:6
+  >------<
+0| // foo
+
+[Insertion delimiter] = " "

--- a/data/fixtures/scopes/go/textFragment.string.multiLine.scope
+++ b/data/fixtures/scopes/go/textFragment.string.multiLine.scope
@@ -1,0 +1,15 @@
+`
+foo
+`
+---
+
+[Content] =
+[Removal] =
+[Domain] = 0:1-2:0
+   >
+0| `
+1| foo
+2| `
+   <
+
+[Insertion delimiter] = " "

--- a/data/fixtures/scopes/go/textFragment.string.singleLine.scope
+++ b/data/fixtures/scopes/go/textFragment.string.singleLine.scope
@@ -1,0 +1,10 @@
+"foo"
+---
+
+[Content] =
+[Removal] =
+[Domain] = 0:1-0:4
+   >---<
+0| "foo"
+
+[Insertion delimiter] = " "

--- a/packages/common/src/scopeSupportFacets/go.ts
+++ b/packages/common/src/scopeSupportFacets/go.ts
@@ -8,4 +8,8 @@ const { supported, unsupported, notApplicable } = ScopeSupportFacetLevel;
 
 export const goScopeSupport: LanguageScopeSupportFacetMap = {
   "comment.line": supported,
+
+  "textFragment.string.singleLine": supported,
+  "textFragment.string.multiLine": supported,
+  "textFragment.comment.line": supported,
 };

--- a/packages/cursorless-engine/src/languages/TreeSitterQuery/queryPredicateOperators.ts
+++ b/packages/cursorless-engine/src/languages/TreeSitterQuery/queryPredicateOperators.ts
@@ -98,6 +98,23 @@ class ChildRange extends QueryPredicateOperator<ChildRange> {
   }
 }
 
+class CharacterRange extends QueryPredicateOperator<CharacterRange> {
+  name = "character-range!" as const;
+  schema = z.union([
+    z.tuple([q.node, q.integer]),
+    z.tuple([q.node, q.integer, q.integer]),
+  ]);
+
+  run(nodeInfo: MutableQueryCapture, startOffset: number, endOffset?: number) {
+    nodeInfo.range = new Range(
+      nodeInfo.range.start.translate(undefined, startOffset),
+      nodeInfo.range.end.translate(undefined, endOffset ?? 0),
+    );
+
+    return true;
+  }
+}
+
 /**
  * A predicate operator that modifies the range of the match to shrink to regex
  * match.  For example, `(#shrink-to-match! @foo "\\S+")` will modify the range
@@ -252,6 +269,7 @@ export const queryPredicateOperators = [
   new NotParentType(),
   new IsNthChild(),
   new ChildRange(),
+  new CharacterRange(),
   new ShrinkToMatch(),
   new AllowMultiple(),
   new InsertionDelimiter(),

--- a/queries/go.scm
+++ b/queries/go.scm
@@ -30,11 +30,13 @@
 ] @statement
 
 (
-  [
-    (interpreted_string_literal)
-    (raw_string_literal)
-  ] @string @textFragment
+  (interpreted_string_literal) @string @textFragment
   (#child-range! @textFragment 0 -1 true true)
+)
+
+(
+  (raw_string_literal) @string @textFragment
+  (#character-range! @textFragment 1 -1)
 )
 
 (comment) @comment @textFragment


### PR DESCRIPTION
When using these multiline strings in go
```
`foo`
```
we get a node of type `raw_string_literal` which have no children so the `child-range` predicate ran into an undefined at runtime problem.

Fixes #2458

## Checklist

- [x] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [/] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [/] I have not broken the cheatsheet
