### PR TITLE
keyboard: Target selection after action, rather than "that"

### DIFF
--- a/packages/cursorless-vscode-e2e/src/suite/keyboard/basic.vscode.test.ts
+++ b/packages/cursorless-vscode-e2e/src/suite/keyboard/basic.vscode.test.ts
@@ -83,11 +83,11 @@ const testCases: TestCase[] = [
     finalContent: "(a)",
   },
   {
-    name: "preserve keyboard target",
+    name: "set keyboard target to cursor",
     initialContent: "a\n",
     // round wrap air; round wrap <keyboard target>
     keySequence: ["da", "aw", "wp", "aw", "wp"],
-    finalContent: "((a))\n",
+    finalContent: "(a)\n()",
   },
   {
     name: "slice range",

--- a/packages/cursorless-vscode/src/keyboard/KeyboardCommandsTargeted.ts
+++ b/packages/cursorless-vscode/src/keyboard/KeyboardCommandsTargeted.ts
@@ -261,12 +261,7 @@ export default class KeyboardCommandsTargeted {
     } else {
       // If we're not exiting cursorless mode, preserve the keyboard mark
       // FIXME: Better to just not clobber the keyboard mark on each action?
-      await setKeyboardTarget({
-        type: "primitive",
-        mark: {
-          type: "that",
-        },
-      });
+      await this.targetSelection();
     }
 
     return returnValue;


### PR DESCRIPTION


## Checklist

- [x] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [-] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [-] I have not broken the cheatsheet
