### PR TITLE
bump github action versions

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.x
       - run: corepack enable
@@ -24,6 +24,6 @@ jobs:
           node-version-file: .nvmrc
           cache: pnpm
       - run: pnpm --color install
-      - uses: pre-commit/action@v3.0.0
-      - uses: pre-commit-ci/lite-action@v1.0.1
+      - uses: pre-commit/action@v3.0.1
+      - uses: pre-commit-ci/lite-action@v1.0.2
         if: always()


### PR DESCRIPTION
To remove deprecation warning:

```
The following actions uses Node.js version which is deprecated and will be forced to run on node20: actions/setup-python@v4, actions/cache@v3, pre-commit-ci/lite-action@v1.0.1. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
```

Eg in https://github.com/cursorless-dev/cursorless/actions/runs/9993881129

## Checklist

- [-] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [-] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [-] I have not broken the cheatsheet
