### PR TITLE
tutorial: Fix bug with tutorial reparse

### DIFF
--- a/packages/cursorless-tutorial/src/TutorialImpl.ts
+++ b/packages/cursorless-tutorial/src/TutorialImpl.ts
@@ -187,6 +187,8 @@ export class TutorialImpl implements Tutorial, CommandRunnerDecorator {
             stepContent: tutorialContent.steps[this.state_.stepNumber].content,
           },
     );
+
+    await this.checkPreconditions();
   }
 
   private getRawTutorial(tutorialId: string) {


### PR DESCRIPTION
This one is a bit hard to test, but basically if you change a spoken form while preconditions are not met, it will think that they are met

I'm not sure why the change spoken form code was triggering tbh, but that is a question for another day

## Checklist

- [-] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [-] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [-] I have not broken the cheatsheet
