### PR TITLE
Fix "pour" / "drink" with keyboardTargetFollowsSelection

### DIFF
--- a/packages/cursorless-engine/src/KeyboardTargetUpdater.ts
+++ b/packages/cursorless-engine/src/KeyboardTargetUpdater.ts
@@ -1,7 +1,7 @@
 import { Disposable } from "@cursorless/common";
 import { Debouncer } from "./core/Debouncer";
 import { StoredTargetMap } from "./core/StoredTargets";
-import { PlainTarget } from "./processTargets/targets";
+import { CursorStage } from "./processTargets/marks/CursorStage";
 import { ide } from "./singletons/ide.singleton";
 
 export class KeyboardTargetUpdater {
@@ -49,17 +49,7 @@ export class KeyboardTargetUpdater {
       return;
     }
 
-    this.storedTargets.set(
-      "keyboard",
-      activeEditor.selections.map(
-        (selection) =>
-          new PlainTarget({
-            contentRange: selection,
-            editor: activeEditor,
-            isReversed: selection.isReversed,
-          }),
-      ),
-    );
+    this.storedTargets.set("keyboard", new CursorStage().run());
   }
 
   dispose() {

--- a/packages/cursorless-engine/src/processTargets/MarkStageFactoryImpl.ts
+++ b/packages/cursorless-engine/src/processTargets/MarkStageFactoryImpl.ts
@@ -30,7 +30,7 @@ export class MarkStageFactoryImpl implements MarkStageFactory {
   create(mark: Mark): MarkStage {
     switch (mark.type) {
       case "cursor":
-        return new CursorStage(mark);
+        return new CursorStage();
       case "that":
       case "source":
       case "keyboard":

--- a/packages/cursorless-engine/src/processTargets/marks/CursorStage.ts
+++ b/packages/cursorless-engine/src/processTargets/marks/CursorStage.ts
@@ -1,4 +1,3 @@
-import type { CursorMark } from "@cursorless/common";
 import { ide } from "../../singletons/ide.singleton";
 import type { Target } from "../../typings/target.types";
 import type { MarkStage } from "../PipelineStages.types";
@@ -6,8 +5,6 @@ import { UntypedTarget } from "../targets";
 import { getActiveSelections } from "./getActiveSelections";
 
 export class CursorStage implements MarkStage {
-  constructor(private mark: CursorMark) {}
-
   run(): Target[] {
     return getActiveSelections(ide()).map(
       (selection) =>


### PR DESCRIPTION
Before, if you have the new target follows cursor setting enabled, the "pour" action wouldn't do anything because it was a strong target. Changing it so it's equivalent to setting keyboard target to "this" every time you move cursor

Didn't add tests because this setting is still super experimental; not convinced we want to keep it

## Checklist

- [-] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [-] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [-] I have not broken the cheatsheet
