### PR TITLE
New interface for performing edits and updating ranges

### DIFF
--- a/packages/cursorless-engine/src/actions/BreakLine.ts
+++ b/packages/cursorless-engine/src/actions/BreakLine.ts
@@ -7,7 +7,7 @@ import {
 } from "@cursorless/common";
 import { flatten, zip } from "lodash-es";
 import type { RangeUpdater } from "../core/updateSelections/RangeUpdater";
-import { EditsUpdater } from "../core/updateSelections/updateSelections";
+import { performEditsAndUpdateSelections } from "../core/updateSelections/updateSelections";
 import { ide } from "../singletons/ide.singleton";
 import { Target } from "../typings/target.types";
 import { flashTargets, runOnTargetsForEachEditor } from "../util/targetUtils";
@@ -27,12 +27,15 @@ export class BreakLine {
         const edits = getEdits(editor, contentRanges);
         const editableEditor = ide().getEditableTextEditor(editor);
 
-        const {
-          ranges: [updatedRanges],
-        } = await new EditsUpdater(this.rangeUpdater, editableEditor, edits)
-          .ranges(contentRanges)
-          .updateEditorSelections()
-          .run();
+        const { contentRanges: updatedRanges } =
+          await performEditsAndUpdateSelections({
+            rangeUpdater: this.rangeUpdater,
+            editor: editableEditor,
+            edits,
+            selections: {
+              contentRanges,
+            },
+          });
 
         return zip(targets, updatedRanges).map(([target, range]) => ({
           editor: target!.editor,

--- a/packages/cursorless-engine/src/actions/CallbackAction.ts
+++ b/packages/cursorless-engine/src/actions/CallbackAction.ts
@@ -114,7 +114,7 @@ export class CallbackAction {
     // Reset original selections
     if (options.setSelection && options.restoreSelection) {
       // NB: We don't focus the editor here because we'll do that at the
-      // very end. This code can run on mul:truetiple editors in the course of
+      // very end. This code can run on multiple editors in the course of
       // one command, so we want to avoid focusing the editor multiple
       // times.
       await editableEditor.setSelections(updatedOriginalSelections);

--- a/packages/cursorless-engine/src/actions/CallbackAction.ts
+++ b/packages/cursorless-engine/src/actions/CallbackAction.ts
@@ -104,7 +104,7 @@ export class CallbackAction {
       rangeUpdater: this.rangeUpdater,
       editor: editableEditor,
       callback: () => options.callback(editableEditor, targets),
-      preserveEditorSelections: true,
+      preserveCursorSelections: true,
       selections: {
         originalSelections,
         targetSelections,

--- a/packages/cursorless-engine/src/actions/EditNew/runEditTargets.ts
+++ b/packages/cursorless-engine/src/actions/EditNew/runEditTargets.ts
@@ -62,7 +62,7 @@ export async function runEditTargets(
     rangeUpdater,
     editor,
     edits,
-    preserveEditorSelections: true,
+    preserveCursorSelections: true,
     selections: {
       thatRanges: state.thatRanges,
       cursorRanges,

--- a/packages/cursorless-engine/src/actions/EditNew/runEditTargets.ts
+++ b/packages/cursorless-engine/src/actions/EditNew/runEditTargets.ts
@@ -1,7 +1,7 @@
 import { EditableTextEditor, RangeExpansionBehavior } from "@cursorless/common";
 import { zip } from "lodash-es";
 import { RangeUpdater } from "../../core/updateSelections/RangeUpdater";
-import { EditsUpdater } from "../../core/updateSelections/updateSelections";
+import { performEditsAndUpdateSelections } from "../../core/updateSelections/updateSelections";
 import { EditDestination, State } from "./EditNew.types";
 
 /**
@@ -55,13 +55,23 @@ export async function runEditTargets(
   const editRanges = edits.map((edit) => edit.range);
 
   const {
-    ranges: [updatedThatRanges, updatedCursorRanges, updatedEditRanges],
-  } = await new EditsUpdater(rangeUpdater, editor, edits)
-    .ranges(state.thatRanges)
-    .ranges(cursorRanges)
-    .ranges(editRanges, RangeExpansionBehavior.openOpen)
-    // .updateEditorSelections()
-    .run();
+    thatRanges: updatedThatRanges,
+    cursorRanges: updatedCursorRanges,
+    editRanges: updatedEditRanges,
+  } = await performEditsAndUpdateSelections({
+    rangeUpdater,
+    editor,
+    edits,
+    preserveEditorSelections: true,
+    selections: {
+      thatRanges: state.thatRanges,
+      cursorRanges,
+      editRanges: {
+        selections: editRanges,
+        behavior: RangeExpansionBehavior.openOpen,
+      },
+    },
+  });
 
   const finalCursorRanges = [...state.cursorRanges];
 

--- a/packages/cursorless-engine/src/actions/EditNew/runInsertLineAfterTargets.ts
+++ b/packages/cursorless-engine/src/actions/EditNew/runInsertLineAfterTargets.ts
@@ -60,7 +60,7 @@ export async function runInsertLineAfterTargets(
       rangeUpdater,
       editor,
       callback,
-      preserveEditorSelections: true,
+      preserveCursorSelections: true,
       selections: {
         targetRanges,
         thatRanges: state.thatRanges,

--- a/packages/cursorless-engine/src/actions/InsertEmptyLines.ts
+++ b/packages/cursorless-engine/src/actions/InsertEmptyLines.ts
@@ -1,11 +1,11 @@
-import { FlashStyle, Range, Selection, toLineRange } from "@cursorless/common";
+import { FlashStyle, Range, toLineRange } from "@cursorless/common";
 import { flatten } from "lodash-es";
 import { RangeUpdater } from "../core/updateSelections/RangeUpdater";
-import { performEditsAndUpdateSelections } from "../core/updateSelections/updateSelections";
+import { EditsUpdater } from "../core/updateSelections/updateSelections";
 import { ide } from "../singletons/ide.singleton";
 import { Target } from "../typings/target.types";
 import { runOnTargetsForEachEditor } from "../util/targetUtils";
-import { SimpleAction, ActionReturnValue } from "./actions.types";
+import { ActionReturnValue, SimpleAction } from "./actions.types";
 
 class InsertEmptyLines implements SimpleAction {
   constructor(
@@ -45,22 +45,19 @@ class InsertEmptyLines implements SimpleAction {
       await runOnTargetsForEachEditor(targets, async (editor, targets) => {
         const ranges = this.getRanges(targets);
         const edits = this.getEdits(ranges);
-
+        const contentSelections = targets.map(
+          (target) => target.thatTarget.contentSelection,
+        );
         const editableEditor = ide().getEditableTextEditor(editor);
 
-        const [updatedThatSelections, lineSelections, updatedCursorSelections] =
-          await performEditsAndUpdateSelections(
-            this.rangeUpdater,
-            editableEditor,
-            edits,
-            [
-              targets.map((target) => target.thatTarget.contentSelection),
-              ranges.map((range) => new Selection(range.start, range.end)),
-              editor.selections,
-            ],
-          );
-
-        await editableEditor.setSelections(updatedCursorSelections);
+        const {
+          selections: [updatedThatSelections],
+          ranges: [lineSelections],
+        } = await new EditsUpdater(this.rangeUpdater, editableEditor, edits)
+          .selections(contentSelections)
+          .ranges(ranges)
+          .updateEditorSelections()
+          .run();
 
         return {
           thatMark: updatedThatSelections.map((selection) => ({

--- a/packages/cursorless-engine/src/actions/InsertEmptyLines.ts
+++ b/packages/cursorless-engine/src/actions/InsertEmptyLines.ts
@@ -1,7 +1,7 @@
 import { FlashStyle, Range, toLineRange } from "@cursorless/common";
 import { flatten } from "lodash-es";
 import { RangeUpdater } from "../core/updateSelections/RangeUpdater";
-import { EditsUpdater } from "../core/updateSelections/updateSelections";
+import { performEditsAndUpdateSelections } from "../core/updateSelections/updateSelections";
 import { ide } from "../singletons/ide.singleton";
 import { Target } from "../typings/target.types";
 import { runOnTargetsForEachEditor } from "../util/targetUtils";
@@ -51,13 +51,17 @@ class InsertEmptyLines implements SimpleAction {
         const editableEditor = ide().getEditableTextEditor(editor);
 
         const {
-          selections: [updatedThatSelections],
-          ranges: [lineSelections],
-        } = await new EditsUpdater(this.rangeUpdater, editableEditor, edits)
-          .selections(contentSelections)
-          .ranges(ranges)
-          .updateEditorSelections()
-          .run();
+          contentSelections: updatedThatSelections,
+          ranges: lineSelections,
+        } = await performEditsAndUpdateSelections({
+          rangeUpdater: this.rangeUpdater,
+          editor: editableEditor,
+          edits,
+          selections: {
+            contentSelections,
+            ranges,
+          },
+        });
 
         return {
           thatMark: updatedThatSelections.map((selection) => ({

--- a/packages/cursorless-engine/src/actions/InsertSnippet.ts
+++ b/packages/cursorless-engine/src/actions/InsertSnippet.ts
@@ -8,10 +8,7 @@ import {
 } from "@cursorless/common";
 import { Snippets } from "../core/Snippets";
 import { RangeUpdater } from "../core/updateSelections/RangeUpdater";
-import {
-  callFunctionAndUpdateSelectionInfos,
-  getSelectionInfo,
-} from "../core/updateSelections/updateSelections";
+import { CallbackUpdater } from "../core/updateSelections/updateSelections";
 import { ModifierStageFactory } from "../processTargets/ModifierStageFactory";
 import { ModifyIfUntypedExplicitStage } from "../processTargets/modifiers/ConditionalModifierStages";
 import { UntypedTarget } from "../processTargets/targets";
@@ -116,13 +113,6 @@ export default class InsertSnippet {
 
     await this.actions.editNew.run(destinations);
 
-    const targetSelectionInfos = editor.selections.map((selection) =>
-      getSelectionInfo(
-        editor.document,
-        selection,
-        RangeExpansionBehavior.openOpen,
-      ),
-    );
     const { body, formatSubstitutions } = this.getSnippetInfo(
       snippetDescription,
       // Use new selection locations instead of original targets because
@@ -147,15 +137,13 @@ export default class InsertSnippet {
     );
 
     const snippetString = parsedSnippet.toTextmateString();
+    const callback = () => editor.insertSnippet(snippetString);
 
-    // NB: We used the command "editor.action.insertSnippet" instead of calling editor.insertSnippet
-    // because the latter doesn't support special variables like CLIPBOARD
-    const [updatedTargetSelections] = await callFunctionAndUpdateSelectionInfos(
-      this.rangeUpdater,
-      () => editor.insertSnippet(snippetString),
-      editor.document,
-      [targetSelectionInfos],
-    );
+    const {
+      selections: [updatedTargetSelections],
+    } = await new CallbackUpdater(this.rangeUpdater, editor, callback)
+      .selections(editor.selections, RangeExpansionBehavior.openOpen)
+      .run();
 
     return {
       thatSelections: updatedTargetSelections.map((selection) => ({

--- a/packages/cursorless-engine/src/actions/InsertSnippet.ts
+++ b/packages/cursorless-engine/src/actions/InsertSnippet.ts
@@ -143,7 +143,7 @@ export default class InsertSnippet {
         rangeUpdater: this.rangeUpdater,
         editor,
         callback: () => editor.insertSnippet(snippetString),
-        preserveEditorSelections: true,
+        preserveCursorSelections: true,
         selections: {
           editorSelections: {
             selections: editor.selections,

--- a/packages/cursorless-engine/src/actions/JoinLines.ts
+++ b/packages/cursorless-engine/src/actions/JoinLines.ts
@@ -2,7 +2,7 @@ import { Edit, FlashStyle, Range, TextEditor } from "@cursorless/common";
 import { range as iterRange, map, pairwise } from "itertools";
 import { flatten, zip } from "lodash-es";
 import type { RangeUpdater } from "../core/updateSelections/RangeUpdater";
-import { performEditsAndUpdateRanges } from "../core/updateSelections/updateSelections";
+import { EditsUpdater } from "../core/updateSelections/updateSelections";
 import { ide } from "../singletons/ide.singleton";
 import { Target } from "../typings/target.types";
 import { flashTargets, runOnTargetsForEachEditor } from "../util/targetUtils";
@@ -20,13 +20,14 @@ export default class JoinLines {
       await runOnTargetsForEachEditor(targets, async (editor, targets) => {
         const contentRanges = targets.map(({ contentRange }) => contentRange);
         const edits = getEdits(editor, contentRanges);
+        const editableEditor = ide().getEditableTextEditor(editor);
 
-        const [updatedRanges] = await performEditsAndUpdateRanges(
-          this.rangeUpdater,
-          ide().getEditableTextEditor(editor),
-          edits,
-          [contentRanges],
-        );
+        const {
+          ranges: [updatedRanges],
+        } = await new EditsUpdater(this.rangeUpdater, editableEditor, edits)
+          .ranges(contentRanges)
+          .updateEditorSelections()
+          .run();
 
         return zip(targets, updatedRanges).map(([target, range]) => ({
           editor: target!.editor,

--- a/packages/cursorless-engine/src/actions/JoinLines.ts
+++ b/packages/cursorless-engine/src/actions/JoinLines.ts
@@ -2,7 +2,7 @@ import { Edit, FlashStyle, Range, TextEditor } from "@cursorless/common";
 import { range as iterRange, map, pairwise } from "itertools";
 import { flatten, zip } from "lodash-es";
 import type { RangeUpdater } from "../core/updateSelections/RangeUpdater";
-import { EditsUpdater } from "../core/updateSelections/updateSelections";
+import { performEditsAndUpdateSelections } from "../core/updateSelections/updateSelections";
 import { ide } from "../singletons/ide.singleton";
 import { Target } from "../typings/target.types";
 import { flashTargets, runOnTargetsForEachEditor } from "../util/targetUtils";
@@ -19,15 +19,16 @@ export default class JoinLines {
     const thatSelections = flatten(
       await runOnTargetsForEachEditor(targets, async (editor, targets) => {
         const contentRanges = targets.map(({ contentRange }) => contentRange);
-        const edits = getEdits(editor, contentRanges);
-        const editableEditor = ide().getEditableTextEditor(editor);
 
-        const {
-          ranges: [updatedRanges],
-        } = await new EditsUpdater(this.rangeUpdater, editableEditor, edits)
-          .ranges(contentRanges)
-          .updateEditorSelections()
-          .run();
+        const { contentRanges: updatedRanges } =
+          await performEditsAndUpdateSelections({
+            rangeUpdater: this.rangeUpdater,
+            editor: ide().getEditableTextEditor(editor),
+            edits: getEdits(editor, contentRanges),
+            selections: {
+              contentRanges,
+            },
+          });
 
         return zip(targets, updatedRanges).map(([target, range]) => ({
           editor: target!.editor,

--- a/packages/cursorless-engine/src/actions/PasteFromClipboard.ts
+++ b/packages/cursorless-engine/src/actions/PasteFromClipboard.ts
@@ -4,10 +4,7 @@ import {
   toCharacterRange,
 } from "@cursorless/common";
 import { RangeUpdater } from "../core/updateSelections/RangeUpdater";
-import {
-  callFunctionAndUpdateSelections,
-  callFunctionAndUpdateSelectionsWithBehavior,
-} from "../core/updateSelections/updateSelections";
+import { CallbackUpdater } from "../core/updateSelections/updateSelections";
 import { ide } from "../singletons/ide.singleton";
 import { Destination } from "../typings/target.types";
 import { ensureSingleEditor } from "../util/targetUtils";
@@ -29,32 +26,25 @@ export class PasteFromClipboard {
     // First call editNew in order to insert delimiters if necessary and leave
     // the cursor in the right position. Note that this action will focus the
     // editor containing the targets
-    const [originalCursorSelections] = await callFunctionAndUpdateSelections(
-      this.rangeUpdater,
-      async () => {
-        await this.actions.editNew.run(destinations);
-      },
-      editor.document,
-      [editor.selections],
-    );
+    const callbackEdit = async () => {
+      await this.actions.editNew.run(destinations);
+    };
+    const {
+      selections: [originalCursorSelections],
+    } = await new CallbackUpdater(this.rangeUpdater, editor, callbackEdit)
+      .selections(editor.selections)
+      .run();
 
     // Then use VSCode paste command, using open ranges at the place where we
     // paste in order to capture the pasted text for highlights and `that` mark
-    const [updatedCursorSelections, updatedTargetSelections] =
-      await callFunctionAndUpdateSelectionsWithBehavior(
-        this.rangeUpdater,
-        () => editor.clipboardPaste(),
-        editor.document,
-        [
-          {
-            selections: originalCursorSelections,
-          },
-          {
-            selections: editor.selections,
-            rangeBehavior: RangeExpansionBehavior.openOpen,
-          },
-        ],
-      );
+    const callbackPaste = () => editor.clipboardPaste();
+    const {
+      selections: [updatedCursorSelections, updatedTargetSelections],
+    } = await new CallbackUpdater(this.rangeUpdater, editor, callbackPaste)
+      .selections(originalCursorSelections)
+      .selections(editor.selections, RangeExpansionBehavior.openOpen)
+      .updateEditorSelections()
+      .run();
 
     // Reset cursors on the editor where the edits took place.
     // NB: We don't focus the editor here because we want to focus the original

--- a/packages/cursorless-engine/src/actions/PasteFromClipboard.ts
+++ b/packages/cursorless-engine/src/actions/PasteFromClipboard.ts
@@ -34,7 +34,7 @@ export class PasteFromClipboard {
       await performEditsAndUpdateSelections({
         rangeUpdater: this.rangeUpdater,
         editor,
-        preserveEditorSelections: true,
+        preserveCursorSelections: true,
         callback: callbackEdit,
         selections: {
           cursorSelections: editor.selections,

--- a/packages/cursorless-engine/src/actions/Remove.ts
+++ b/packages/cursorless-engine/src/actions/Remove.ts
@@ -1,13 +1,13 @@
-import { FlashStyle, Selection, TextEditor } from "@cursorless/common";
+import { FlashStyle, TextEditor } from "@cursorless/common";
 import { flatten, zip } from "lodash-es";
 import { RangeUpdater } from "../core/updateSelections/RangeUpdater";
-import { performEditsAndUpdateSelections } from "../core/updateSelections/updateSelections";
+import { EditsUpdater } from "../core/updateSelections/updateSelections";
 import { RawSelectionTarget } from "../processTargets/targets";
 import { ide } from "../singletons/ide.singleton";
 import { Target } from "../typings/target.types";
 import { flashTargets, runOnTargetsForEachEditor } from "../util/targetUtils";
 import { unifyRemovalTargets } from "../util/unifyRanges";
-import { SimpleAction, ActionReturnValue } from "./actions.types";
+import { ActionReturnValue, SimpleAction } from "./actions.types";
 
 export default class Delete implements SimpleAction {
   constructor(private rangeUpdater: RangeUpdater) {
@@ -37,22 +37,16 @@ export default class Delete implements SimpleAction {
 
   private async runForEditor(editor: TextEditor, targets: Target[]) {
     const edits = targets.map((target) => target.constructRemovalEdit());
-
-    const cursorSelections = editor.selections;
-    const editSelections = edits.map(({ range }) => range.toSelection(false));
     const editableEditor = ide().getEditableTextEditor(editor);
 
-    const [updatedCursorSelections, updatedEditSelections]: Selection[][] =
-      await performEditsAndUpdateSelections(
-        this.rangeUpdater,
-        editableEditor,
-        edits,
-        [cursorSelections, editSelections],
-      );
+    const {
+      ranges: [updatedEditRanges],
+    } = await new EditsUpdater(this.rangeUpdater, editableEditor, edits)
+      .ranges(edits.map(({ range }) => range))
+      .updateEditorSelections()
+      .run();
 
-    await editableEditor.setSelections(updatedCursorSelections);
-
-    return zip(targets, updatedEditSelections).map(
+    return zip(targets, updatedEditRanges).map(
       ([target, range]) =>
         new RawSelectionTarget({
           editor: target!.editor,

--- a/packages/cursorless-engine/src/actions/Replace.ts
+++ b/packages/cursorless-engine/src/actions/Replace.ts
@@ -5,7 +5,7 @@ import {
 } from "@cursorless/common";
 import { zip } from "lodash-es";
 import { RangeUpdater } from "../core/updateSelections/RangeUpdater";
-import { EditsUpdater } from "../core/updateSelections/updateSelections";
+import { performEditsAndUpdateSelections } from "../core/updateSelections/updateSelections";
 import { ide } from "../singletons/ide.singleton";
 import { SelectionWithEditor } from "../typings/Types";
 import { Destination, Target } from "../typings/target.types";
@@ -72,13 +72,20 @@ export default class Replace {
         const editableEditor = ide().getEditableTextEditor(editor);
 
         const {
-          selections: [updatedContentSelections],
-          ranges: [updatedEditRanges],
-        } = await new EditsUpdater(this.rangeUpdater, editableEditor, edits)
-          .selections(contentSelections)
-          .ranges(editRanges, RangeExpansionBehavior.openOpen)
-          .updateEditorSelections()
-          .run();
+          contentSelections: updatedContentSelections,
+          editRanges: updatedEditRanges,
+        } = await performEditsAndUpdateSelections({
+          rangeUpdater: this.rangeUpdater,
+          editor: editableEditor,
+          edits,
+          selections: {
+            contentSelections,
+            editRanges: {
+              selections: editRanges,
+              behavior: RangeExpansionBehavior.openOpen,
+            },
+          },
+        });
 
         for (const [wrapper, selection] of zip(
           editWrappers,

--- a/packages/cursorless-engine/src/actions/Replace.ts
+++ b/packages/cursorless-engine/src/actions/Replace.ts
@@ -65,23 +65,20 @@ export default class Replace {
       (edit) => edit.editor,
       async (editor, editWrappers) => {
         const edits = editWrappers.map(({ edit }) => edit);
-        const contentSelections = editWrappers.map(
-          ({ target }) => target.contentSelection,
-        );
-        const editRanges = edits.map(({ range }) => range);
-        const editableEditor = ide().getEditableTextEditor(editor);
 
         const {
           contentSelections: updatedContentSelections,
           editRanges: updatedEditRanges,
         } = await performEditsAndUpdateSelections({
           rangeUpdater: this.rangeUpdater,
-          editor: editableEditor,
+          editor: ide().getEditableTextEditor(editor),
           edits,
           selections: {
-            contentSelections,
+            contentSelections: editWrappers.map(
+              ({ target }) => target.contentSelection,
+            ),
             editRanges: {
-              selections: editRanges,
+              selections: edits.map(({ range }) => range),
               behavior: RangeExpansionBehavior.openOpen,
             },
           },

--- a/packages/cursorless-engine/src/actions/Wrap.ts
+++ b/packages/cursorless-engine/src/actions/Wrap.ts
@@ -6,7 +6,7 @@ import {
   toCharacterRange,
 } from "@cursorless/common";
 import { RangeUpdater } from "../core/updateSelections/RangeUpdater";
-import { EditsUpdater } from "../core/updateSelections/updateSelections";
+import { performEditsAndUpdateSelections } from "../core/updateSelections/updateSelections";
 import { ide } from "../singletons/ide.singleton";
 import { Target } from "../typings/target.types";
 import { runOnTargetsForEachEditor } from "../util/targetUtils";
@@ -55,25 +55,30 @@ export default class Wrap {
         );
 
         const {
-          selections: [
-            delimiterStartSelections,
-            delimiterEndSelections,
-            sourceMarkSelections,
-            thatMarkSelections,
-          ],
-        } = await new EditsUpdater(this.rangeUpdater, editableEditor, edits)
-          .selections(
-            boundariesStartSelections,
-            RangeExpansionBehavior.openClosed,
-          )
-          .selections(
-            boundariesEndSelections,
-            RangeExpansionBehavior.closedOpen,
-          )
-          .selections(contentSelections)
-          .selections(contentSelections, RangeExpansionBehavior.openOpen)
-          .updateEditorSelections()
-          .run();
+          boundariesStartSelections: delimiterStartSelections,
+          boundariesEndSelections: delimiterEndSelections,
+          sourceSelections: sourceMarkSelections,
+          thatSelections: thatMarkSelections,
+        } = await performEditsAndUpdateSelections({
+          rangeUpdater: this.rangeUpdater,
+          editor: editableEditor,
+          edits,
+          selections: {
+            boundariesStartSelections: {
+              selections: boundariesStartSelections,
+              behavior: RangeExpansionBehavior.openClosed,
+            },
+            boundariesEndSelections: {
+              selections: boundariesEndSelections,
+              behavior: RangeExpansionBehavior.closedOpen,
+            },
+            sourceSelections: contentSelections,
+            thatSelections: {
+              selections: contentSelections,
+              behavior: RangeExpansionBehavior.openOpen,
+            },
+          },
+        });
 
         const delimiterSelections = [
           ...delimiterStartSelections,

--- a/packages/cursorless-engine/src/actions/Wrap.ts
+++ b/packages/cursorless-engine/src/actions/Wrap.ts
@@ -6,13 +6,9 @@ import {
   toCharacterRange,
 } from "@cursorless/common";
 import { RangeUpdater } from "../core/updateSelections/RangeUpdater";
-import {
-  getSelectionInfo,
-  performEditsAndUpdateFullSelectionInfos,
-} from "../core/updateSelections/updateSelections";
+import { EditsUpdater } from "../core/updateSelections/updateSelections";
 import { ide } from "../singletons/ide.singleton";
 import { Target } from "../typings/target.types";
-import { FullSelectionInfo } from "../typings/updateSelections";
 import { runOnTargetsForEachEditor } from "../util/targetUtils";
 import { ActionReturnValue } from "./actions.types";
 
@@ -29,7 +25,6 @@ export default class Wrap {
     const results = await runOnTargetsForEachEditor(
       targets,
       async (editor, targets) => {
-        const { document } = editor;
         const boundaries = targets.map((target) => ({
           start: new Selection(
             target.contentRange.start,
@@ -50,67 +45,40 @@ export default class Wrap {
           },
         ]);
 
-        const delimiterSelectionInfos: FullSelectionInfo[] = boundaries.flatMap(
-          ({ start, end }) => {
-            return [
-              getSelectionInfo(
-                document,
-                start,
-                RangeExpansionBehavior.openClosed,
-              ),
-              getSelectionInfo(
-                document,
-                end,
-                RangeExpansionBehavior.closedOpen,
-              ),
-            ];
-          },
-        );
-
-        const cursorSelectionInfos = editor.selections.map((selection) =>
-          getSelectionInfo(
-            document,
-            selection,
-            RangeExpansionBehavior.closedClosed,
-          ),
-        );
-
-        const sourceMarkSelectionInfos = targets.map((target) =>
-          getSelectionInfo(
-            document,
-            target.contentSelection,
-            RangeExpansionBehavior.closedClosed,
-          ),
-        );
-
-        const thatMarkSelectionInfos = targets.map((target) =>
-          getSelectionInfo(
-            document,
-            target.contentSelection,
-            RangeExpansionBehavior.openOpen,
-          ),
-        );
+        const boundariesStartSelections = boundaries.map(({ start }) => start);
+        const boundariesEndSelections = boundaries.map(({ end }) => end);
 
         const editableEditor = ide().getEditableTextEditor(editor);
 
-        const [
-          delimiterSelections,
-          cursorSelections,
-          sourceMarkSelections,
-          thatMarkSelections,
-        ] = await performEditsAndUpdateFullSelectionInfos(
-          this.rangeUpdater,
-          editableEditor,
-          edits,
-          [
-            delimiterSelectionInfos,
-            cursorSelectionInfos,
-            sourceMarkSelectionInfos,
-            thatMarkSelectionInfos,
-          ],
+        const contentSelections = targets.map(
+          (target) => target.contentSelection,
         );
 
-        await editableEditor.setSelections(cursorSelections);
+        const {
+          selections: [
+            delimiterStartSelections,
+            delimiterEndSelections,
+            sourceMarkSelections,
+            thatMarkSelections,
+          ],
+        } = await new EditsUpdater(this.rangeUpdater, editableEditor, edits)
+          .selections(
+            boundariesStartSelections,
+            RangeExpansionBehavior.openClosed,
+          )
+          .selections(
+            boundariesEndSelections,
+            RangeExpansionBehavior.closedOpen,
+          )
+          .selections(contentSelections)
+          .selections(contentSelections, RangeExpansionBehavior.openOpen)
+          .updateEditorSelections()
+          .run();
+
+        const delimiterSelections = [
+          ...delimiterStartSelections,
+          ...delimiterEndSelections,
+        ];
 
         await ide().flashRanges(
           delimiterSelections.map((selection) => ({

--- a/packages/cursorless-engine/src/actions/Wrap.ts
+++ b/packages/cursorless-engine/src/actions/Wrap.ts
@@ -72,7 +72,10 @@ export default class Wrap {
               selections: boundariesEndSelections,
               behavior: RangeExpansionBehavior.closedOpen,
             },
-            sourceSelections: contentSelections,
+            sourceSelections: {
+              selections: contentSelections,
+              behavior: RangeExpansionBehavior.closedClosed,
+            },
             thatSelections: {
               selections: contentSelections,
               behavior: RangeExpansionBehavior.openOpen,

--- a/packages/cursorless-engine/src/actions/Wrap.ts
+++ b/packages/cursorless-engine/src/actions/Wrap.ts
@@ -45,11 +45,6 @@ export default class Wrap {
           },
         ]);
 
-        const boundariesStartSelections = boundaries.map(({ start }) => start);
-        const boundariesEndSelections = boundaries.map(({ end }) => end);
-
-        const editableEditor = ide().getEditableTextEditor(editor);
-
         const contentSelections = targets.map(
           (target) => target.contentSelection,
         );
@@ -61,15 +56,15 @@ export default class Wrap {
           thatSelections: thatMarkSelections,
         } = await performEditsAndUpdateSelections({
           rangeUpdater: this.rangeUpdater,
-          editor: editableEditor,
+          editor: ide().getEditableTextEditor(editor),
           edits,
           selections: {
             boundariesStartSelections: {
-              selections: boundariesStartSelections,
+              selections: boundaries.map(({ start }) => start),
               behavior: RangeExpansionBehavior.openClosed,
             },
             boundariesEndSelections: {
-              selections: boundariesEndSelections,
+              selections: boundaries.map(({ end }) => end),
               behavior: RangeExpansionBehavior.closedOpen,
             },
             sourceSelections: {

--- a/packages/cursorless-engine/src/actions/WrapWithSnippet.ts
+++ b/packages/cursorless-engine/src/actions/WrapWithSnippet.ts
@@ -110,7 +110,7 @@ export default class WrapWithSnippet {
         rangeUpdater: this.rangeUpdater,
         editor,
         callback,
-        preserveEditorSelections: true,
+        preserveCursorSelections: true,
         selections: {
           targetSelections,
         },

--- a/packages/cursorless-engine/src/actions/WrapWithSnippet.ts
+++ b/packages/cursorless-engine/src/actions/WrapWithSnippet.ts
@@ -1,7 +1,7 @@
 import { FlashStyle, ScopeType, WrapWithSnippetArg } from "@cursorless/common";
 import { Snippets } from "../core/Snippets";
 import { RangeUpdater } from "../core/updateSelections/RangeUpdater";
-import { CallbackUpdater } from "../core/updateSelections/updateSelections";
+import { performEditsAndUpdateSelections } from "../core/updateSelections/updateSelections";
 import { ModifierStageFactory } from "../processTargets/ModifierStageFactory";
 import { ModifyIfUntypedStage } from "../processTargets/modifiers/ConditionalModifierStages";
 import { ide } from "../singletons/ide.singleton";
@@ -105,11 +105,16 @@ export default class WrapWithSnippet {
     const callback = () =>
       editor.insertSnippet(snippetString, targetSelections);
 
-    const {
-      selections: [updatedTargetSelections],
-    } = await new CallbackUpdater(this.rangeUpdater, editor, callback)
-      .selections(targetSelections)
-      .run();
+    const { targetSelections: updatedTargetSelections } =
+      await performEditsAndUpdateSelections({
+        rangeUpdater: this.rangeUpdater,
+        editor,
+        callback,
+        preserveEditorSelections: true,
+        selections: {
+          targetSelections,
+        },
+      });
 
     return {
       thatSelections: updatedTargetSelections.map((selection) => ({

--- a/packages/cursorless-engine/src/actions/WrapWithSnippet.ts
+++ b/packages/cursorless-engine/src/actions/WrapWithSnippet.ts
@@ -1,7 +1,7 @@
 import { FlashStyle, ScopeType, WrapWithSnippetArg } from "@cursorless/common";
 import { Snippets } from "../core/Snippets";
 import { RangeUpdater } from "../core/updateSelections/RangeUpdater";
-import { callFunctionAndUpdateSelections } from "../core/updateSelections/updateSelections";
+import { CallbackUpdater } from "../core/updateSelections/updateSelections";
 import { ModifierStageFactory } from "../processTargets/ModifierStageFactory";
 import { ModifyIfUntypedStage } from "../processTargets/modifiers/ConditionalModifierStages";
 import { ide } from "../singletons/ide.singleton";
@@ -102,14 +102,14 @@ export default class WrapWithSnippet {
 
     const targetSelections = targets.map((target) => target.contentSelection);
 
-    // NB: We used the command "editor.action.insertSnippet" instead of calling editor.insertSnippet
-    // because the latter doesn't support special variables like CLIPBOARD
-    const [updatedTargetSelections] = await callFunctionAndUpdateSelections(
-      this.rangeUpdater,
-      () => editor.insertSnippet(snippetString, targetSelections),
-      editor.document,
-      [targetSelections],
-    );
+    const callback = () =>
+      editor.insertSnippet(snippetString, targetSelections);
+
+    const {
+      selections: [updatedTargetSelections],
+    } = await new CallbackUpdater(this.rangeUpdater, editor, callback)
+      .selections(targetSelections)
+      .run();
 
     return {
       thatSelections: updatedTargetSelections.map((selection) => ({

--- a/packages/cursorless-engine/src/core/updateSelections/updateSelections.ts
+++ b/packages/cursorless-engine/src/core/updateSelections/updateSelections.ts
@@ -32,8 +32,8 @@ interface BaseProps<K extends string> {
   rangeUpdater: RangeUpdater;
   /** The editor containing the selections */
   editor: EditableTextEditor;
-  /** Whether to preserve the editor's current selections */
-  preserveEditorSelections?: boolean;
+  /** Whether to preserve the editor's current cursor selections */
+  preserveCursorSelections?: boolean;
   /** The selections to update */
   selections: Record<K, SelectionsOrRanges | SelectionsWithBehavior>;
 }
@@ -60,7 +60,7 @@ export async function performEditsAndUpdateSelections<K extends string>({
   rangeUpdater,
   editor,
   selections,
-  preserveEditorSelections,
+  preserveCursorSelections: preserveEditorSelections,
   ...rest
 }: UpdaterProps<K>): Promise<Record<K, Selection[]>> {
   const keys = unsafeKeys(selections);

--- a/packages/cursorless-engine/src/core/updateSelections/updateSelections.ts
+++ b/packages/cursorless-engine/src/core/updateSelections/updateSelections.ts
@@ -15,30 +15,47 @@ import {
 import { performDocumentEdits } from "../../util/performDocumentEdits";
 import { RangeUpdater } from "./RangeUpdater";
 
+/** Selections OR ranges */
 type SelectionsOrRanges = readonly Selection[] | readonly Range[];
 
+/** Selections to be updated  with specified expansion behavior */
 interface SelectionsWithBehavior {
+  /** Selections or ranges to be updated */
   selections: SelectionsOrRanges;
+  /** The behavior to use expanding ranges  */
   behavior: RangeExpansionBehavior;
 }
 
+/** Base properties for updating selections */
 interface BaseProps<K extends string> {
+  /** A RangeUpdate instance that will perform actual range updating */
   rangeUpdater: RangeUpdater;
+  /** The editor containing the selections */
   editor: EditableTextEditor;
+  /** Whether to preserve the editor's current selections */
   preserveEditorSelections?: boolean;
+  /** The selections to update */
   selections: Record<K, SelectionsOrRanges | SelectionsWithBehavior>;
 }
 
+/** Updater properties for editor edits */
 interface EditsProps<K extends string> extends BaseProps<K> {
   edits: Edit[];
 }
 
+/** Updater properties for callback */
 interface CallbackProps<K extends string> extends BaseProps<K> {
   callback: () => Promise<void>;
 }
 
+/** Updater properties. Can contain edits OR a callback */
 type UpdaterProps<K extends string> = EditsProps<K> | CallbackProps<K>;
 
+/**
+ * Perform editor edits or call callback and update the selections based on the
+ * changes that occurred.
+ * @returns The initial selections updated based upon the changes that occurred.
+ */
 export async function performEditsAndUpdateSelections<K extends string>({
   rangeUpdater,
   editor,
@@ -50,7 +67,7 @@ export async function performEditsAndUpdateSelections<K extends string>({
 
   const selectionInfos = keys.map((key) => {
     const selectionValue = selections[key];
-    const selectionsWithBehavior = getsSelectionsWithBehavior(selectionValue);
+    const selectionsWithBehavior = getSelectionsWithBehavior(selectionValue);
     return getFullSelectionInfos(
       editor.document,
       selectionsWithBehavior.selections,

--- a/packages/cursorless-engine/src/core/updateSelections/updateSelections.ts
+++ b/packages/cursorless-engine/src/core/updateSelections/updateSelections.ts
@@ -14,6 +14,79 @@ import {
 import { performDocumentEdits } from "../../util/performDocumentEdits";
 import { RangeUpdater } from "./RangeUpdater";
 
+// const {
+//     sourceEditRanges: updatedSourceEditRanges,
+//     destinationEditRanges: updatedDestinationEditRanges,
+//   } = await performEditsAndUpdateSelections({
+//     rangeUpdator,
+//     editor: editableEditor,
+//     edits: filteredEdits.map(({ edit }) => edit),
+//     // callback: async () => {...do whatever},
+//     selections: {
+//       sourceEditRanges,
+//       destinationEditRanges: {
+//         selections: destinationEditRanges,
+//         behavior: RangeExpansionBehavior.openOpen,
+//       },
+//     },
+//     // preserveEditorSelections: true,
+//   });
+
+type SelectionsOrRanges = readonly Selection[] | readonly Range[];
+
+interface SelectionsWithBehavior2 {
+  selections: SelectionsOrRanges;
+  behavior: RangeExpansionBehavior;
+}
+
+interface BaseProps {
+  rangeUpdater: RangeUpdater;
+  editor: EditableTextEditor;
+  preserveEditorSelections?: boolean;
+  selections: Record<string, SelectionsOrRanges | SelectionsWithBehavior2>;
+}
+
+interface EditProps extends BaseProps {
+  edits: Edit[];
+}
+
+interface CallbackProps extends BaseProps {
+  callback: () => Promise<void>;
+}
+
+type UpdaterProps = EditProps | CallbackProps;
+
+export function performEditsAndUpdateSelections({
+  rangeUpdater,
+  editor,
+  selections,
+  preserveEditorSelections,
+  ...rest
+}: UpdaterProps) {
+  for (const key in selections) {
+    const value = selections[key];
+
+    const { selectionsOrRanges, behavior } = (() => {
+      if ("selections" in value) {
+        const { selections, behavior } = value;
+        return { selectionsOrRanges: selections, behavior };
+      }
+      return {
+        selectionsOrRanges: value,
+        behavior: RangeExpansionBehavior.closedClosed,
+      };
+    })();
+
+    console.log(selectionsOrRanges, behavior);
+  }
+
+  if ("edits" in rest) {
+    const { edits } = rest;
+  } else {
+    const { callback } = rest;
+  }
+}
+
 abstract class Updater {
   protected _selections: SelectionsWithBehavior[] = [];
   protected _ranges: RangesWithBehavior[] = [];

--- a/packages/cursorless-engine/src/core/updateSelections/updateSelections.ts
+++ b/packages/cursorless-engine/src/core/updateSelections/updateSelections.ts
@@ -5,6 +5,7 @@ import {
   RangeExpansionBehavior,
   Selection,
   TextDocument,
+  unsafeKeys,
 } from "@cursorless/common";
 import { flatten } from "lodash-es";
 import {
@@ -45,7 +46,7 @@ export async function performEditsAndUpdateSelections<K extends string>({
   preserveEditorSelections,
   ...rest
 }: UpdaterProps<K>): Promise<Record<K, Selection[]>> {
-  const keys = Object.keys(selections) as K[];
+  const keys = unsafeKeys(selections);
 
   const selectionInfos = keys.map((key) => {
     const selectionValue = selections[key];

--- a/packages/cursorless-vscode/src/ide/vscode/VscodeInsertSnippets.ts
+++ b/packages/cursorless-vscode/src/ide/vscode/VscodeInsertSnippets.ts
@@ -13,7 +13,7 @@ export async function vscodeInsertSnippet(
 
   await editor.focus();
 
-  // NB: We used the command "editor.action.insertSnippet" instead of calling editor.insertSnippet
+  // NB: We use the command "editor.action.insertSnippet" instead of calling editor.insertSnippet
   // because the latter doesn't support special variables like CLIPBOARD
   await vscode.commands.executeCommand("editor.action.insertSnippet", {
     snippet,

--- a/packages/cursorless-vscode/src/ide/vscode/VscodeInsertSnippets.ts
+++ b/packages/cursorless-vscode/src/ide/vscode/VscodeInsertSnippets.ts
@@ -12,6 +12,9 @@ export async function vscodeInsertSnippet(
   }
 
   await editor.focus();
+
+  // NB: We used the command "editor.action.insertSnippet" instead of calling editor.insertSnippet
+  // because the latter doesn't support special variables like CLIPBOARD
   await vscode.commands.executeCommand("editor.action.insertSnippet", {
     snippet,
   });


### PR DESCRIPTION
This introduces a new interface to perform updates. The requirements I had was:
1. Support both selections and ranges
2. Support both edits and callback
3. Support setting range expansion behavior per range/selection
4. Support updating selection internally

What this pr doesn't try to do:
1. Improve the range updater logic

Example
```ts
const {
  selections: [updatedContentSelections],
  ranges: [updatedEditRanges]
} = await new EditsUpdater(rangeUpdater, editableEditor, edits)
  .selections(contentSelections)
  .ranges(editRanges, RangeExpansionBehavior.openOpen)
  .updateEditorSelections()
  .run();
```

## Ponderings
1. Should updating editor selections be opt out instead?
1. Here I'm using two separate classes `EditsUpdater` and `CallbackUpdater`. I'm a bit tempted to just use a single class and a polymorphic argument. `editsOrCallback: Edit[] | () => Promise<void>`. Something like that.
2. Strict necessary we don't actually need the two separate return lists. Internally the range updater works with selections so we converting ranges to selections internally. We could just return a single list of selections and since all selections are also ranges I don't think any of the actions would actually care?

If we embrace this polymorphic nature it could look something like this:
```ts
const [updatedEditSelections, updatedContentSelections] =
  await new EditsUpdater(rangeUpdater, editableEditor, edits)
    .add(contentSelections)
    .add(editRanges, RangeExpansionBehavior.openOpen)
    .updateEditorSelections()
    .run();
```

Personally I am a fan of the above since it became cleaner and simpler, but I know that @pokey generally doesn't prefer union arguments if it can be avoided.

We could of course get rid of `new` if we wanted to make it even cleaner.

```ts
const [updatedEditSelections, updatedContentSelections] =
  await performUpdates(rangeUpdater, editableEditor, edits)
    .add(contentSelections)
    .add(editRanges, RangeExpansionBehavior.openOpen)
    .updateEditorSelections()
    .run();
```

Related to #729

## Checklist

- [/] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [/] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [/] I have not broken the cheatsheet
