### PR TITLE
feat: add manual workflow dispatch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,7 @@ on:
     types: [opened, synchronize, reopened]
   merge_group:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   test:


### PR DESCRIPTION
This is a very minor tweak, but super useful for testing workflows. It allows you to trigger workflows manually via a github repo's actions tab, or even more useful is running the workflows on alternative branches via the command line. So for example if I am testing changes I've pushed to workflow in my own dev branch and want to quickly see if it works without having to send a PR or work on main branch to trigger, I can do something like this: `gh workflow run "Run Tests" --ref fix-lua-test-ci` and it will manually trigger the `Run Tests` workflow.