### PR TITLE
Remove node from runIntegrationTests

### DIFF
--- a/packages/cursorless-engine/src/runIntegrationTests.ts
+++ b/packages/cursorless-engine/src/runIntegrationTests.ts
@@ -2,7 +2,6 @@ import { languageMatchers } from "./languages/getNodeMatcher";
 import { TreeSitter } from "./typings/TreeSitter";
 import { legacyLanguageIds } from "./languages/LegacyLanguageId";
 import { LanguageDefinitions } from "./languages/LanguageDefinitions";
-import assert from "assert";
 import { unsafeKeys } from "./util/object";
 
 /**
@@ -42,5 +41,7 @@ async function assertNoScopesBothLegacyAndNew(
     });
   }
 
-  assert.deepStrictEqual(errors, []);
+  if (errors.length > 0) {
+    throw Error(errors.join("\n"));
+  }
 }


### PR DESCRIPTION
Since `runIntegrationTests` is constructed in the engine it cannot use assert. Switching assert to throwing an error I think is totally fine here. It will still fail the test and we don't have that many legacy scopes left and hopefully soon they will be gone as well.

## Checklist

- [/] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [/] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [/] I have not broken the cheatsheet
