### PR TITLE
Stop using Intl.Collator

### DIFF
--- a/packages/cursorless-engine/src/actions/Sort.ts
+++ b/packages/cursorless-engine/src/actions/Sort.ts
@@ -45,13 +45,15 @@ abstract class SortBase implements SimpleAction {
 }
 
 export class Sort extends SortBase {
-  private collator = new Intl.Collator(undefined, {
+  private readonly options: Intl.CollatorOptions = {
     numeric: true,
     caseFirst: "upper",
-  });
+  };
 
   protected sortTexts(texts: string[]) {
-    return texts.sort(this.collator.compare);
+    return texts.sort((a, b) => {
+      return a.localeCompare(b, undefined, this.options);
+    });
   }
 }
 

--- a/packages/cursorless-engine/src/actions/Sort.ts
+++ b/packages/cursorless-engine/src/actions/Sort.ts
@@ -45,15 +45,13 @@ abstract class SortBase implements SimpleAction {
 }
 
 export class Sort extends SortBase {
-  private readonly options: Intl.CollatorOptions = {
-    numeric: true,
-    caseFirst: "upper",
-  };
-
   protected sortTexts(texts: string[]) {
-    return texts.sort((a, b) => {
-      return a.localeCompare(b, undefined, this.options);
-    });
+    return texts.sort((a, b) =>
+      a.localeCompare(b, undefined, {
+        numeric: true,
+        caseFirst: "upper",
+      }),
+    );
   }
 }
 


### PR DESCRIPTION
`Intl.Collator` is not available in all environments. `localeCompare` gives the same result

## Checklist

- [/] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [/] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [/] I have not broken the cheatsheet
