### PR TITLE
Fix Python type error

### DIFF
--- a/cursorless-talon/src/command.py
+++ b/cursorless-talon/src/command.py
@@ -96,7 +96,11 @@ def make_serializable(value: Any) -> Any:
         return [make_serializable(v) for v in value]
     if dataclasses.is_dataclass(value):
         items = {
-            **{k: v for k, v in value.__class__.__dict__.items() if k[0] != "_"},
+            **{
+                k: v
+                for k, v in vars(type(value)).items()
+                if not k.startswith("_") and not isinstance(v, property)
+            },
             **value.__dict__,
         }
         return {k: make_serializable(v) for k, v in items.items() if v is not None}


### PR DESCRIPTION
Latest pylance version is giving me the following error:

```
Cannot access attribute "__class__" for class "type[DataclassInstance]"
  A property defined within a protocol class cannot be accessed as a class variable
```

Note that this solution came from a chat with chatgpt so I have no idea whether it's correct. Please review carefully. We really should have unit tests for this function

I did run local talon tests and all green, as well as tried cheatsheet

## Checklist

- [-] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [-] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [x] I have not broken the cheatsheet
