### PR TITLE
Support funk name scope in map

### DIFF
--- a/data/fixtures/scopes/javascript.core/functionName2.scope
+++ b/data/fixtures/scopes/javascript.core/functionName2.scope
@@ -1,0 +1,20 @@
+map = { funk: () => { } }
+---
+
+[Content] = 0:8-0:12
+          >----<
+0| map = { funk: () => { } }
+
+[Removal] = 0:7-0:12
+         >-----<
+0| map = { funk: () => { } }
+
+[Leading delimiter] = 0:7-0:8
+         >-<
+0| map = { funk: () => { } }
+
+[Domain] = 0:8-0:23
+          >---------------<
+0| map = { funk: () => { } }
+
+[Insertion delimiter] = " "

--- a/data/fixtures/scopes/javascript.core/functionName3.scope
+++ b/data/fixtures/scopes/javascript.core/functionName3.scope
@@ -1,0 +1,20 @@
+map = { funk: function() { } }
+---
+
+[Content] = 0:8-0:12
+          >----<
+0| map = { funk: function() { } }
+
+[Removal] = 0:7-0:12
+         >-----<
+0| map = { funk: function() { } }
+
+[Leading delimiter] = 0:7-0:8
+         >-<
+0| map = { funk: function() { } }
+
+[Domain] = 0:8-0:28
+          >--------------------<
+0| map = { funk: function() { } }
+
+[Insertion delimiter] = " "

--- a/queries/javascript.function.scm
+++ b/queries/javascript.function.scm
@@ -165,3 +165,17 @@
     (method_definition)
   )
 ] @namedFunction.iteration @functionName.iteration
+
+;;!! { funk: function() { } }
+;;!    ^^^^
+(pair
+  key: (_) @functionName @name
+  value: (function_expression)
+) @_.domain
+
+;;!! { funk: () => { } }
+;;!    ^^^^
+(pair
+  key: (_) @functionName @name
+  value: (arrow_function)
+) @_.domain


### PR DESCRIPTION
Since `const funk = ()  => {}` works I assumed that a function in a map would be treated the same. 

## Checklist

- [x] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [/] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [/] I have not broken the cheatsheet
