### PR TITLE
Switch fs to async

### DIFF
--- a/packages/cursorless-vscode/src/scripts/preprocessSvgHats.ts
+++ b/packages/cursorless-vscode/src/scripts/preprocessSvgHats.ts
@@ -1,6 +1,6 @@
 import { getCursorlessRepoRoot } from "@cursorless/common";
 import * as parser from "fast-xml-parser";
-import { promises as fsp, readdirSync } from "fs";
+import * as fs from "fs/promises";
 import * as path from "pathe";
 
 async function main() {
@@ -12,12 +12,14 @@ async function main() {
     format: true,
   });
 
-  for (const dirent of readdirSync(directory, { withFileTypes: true })) {
+  const files = await fs.readdir(directory, { withFileTypes: true });
+
+  for (const dirent of files) {
     if (!dirent.isFile() || !dirent.name.endsWith(".svg")) {
       continue;
     }
     const filePath = path.join(directory, dirent.name);
-    const rawSvg = await fsp.readFile(filePath, { encoding: "utf8" });
+    const rawSvg = await fs.readFile(filePath, { encoding: "utf8" });
     const svgJson = new parser.XMLParser({ ignoreAttributes: false }).parse(
       rawSvg,
     );
@@ -37,7 +39,7 @@ async function main() {
       .replace(/fill="(?!none)[^"]+"/g, 'fill="#666666"')
       .replace(/fill:(?!none)[^;]+;/g, "fill:#666666;");
 
-    await fsp.writeFile(filePath, outputSvg);
+    await fs.writeFile(filePath, outputSvg);
   }
 }
 


### PR DESCRIPTION
Note that there are references to `fs` I have not migrated. But all of those are in the test harness, various run scripts, or webpage.
Fixes #1986

## Checklist

- [/] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [/] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [/] I have not broken the cheatsheet
