### PR TITLE
Allow whitespace lines when calculating edit indentation

### DIFF
--- a/data/fixtures/recorded/actions/drinkLine2.yml
+++ b/data/fixtures/recorded/actions/drinkLine2.yml
@@ -1,0 +1,37 @@
+languageId: plaintext
+command:
+  version: 7
+  spokenForm: drink line
+  action:
+    name: editNewLineBefore
+    target:
+      type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: line}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    def my_funk():
+        
+        pass
+  selections:
+    - anchor: {line: 1, character: 4}
+      active: {line: 1, character: 4}
+  marks: {}
+finalState:
+  documentContents: |-
+    def my_funk():
+        
+        
+        pass
+  selections:
+    - anchor: {line: 1, character: 4}
+      active: {line: 1, character: 4}
+  thatMark:
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 2, character: 0}
+        end: {line: 2, character: 4}
+      isReversed: false
+      hasExplicitRange: true

--- a/data/fixtures/recorded/actions/pourLine2.yml
+++ b/data/fixtures/recorded/actions/pourLine2.yml
@@ -1,0 +1,37 @@
+languageId: plaintext
+command:
+  version: 7
+  spokenForm: pour line
+  action:
+    name: editNewLineAfter
+    target:
+      type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: line}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    def my_funk():
+        
+        pass
+  selections:
+    - anchor: {line: 1, character: 4}
+      active: {line: 1, character: 4}
+  marks: {}
+finalState:
+  documentContents: |-
+    def my_funk():
+        
+        
+        pass
+  selections:
+    - anchor: {line: 2, character: 4}
+      active: {line: 2, character: 4}
+  thatMark:
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 1, character: 0}
+        end: {line: 1, character: 4}
+      isReversed: false
+      hasExplicitRange: true

--- a/packages/cursorless-engine/src/processTargets/targets/DestinationImpl.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/DestinationImpl.ts
@@ -184,10 +184,7 @@ function getIndentationString(editor: TextEditor, range: Range) {
   let indentationString = "";
   for (let i = range.start.line; i <= range.end.line; ++i) {
     const line = editor.document.lineAt(i);
-    if (
-      !line.isEmptyOrWhitespace &&
-      line.firstNonWhitespaceCharacterIndex < length
-    ) {
+    if (!line.range.isEmpty && line.firstNonWhitespaceCharacterIndex < length) {
       length = line.firstNonWhitespaceCharacterIndex;
       indentationString = line.text.slice(0, length);
     }


### PR DESCRIPTION
When calculating the edit indentation we want to skip empty lines, but whitespace lines we should actually use.

## Checklist

- [x] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [/] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [/] I have not broken the cheatsheet
