### PR TITLE
Switch delimiter side to enum

### DIFF
--- a/packages/cursorless-engine/src/processTargets/modifiers/scopeHandlers/SurroundingPairScopeHandler/getIndividualDelimiters.ts
+++ b/packages/cursorless-engine/src/processTargets/modifiers/scopeHandlers/SurroundingPairScopeHandler/getIndividualDelimiters.ts
@@ -6,7 +6,7 @@ import {
 } from "@cursorless/common";
 import { concat, uniq } from "lodash-es";
 import { complexDelimiterMap, getSimpleDelimiterMap } from "./delimiterMaps";
-import { IndividualDelimiter } from "./types";
+import { DelimiterSide, IndividualDelimiter } from "./types";
 
 /**
  * Given a list of delimiters, returns a list where each element corresponds to
@@ -55,17 +55,17 @@ function getSimpleIndividualDelimiters(
 
       const side = (() => {
         if (isUnknownSide) {
-          return "unknown";
+          return DelimiterSide.unknown;
         }
         if (isLeft && !isRight) {
-          return "left";
+          return DelimiterSide.opening;
         }
         if (!isLeft && isRight) {
-          return "right";
+          return DelimiterSide.closing;
         }
         // If delimiter text is the same for left and right, we say its side
         // is "unknown", so must be determined from context.
-        return "unknown";
+        return DelimiterSide.unknown;
       })();
 
       return {

--- a/packages/cursorless-engine/src/processTargets/modifiers/scopeHandlers/SurroundingPairScopeHandler/getSurroundingPairOccurrences.ts
+++ b/packages/cursorless-engine/src/processTargets/modifiers/scopeHandlers/SurroundingPairScopeHandler/getSurroundingPairOccurrences.ts
@@ -1,5 +1,9 @@
 import { DefaultMap, SimpleSurroundingPairName } from "@cursorless/common";
-import type { DelimiterOccurrence, SurroundingPairOccurrence } from "./types";
+import {
+  DelimiterSide,
+  type DelimiterOccurrence,
+  type SurroundingPairOccurrence,
+} from "./types";
 
 /**
  * Given a list of occurrences of delimiters, returns a list of occurrences of
@@ -60,8 +64,9 @@ export function getSurroundingPairOccurrences(
     );
 
     if (
-      side === "left" ||
-      (side === "unknown" && relevantOpeningDelimiters.length % 2 === 0)
+      side === DelimiterSide.opening ||
+      (side === DelimiterSide.unknown &&
+        relevantOpeningDelimiters.length % 2 === 0)
     ) {
       openingDelimiters.push(occurrence);
     } else {

--- a/packages/cursorless-engine/src/processTargets/modifiers/scopeHandlers/SurroundingPairScopeHandler/types.ts
+++ b/packages/cursorless-engine/src/processTargets/modifiers/scopeHandlers/SurroundingPairScopeHandler/types.ts
@@ -5,7 +5,22 @@ import { SimpleSurroundingPairName, type Range } from "@cursorless/common";
  * or if we do not know. Note that the terms "opening" and "closing" could be
  * used instead of "left" and "right", respectively.
  */
-export type DelimiterSide = "unknown" | "left" | "right";
+export enum DelimiterSide {
+  /**
+   * We do not know which side of the delimiter this is
+   */
+  unknown,
+
+  /**
+   * This is an opening delimiter
+   */
+  opening,
+
+  /**
+   * This is a closing delimiter
+   */
+  closing,
+}
 
 /**
  * A description of one possible side of a delimiter


### PR DESCRIPTION
Makes it easier to find references, do rename, and have docstring

## Checklist

- [-] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [-] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [-] I have not broken the cheatsheet
