### PR TITLE
Use new `$configDir` setting in tsconfig

### DIFF
--- a/packages/cheatsheet-local/tsconfig.json
+++ b/packages/cheatsheet-local/tsconfig.json
@@ -1,8 +1,6 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": "src",
-    "outDir": "out",
     "jsx": "react-jsx",
     "lib": ["es5", "es6", "dom"],
     "allowSyntheticDefaultImports": true,

--- a/packages/cheatsheet/tsconfig.json
+++ b/packages/cheatsheet/tsconfig.json
@@ -1,8 +1,6 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": "src",
-    "outDir": "out",
     "jsx": "react-jsx",
     "esModuleInterop": true,
     "skipLibCheck": true,

--- a/packages/common/tsconfig.json
+++ b/packages/common/tsconfig.json
@@ -1,9 +1,5 @@
 {
   "extends": "../../tsconfig.base.json",
-  "compilerOptions": {
-    "outDir": "out",
-    "rootDir": "src"
-  },
   "include": ["src/**/*.ts", "src/**/*.json", "../../typings/**/*.d.ts"],
   "references": []
 }

--- a/packages/cursorless-cheatsheet/tsconfig.json
+++ b/packages/cursorless-cheatsheet/tsconfig.json
@@ -1,9 +1,5 @@
 {
   "extends": "../../tsconfig.base.json",
-  "compilerOptions": {
-    "outDir": "out",
-    "rootDir": "src"
-  },
   "include": ["src/**/*.ts", "src/**/*.json", "../../typings/**/*.d.ts"],
   "references": [
     {

--- a/packages/cursorless-engine/tsconfig.json
+++ b/packages/cursorless-engine/tsconfig.json
@@ -1,9 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "es2020",
-    "outDir": "out",
-    "rootDir": "src"
+    "target": "es2020"
   },
   "include": ["src/**/*.ts", "src/**/*.json", "../../typings/**/*.d.ts"],
   "references": [

--- a/packages/cursorless-org-docs/tsconfig.json
+++ b/packages/cursorless-org-docs/tsconfig.json
@@ -1,10 +1,8 @@
 {
   "extends": ["@tsconfig/docusaurus/tsconfig.json", "../../tsconfig.base.json"],
   "compilerOptions": {
-    "rootDir": "src",
     "esModuleInterop": true,
-    "emitDeclarationOnly": false,
-    "outDir": "out"
+    "emitDeclarationOnly": false
   },
   "references": [],
   "include": ["src/**/*.ts", "src/**/*.json", "../../typings/**/*.d.ts"]

--- a/packages/cursorless-org/tsconfig.json
+++ b/packages/cursorless-org/tsconfig.json
@@ -11,9 +11,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
-    "incremental": true,
-    "rootDir": "src",
-    "outDir": "out"
+    "incremental": true
   },
   "include": [
     "src/**/*.ts",

--- a/packages/cursorless-vscode-e2e/tsconfig.json
+++ b/packages/cursorless-vscode-e2e/tsconfig.json
@@ -1,9 +1,5 @@
 {
   "extends": "../../tsconfig.base.json",
-  "compilerOptions": {
-    "outDir": "out",
-    "rootDir": "src"
-  },
   "references": [
     {
       "path": "../common"

--- a/packages/cursorless-vscode/tsconfig.json
+++ b/packages/cursorless-vscode/tsconfig.json
@@ -1,9 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "es2020",
-    "outDir": "out",
-    "rootDir": "src"
+    "target": "es2020"
   },
   "include": ["src/**/*.ts", "src/**/*.json", "../../typings/**/*.d.ts"],
   "references": [

--- a/packages/meta-updater/src/updateTSConfig.ts
+++ b/packages/meta-updater/src/updateTSConfig.ts
@@ -5,7 +5,7 @@ import { pathExists } from "path-exists";
 import { PackageJson, TsConfigJson } from "type-fest";
 import { toPosixPath } from "./toPosixPath";
 import { Context } from "./Context";
-import { uniq } from "lodash-es";
+import { cloneDeep, isEqual, uniq } from "lodash-es";
 import { readFile } from "fs/promises";
 
 /**
@@ -89,14 +89,18 @@ export async function updateTSConfig(
     references.push({ path: relativePath });
   }
 
+  const compilerOptions = {
+    ...(cloneDeep(input.compilerOptions) ?? {}),
+  };
+  delete compilerOptions.outDir;
+  delete compilerOptions.rootDir;
+
   return {
     ...input,
     extends: getExtends(pathFromPackageToRoot, input.extends),
-    compilerOptions: {
-      ...(input.compilerOptions ?? {}),
-      rootDir: "src",
-      outDir: "out",
-    },
+
+    ...(isEqual(compilerOptions, {}) ? {} : { compilerOptions }),
+
     references: references.sort((r1, r2) => r1.path.localeCompare(r2.path)),
     include: [
       "src/**/*.ts",

--- a/packages/meta-updater/tsconfig.json
+++ b/packages/meta-updater/tsconfig.json
@@ -1,8 +1,6 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "out",
-    "rootDir": "src",
     "target": "es2020",
     "module": "ES2020",
     "moduleResolution": "node",

--- a/packages/node-common/tsconfig.json
+++ b/packages/node-common/tsconfig.json
@@ -1,9 +1,5 @@
 {
   "extends": "../../tsconfig.base.json",
-  "compilerOptions": {
-    "rootDir": "src",
-    "outDir": "out"
-  },
   "include": ["src/**/*.ts", "src/**/*.json", "../../typings/**/*.d.ts"],
   "references": [
     {

--- a/packages/sentence-parser/tsconfig.json
+++ b/packages/sentence-parser/tsconfig.json
@@ -1,9 +1,5 @@
 {
   "extends": "../../tsconfig.base.json",
-  "compilerOptions": {
-    "rootDir": "src",
-    "outDir": "out"
-  },
   "references": [],
   "include": ["src/**/*.ts", "src/**/*.json", "../../typings/**/*.d.ts"]
 }

--- a/packages/test-case-recorder/tsconfig.json
+++ b/packages/test-case-recorder/tsconfig.json
@@ -1,9 +1,5 @@
 {
   "extends": "../../tsconfig.base.json",
-  "compilerOptions": {
-    "rootDir": "src",
-    "outDir": "out"
-  },
   "include": ["src/**/*.ts", "src/**/*.json", "../../typings/**/*.d.ts"],
   "references": [
     {

--- a/packages/test-harness/tsconfig.json
+++ b/packages/test-harness/tsconfig.json
@@ -1,9 +1,5 @@
 {
   "extends": "../../tsconfig.base.json",
-  "compilerOptions": {
-    "outDir": "out",
-    "rootDir": "src"
-  },
   "include": ["src/**/*.ts", "src/**/*.json", "../../typings/**/*.d.ts"],
   "references": [
     {

--- a/packages/vscode-common/tsconfig.json
+++ b/packages/vscode-common/tsconfig.json
@@ -1,9 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "es2020",
-    "outDir": "out",
-    "rootDir": "src"
+    "target": "es2020"
   },
   "include": ["src/**/*.ts", "src/**/*.json", "../../typings/**/*.d.ts"],
   "references": [

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -11,6 +11,8 @@
     "composite": true,
     "forceConsistentCasingInFileNames": true,
     "isolatedModules": true,
-    "strict": true
+    "strict": true,
+    "rootDir": "${configDir}/src",
+    "outDir": "${configDir}/out"
   }
 }


### PR DESCRIPTION
This shipped in Typescript 5.5; see https://devblogs.microsoft.com/typescript/announcing-typescript-5-5/#the-configdir-template-variable-for-configuration-files

## Checklist

- [-] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [-] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [-] I have not broken the cheatsheet
