### PR TITLE
Fix esbuild warning

### DIFF
--- a/packages/test-harness/package.json
+++ b/packages/test-harness/package.json
@@ -6,7 +6,7 @@
   "main": "./out/index.js",
   "scripts": {
     "test": "env CURSORLESS_MODE=test my-ts-node src/scripts/runTestsCI.ts",
-    "build:base": "esbuild --sourcemap --conditions=cursorless:bundler --bundle --external:vscode --format=cjs --platform=node",
+    "build:base": "esbuild --sourcemap --conditions=cursorless:bundler --bundle --external:vscode --external:./reporters/parallel-buffered --external:./worker.js --format=cjs --platform=node",
     "build": "pnpm run build:runner && pnpm run build:tests && pnpm run build:unit && pnpm run build:talon",
     "build:runner": "pnpm run build:base ./src/runners/extensionTestsVscode.ts --outfile=dist/extensionTestsVscode.cjs",
     "build:unit": "pnpm run build:base ./src/scripts/runUnitTestsOnly.ts --outfile=dist/runUnitTestsOnly.cjs",


### PR DESCRIPTION
Not totally sure what it's about but this fix makes the warnings go away and doesn't break anything

```
▲ [WARNING] "./reporters/parallel-buffered" should be marked as external for use with "require.resolve" [require-resolve-not-external]

    ../../node_modules/.pnpm/mocha@10.3.0/node_modules/mocha/lib/nodejs/parallel-buffered-runner.js:19:2:
      19 │   './reporters/parallel-buffered'
         ╵   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

▲ [WARNING] "./worker.js" should be marked as external for use with "require.resolve" [require-resolve-not-external]

    ../../node_modules/.pnpm/mocha@10.3.0/node_modules/mocha/lib/nodejs/buffered-worker-pool.js:16:36:
      16 │ const WORKER_PATH = require.resolve('./worker.js');
         ╵                                     ~~~~~~~~~~~~~
```



## Checklist

- [-] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [-] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [-] I have not broken the cheatsheet
