### PR TITLE
Proper return type on HatMap.getToken()

### DIFF
--- a/packages/common/src/testUtil/extractTargetedMarks.ts
+++ b/packages/common/src/testUtil/extractTargetedMarks.ts
@@ -10,7 +10,11 @@ export function extractTargetedMarks(
 
   targetKeys.forEach((key) => {
     const { hatStyle, character } = splitKey(key);
-    targetedMarks[key] = hatTokenMap.getToken(hatStyle, character);
+    const token = hatTokenMap.getToken(hatStyle, character);
+    if (token == null) {
+      throw new Error(`Couldn't find mark ${hatStyle} '${character}'`);
+    }
+    targetedMarks[key] = token;
   });
 
   return targetedMarks;

--- a/packages/common/src/types/HatTokenMap.ts
+++ b/packages/common/src/types/HatTokenMap.ts
@@ -19,5 +19,5 @@ export interface TokenHat {
 
 export interface ReadOnlyHatMap {
   getEntries(): readonly [string, Token][];
-  getToken(hatStyle: HatStyleName, character: string): Token;
+  getToken(hatStyle: HatStyleName, character: string): Token | undefined;
 }

--- a/packages/cursorless-engine/src/core/IndividualHatMap.ts
+++ b/packages/cursorless-engine/src/core/IndividualHatMap.ts
@@ -108,7 +108,7 @@ export class IndividualHatMap implements ReadOnlyHatMap {
     return Object.entries(this.map);
   }
 
-  getToken(hatStyle: HatStyleName, character: string): Token {
+  getToken(hatStyle: HatStyleName, character: string): Token | undefined {
     this.checkExpired();
     return this.map[
       getKey(hatStyle, tokenGraphemeSplitter().normalizeGrapheme(character))


### PR DESCRIPTION
In some places we rely on the fact that the hat map can return undefined for a token and in other places we didn't handle this because the return type was wrong.

## Checklist

- [/] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [/] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [/] I have not broken the cheatsheet
