### PR TITLE
Remove references to left and right in surrounding pair documentation

### DIFF
--- a/cursorless-talon/src/modifiers/surrounding_pair.py
+++ b/cursorless-talon/src/modifiers/surrounding_pair.py
@@ -9,7 +9,7 @@ ctx = Context()
 
 mod.list(
     "cursorless_delimiter_force_direction",
-    desc="Can be used to force an ambiguous delimiter to extend in one direction",
+    desc="DEPRECATED: Can be used to force an ambiguous delimiter to extend in one direction",
 )
 # FIXME: Remove type ignore once Talon supports list types
 # See https://github.com/talonvoice/talon/issues/654

--- a/packages/cursorless-org-docs/src/docs/user/README.md
+++ b/packages/cursorless-org-docs/src/docs/user/README.md
@@ -437,16 +437,6 @@ This is a "line with" a few "quotation marks" on it
        opening   closing opening         closing
 ```
 
-This heuristic works well in most cases, but when it does get tripped up, you can override its behavior. Position your cursor directly next to the delimiter (or just use the delimiter as a mark), and then prefix the name of the delimiter pair with "left" or "right" to force cursorless to expand the selection to the left or right, respectively.
-
-For example:
-
-- `"take left quad"` (with your cursor adjacent to a quote)
-- `"take left pair green double"` (with your cursor anywhere)
-- `"take inside right quad"`
-
-If your cursor / mark is between two delimiters (not adjacent to one), then saying either "left" or "right" will cause cursorless to just expand to the nearest delimiters on either side, without trying to determine whether they are opening or closing delimiters.
-
 ##### `"its"`
 
 The the modifier `"its"` is intended to be used as part of a compound target, and will tell Cursorless to use the previously mentioned mark in the compound target.


### PR DESCRIPTION
These are now deprecated and now error out after https://github.com/cursorless-dev/cursorless/pull/2457. We missed this reference in the documentation.

Fixes #2625

## Checklist

- [/] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [x] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [/] I have not broken the cheatsheet
