### PR TITLE
Change "that" target for "chuck" to be untyped

### DIFF
--- a/data/fixtures/recorded/actions/carveVest.yml
+++ b/data/fixtures/recorded/actions/carveVest.yml
@@ -26,7 +26,7 @@ finalState:
     - anchor: {line: 0, character: 0}
       active: {line: 0, character: 0}
   thatMark:
-    - type: RawSelectionTarget
+    - type: UntypedTarget
       contentRange:
         start: {line: 1, character: 6}
         end: {line: 1, character: 6}

--- a/data/fixtures/recorded/actions/changeNextInstanceChar.yml
+++ b/data/fixtures/recorded/actions/changeNextInstanceChar.yml
@@ -34,7 +34,7 @@ finalState:
     - anchor: {line: 0, character: 0}
       active: {line: 0, character: 0}
   thatMark:
-    - type: RawSelectionTarget
+    - type: UntypedTarget
       contentRange:
         start: {line: 0, character: 0}
         end: {line: 0, character: 0}

--- a/data/fixtures/recorded/actions/chuckArgMadeAndAir.yml
+++ b/data/fixtures/recorded/actions/chuckArgMadeAndAir.yml
@@ -32,7 +32,7 @@ finalState:
     - anchor: {line: 0, character: 0}
       active: {line: 0, character: 0}
   thatMark:
-    - type: RawSelectionTarget
+    - type: UntypedTarget
       contentRange:
         start: {line: 0, character: 29}
         end: {line: 0, character: 29}

--- a/data/fixtures/recorded/actions/chuckArgMadeAndAirAndJustSoon.yml
+++ b/data/fixtures/recorded/actions/chuckArgMadeAndAirAndJustSoon.yml
@@ -39,7 +39,7 @@ finalState:
     - anchor: {line: 0, character: 0}
       active: {line: 0, character: 0}
   thatMark:
-    - type: RawSelectionTarget
+    - type: UntypedTarget
       contentRange:
         start: {line: 0, character: 22}
         end: {line: 0, character: 22}

--- a/data/fixtures/recorded/actions/chuckEveryArgMade.yml
+++ b/data/fixtures/recorded/actions/chuckEveryArgMade.yml
@@ -25,7 +25,7 @@ finalState:
     - anchor: {line: 0, character: 0}
       active: {line: 0, character: 0}
   thatMark:
-    - type: RawSelectionTarget
+    - type: UntypedTarget
       contentRange:
         start: {line: 0, character: 16}
         end: {line: 0, character: 16}

--- a/data/fixtures/recorded/actions/chuckVest.yml
+++ b/data/fixtures/recorded/actions/chuckVest.yml
@@ -26,7 +26,7 @@ finalState:
     - anchor: {line: 0, character: 0}
       active: {line: 0, character: 0}
   thatMark:
-    - type: RawSelectionTarget
+    - type: UntypedTarget
       contentRange:
         start: {line: 1, character: 6}
         end: {line: 1, character: 6}

--- a/data/fixtures/recorded/actions/clearVest.yml
+++ b/data/fixtures/recorded/actions/clearVest.yml
@@ -26,7 +26,7 @@ finalState:
     - anchor: {line: 1, character: 6}
       active: {line: 1, character: 6}
   thatMark:
-    - type: RawSelectionTarget
+    - type: UntypedTarget
       contentRange:
         start: {line: 1, character: 6}
         end: {line: 1, character: 6}

--- a/data/fixtures/recorded/actions/cutEveryArgMade.yml
+++ b/data/fixtures/recorded/actions/cutEveryArgMade.yml
@@ -25,7 +25,7 @@ finalState:
     - anchor: {line: 0, character: 0}
       active: {line: 0, character: 0}
   thatMark:
-    - type: RawSelectionTarget
+    - type: UntypedTarget
       contentRange:
         start: {line: 0, character: 16}
         end: {line: 0, character: 16}

--- a/data/fixtures/recorded/actions/parsed/destroyAir.yml
+++ b/data/fixtures/recorded/actions/parsed/destroyAir.yml
@@ -32,7 +32,7 @@ finalState:
     - anchor: {line: 1, character: 3}
       active: {line: 1, character: 3}
   thatMark:
-    - type: RawSelectionTarget
+    - type: UntypedTarget
       contentRange:
         start: {line: 0, character: 0}
         end: {line: 0, character: 0}

--- a/data/fixtures/recorded/actions/parsed/destroyAirAndEachPastGust.yml
+++ b/data/fixtures/recorded/actions/parsed/destroyAirAndEachPastGust.yml
@@ -55,13 +55,13 @@ finalState:
     - anchor: {line: 1, character: 3}
       active: {line: 1, character: 3}
   thatMark:
-    - type: RawSelectionTarget
+    - type: UntypedTarget
       contentRange:
         start: {line: 0, character: 0}
         end: {line: 0, character: 0}
       isReversed: false
       hasExplicitRange: true
-    - type: RawSelectionTarget
+    - type: UntypedTarget
       contentRange:
         start: {line: 1, character: 3}
         end: {line: 1, character: 3}

--- a/data/fixtures/recorded/actions/parsed/destruction.yml
+++ b/data/fixtures/recorded/actions/parsed/destruction.yml
@@ -27,7 +27,7 @@ finalState:
     - anchor: {line: 0, character: 0}
       active: {line: 0, character: 0}
   thatMark:
-    - type: RawSelectionTarget
+    - type: UntypedTarget
       contentRange:
         start: {line: 0, character: 0}
         end: {line: 0, character: 0}

--- a/packages/cursorless-engine/src/actions/Remove.ts
+++ b/packages/cursorless-engine/src/actions/Remove.ts
@@ -2,12 +2,12 @@ import { FlashStyle, Selection, TextEditor } from "@cursorless/common";
 import { flatten, zip } from "lodash";
 import { RangeUpdater } from "../core/updateSelections/RangeUpdater";
 import { performEditsAndUpdateSelections } from "../core/updateSelections/updateSelections";
-import { RawSelectionTarget } from "../processTargets/targets";
+import { UntypedTarget } from "../processTargets/targets";
 import { ide } from "../singletons/ide.singleton";
 import { Target } from "../typings/target.types";
 import { flashTargets, runOnTargetsForEachEditor } from "../util/targetUtils";
 import { unifyRemovalTargets } from "../util/unifyRanges";
-import { SimpleAction, ActionReturnValue } from "./actions.types";
+import { ActionReturnValue, SimpleAction } from "./actions.types";
 
 export default class Delete implements SimpleAction {
   constructor(private rangeUpdater: RangeUpdater) {
@@ -54,10 +54,12 @@ export default class Delete implements SimpleAction {
 
     return zip(targets, updatedEditSelections).map(
       ([target, range]) =>
-        new RawSelectionTarget({
+        new UntypedTarget({
           editor: target!.editor,
           isReversed: target!.isReversed,
           contentRange: range!,
+          hasExplicitRange: true,
+          isToken: false,
         }),
     );
   }


### PR DESCRIPTION
This was an issue raised by a keyboard user. The problem is that "chuck line air" followed by "pour that" resulted in just moving cursor to the start of the line after the one that was deleted. I think this change is fairly harmless

I kept it as having an explicit range because that way "chuck air" followed by "take that" won't select the adjacent token. However, keep in mind that this means that "chuck air" followed by "take every token that" won't select every token on that line.

I think prob the way forward is to revisit the auto-expansion, but for now this solves the problem of "pour that" after "chuck line air" or "chuck air"

I also don't feel super strongly here; happy to bail on this PR if we don't like the semantics

## Checklist

- [x] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [-] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [-] I have not broken the cheatsheet
