### PR TITLE
Remove node process from hat token map

### DIFF
--- a/packages/cursorless-engine/src/core/HatTokenMapImpl.ts
+++ b/packages/cursorless-engine/src/core/HatTokenMapImpl.ts
@@ -5,9 +5,7 @@ import {
   ReadOnlyHatMap,
   TokenHat,
 } from "@cursorless/common";
-import { hrtime } from "process";
 import { ide } from "../singletons/ide.singleton";
-import { abs } from "../util/bigint";
 import { Debug } from "./Debug";
 import { HatAllocator } from "./HatAllocator";
 import { IndividualHatMap } from "./IndividualHatMap";
@@ -16,7 +14,7 @@ import { RangeUpdater } from "./updateSelections/RangeUpdater";
 /**
  * Maximum age for the pre-phrase snapshot before we consider it to be stale
  */
-const PRE_PHRASE_SNAPSHOT_MAX_AGE_NS = BigInt(6e10); // 60 seconds
+const PRE_PHRASE_SNAPSHOT_MAX_AGE_MS = 60000; // 60 seconds
 
 /**
  * Maps from (hatStyle, character) pairs to tokens
@@ -34,7 +32,7 @@ export class HatTokenMapImpl implements HatTokenMap {
    * hat with the same color and shape will refer to the same logical range.
    */
   private prePhraseMapSnapshot?: IndividualHatMap;
-  private prePhraseMapsSnapshotTimestamp: bigint | null = null;
+  private prePhraseMapsSnapshotTimestamp: number | null = null;
 
   private lastSignalVersion: string | null = null;
   private hatAllocator: HatAllocator;
@@ -106,8 +104,8 @@ export class HatTokenMapImpl implements HatTokenMap {
       }
 
       if (
-        abs(hrtime.bigint() - this.prePhraseMapsSnapshotTimestamp!) >
-        PRE_PHRASE_SNAPSHOT_MAX_AGE_NS
+        Math.abs(Date.now() - this.prePhraseMapsSnapshotTimestamp!) >
+        PRE_PHRASE_SNAPSHOT_MAX_AGE_MS
       ) {
         console.error(
           "Navigation map pre-phrase snapshot requested, but snapshot is more than a minute old",
@@ -149,6 +147,6 @@ export class HatTokenMapImpl implements HatTokenMap {
     }
 
     this.prePhraseMapSnapshot = this.activeMap.clone();
-    this.prePhraseMapsSnapshotTimestamp = hrtime.bigint();
+    this.prePhraseMapsSnapshotTimestamp = Date.now();
   }
 }

--- a/packages/cursorless-engine/src/core/HatTokenMapImpl.ts
+++ b/packages/cursorless-engine/src/core/HatTokenMapImpl.ts
@@ -104,7 +104,7 @@ export class HatTokenMapImpl implements HatTokenMap {
       }
 
       if (
-        Math.abs(Date.now() - this.prePhraseMapsSnapshotTimestamp!) >
+        performance.now() - this.prePhraseMapsSnapshotTimestamp! >
         PRE_PHRASE_SNAPSHOT_MAX_AGE_MS
       ) {
         console.error(
@@ -147,6 +147,6 @@ export class HatTokenMapImpl implements HatTokenMap {
     }
 
     this.prePhraseMapSnapshot = this.activeMap.clone();
-    this.prePhraseMapsSnapshotTimestamp = Date.now();
+    this.prePhraseMapsSnapshotTimestamp = performance.now();
   }
 }

--- a/packages/cursorless-engine/src/util/bigint.ts
+++ b/packages/cursorless-engine/src/util/bigint.ts
@@ -1,4 +1,0 @@
-// From https://stackoverflow.com/a/64953280
-export function abs(x: bigint) {
-  return x < BigInt(0) ? -x : x;
-}


### PR DESCRIPTION
Since we're using a threshold of sixty seconds I don't think we need nanosecond precision. Instead of finding a polyfill for bigint I just switch to date.now which gives us the time in milliseconds.

## Checklist

- [/] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [/] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [/] I have not broken the cheatsheet
