### PR TITLE
fix: make 'pnpm -F cursorless-vscode install-local' work again

### DIFF
--- a/packages/cursorless-vscode/scripts/install-local.sh
+++ b/packages/cursorless-vscode/scripts/install-local.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 # 1. Build local cursorless, using special extension id to break update chain
 pnpm esbuild:prod
 pnpm -F cheatsheet-local build:prod
+pnpm -F cursorless-vscode-tutorial-webview build
 pnpm populate-dist --local-install
 
 # 2. Bundle the extension


### PR DESCRIPTION
This could probably use a test as well, but just putting this up as is for now as many running this stand-alone isn't actually intended/expected.

Fixes #2616 

## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet
