### PR TITLE
Edit base copy and past

### DIFF
--- a/packages/common/src/ide/fake/FakeCapabilities.ts
+++ b/packages/common/src/ide/fake/FakeCapabilities.ts
@@ -2,6 +2,7 @@ import { Capabilities } from "../types/Capabilities";
 
 export class FakeCapabilities implements Capabilities {
   commands = {
+    clipboardPaste: undefined,
     clipboardCopy: undefined,
     toggleLineComment: undefined,
     indentLine: undefined,

--- a/packages/common/src/ide/types/Capabilities.ts
+++ b/packages/common/src/ide/types/Capabilities.ts
@@ -4,10 +4,14 @@ export interface Capabilities {
   readonly commands: CommandCapabilityMap;
 }
 
-export type CommandCapabilityMap = Record<
+type SimpleCommandCapabilityMap = Record<
   CommandId,
   CommandCapabilities | undefined
 >;
+
+export interface CommandCapabilityMap extends SimpleCommandCapabilityMap {
+  clipboardPaste: boolean | undefined;
+}
 
 export interface CommandCapabilities {
   acceptsLocation: boolean;

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -108,3 +108,4 @@ export * from "./util/toPlainObject";
 export * from "./util/type";
 export * from "./util/typeUtils";
 export * from "./util/uniqWithHash";
+export * from "./util/zipStrict";

--- a/packages/common/src/types/TextEditor.ts
+++ b/packages/common/src/types/TextEditor.ts
@@ -149,9 +149,8 @@ export interface EditableTextEditor extends TextEditor {
 
   /**
    * Paste clipboard content
-   * @param ranges A list of {@link Range ranges}
    */
-  clipboardPaste(ranges?: Range[]): Promise<void>;
+  clipboardPaste(): Promise<void>;
 
   /**
    * Toggle breakpoints. For each of the descriptors in {@link descriptors},

--- a/packages/common/src/util/zipStrict.ts
+++ b/packages/common/src/util/zipStrict.ts
@@ -1,0 +1,7 @@
+export function zipStrict<T1, T2>(list1: T1[], list2: T2[]): [T1, T2][] {
+  if (list1.length !== list2.length) {
+    throw new Error("Lists must have the same length");
+  }
+
+  return list1.map((value, index) => [value, list2[index]]);
+}

--- a/packages/cursorless-engine/src/actions/Actions.ts
+++ b/packages/cursorless-engine/src/actions/Actions.ts
@@ -6,6 +6,7 @@ import { BreakLine } from "./BreakLine";
 import { Bring, Move, Swap } from "./BringMoveSwap";
 import Call from "./Call";
 import Clear from "./Clear";
+import { CopyToClipboard } from "./CopyToClipboard";
 import { CutToClipboard } from "./CutToClipboard";
 import Deselect from "./Deselect";
 import { EditNew } from "./EditNew";
@@ -41,7 +42,6 @@ import {
 import { SetSpecialTarget } from "./SetSpecialTarget";
 import ShowParseTree from "./ShowParseTree";
 import {
-  CopyToClipboard,
   ExtractVariable,
   Fold,
   IndentLine,
@@ -76,7 +76,7 @@ export class Actions implements ActionRecord {
 
   callAsFunction = new Call(this);
   clearAndSetSelection = new Clear(this);
-  copyToClipboard = new CopyToClipboard(this.rangeUpdater);
+  copyToClipboard = new CopyToClipboard(this, this.rangeUpdater);
   cutToClipboard = new CutToClipboard(this);
   decrement = new Decrement(this);
   deselect = new Deselect();

--- a/packages/cursorless-engine/src/actions/CopyToClipboard.ts
+++ b/packages/cursorless-engine/src/actions/CopyToClipboard.ts
@@ -21,7 +21,7 @@ export class CopyToClipboard implements SimpleAction {
 
   async run(
     targets: Target[],
-    options: Options = {},
+    options: Options = { showDecorations: true },
   ): Promise<ActionReturnValue> {
     if (ide().capabilities.commands.clipboardCopy != null) {
       const simpleAction = new CopyToClipboardSimple(this.rangeUpdater);

--- a/packages/cursorless-engine/src/actions/CopyToClipboard.ts
+++ b/packages/cursorless-engine/src/actions/CopyToClipboard.ts
@@ -1,0 +1,46 @@
+import { FlashStyle } from "@cursorless/common";
+import type { RangeUpdater } from "../core/updateSelections/RangeUpdater";
+import { ide } from "../singletons/ide.singleton";
+import type { Target } from "../typings/target.types";
+import { flashTargets } from "../util/targetUtils";
+import type { Actions } from "./Actions";
+import { CopyToClipboardSimple } from "./SimpleIdeCommandActions";
+import type { ActionReturnValue, SimpleAction } from "./actions.types";
+
+interface Options {
+  showDecorations?: boolean;
+}
+
+export class CopyToClipboard implements SimpleAction {
+  constructor(
+    private actions: Actions,
+    private rangeUpdater: RangeUpdater,
+  ) {
+    this.run = this.run.bind(this);
+  }
+
+  async run(
+    targets: Target[],
+    options: Options = {},
+  ): Promise<ActionReturnValue> {
+    if (ide().capabilities.commands.clipboardCopy != null) {
+      const simpleAction = new CopyToClipboardSimple(this.rangeUpdater);
+      return simpleAction.run(targets, options);
+    }
+
+    if (options.showDecorations) {
+      await flashTargets(
+        ide(),
+        targets,
+        FlashStyle.referenced,
+        (target) => target.contentRange,
+      );
+    }
+
+    const text = targets.map((t) => t.contentText).join("\n");
+
+    await ide().clipboard.writeText(text);
+
+    return { thatTargets: targets };
+  }
+}

--- a/packages/cursorless-engine/src/actions/SimpleIdeCommandActions.ts
+++ b/packages/cursorless-engine/src/actions/SimpleIdeCommandActions.ts
@@ -58,7 +58,7 @@ abstract class SimpleIdeCommandAction {
   }
 }
 
-export class CopyToClipboard extends SimpleIdeCommandAction {
+export class CopyToClipboardSimple extends SimpleIdeCommandAction {
   command: CommandId = "clipboardCopy";
   ensureSingleEditor = true;
 }

--- a/packages/cursorless-vscode/src/ide/vscode/VscodeCapabilities.ts
+++ b/packages/cursorless-vscode/src/ide/vscode/VscodeCapabilities.ts
@@ -1,6 +1,7 @@
 import { Capabilities, CommandCapabilityMap } from "@cursorless/common";
 
 const COMMAND_CAPABILITIES: CommandCapabilityMap = {
+  clipboardPaste: true,
   clipboardCopy: { acceptsLocation: false },
   toggleLineComment: { acceptsLocation: false },
   indentLine: { acceptsLocation: false },

--- a/packages/cursorless-vscode/src/ide/vscode/VscodeTextEditorImpl.ts
+++ b/packages/cursorless-vscode/src/ide/vscode/VscodeTextEditorImpl.ts
@@ -175,7 +175,7 @@ export class VscodeTextEditorImpl implements EditableTextEditor {
     await vscode.commands.executeCommand("editor.action.clipboardCopyAction");
   }
 
-  public async clipboardPaste(_ranges?: Range[]): Promise<void> {
+  public async clipboardPaste(): Promise<void> {
     // We add these sleeps here to workaround a bug in VSCode. See #1521
     await sleep(100);
     await vscode.commands.executeCommand("editor.action.clipboardPasteAction");


### PR DESCRIPTION
For ide that don't have vscode specific copy and paste behavior I have now implemented a text edit basted copy and paste. This also gives us a starting platform if we want to try to implement vscodes behavior ourself.

## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet
