### PR TITLE
Switch all lint warnings to errors

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -100,6 +100,7 @@
     "**/vendor/**/*.ts",
     "**/vendor/**/*.js",
     "**/out/**",
-    "**/generated/**"
+    "**/generated/**",
+    "data/playground/**"
   ]
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -42,16 +42,16 @@
     "@typescript-eslint/no-non-null-assertion": "off",
     "unused-imports/no-unused-imports": "error",
     "@typescript-eslint/no-unused-vars": [
-      "warn",
+      "error",
       {
         "argsIgnorePattern": "^_",
         "varsIgnorePattern": "^_",
         "ignoreRestSiblings": true
       }
     ],
-    "curly": "warn",
+    "curly": "error",
     "eqeqeq": [
-      "warn",
+      "error",
       "always",
       {
         "null": "never"
@@ -67,7 +67,7 @@
       "error",
       "MemberExpression[object.property.name='constructor'][property.name='name']"
     ],
-    "no-throw-literal": "warn",
+    "no-throw-literal": "error",
     "semi": "off",
     "unicorn/prefer-module": "error",
     "mocha/no-skipped-tests": "error",


### PR DESCRIPTION
I don't know why we have any warnings. We either care about something or we don't. If we care, it shouldn't be allowed in CI. I hate yellow squiggles

## Checklist

- [-] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [-] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [-] I have not broken the cheatsheet
