### PR TITLE
Added setting to restore system default microphone after Talon grammar tests

### DIFF
--- a/cursorless-talon-dev/src/spoken_form_test.py
+++ b/cursorless-talon-dev/src/spoken_form_test.py
@@ -13,7 +13,7 @@ mod.mode(
 mod.setting(
     "cursorless_spoken_form_test_restore_microphone",
     str,
-    desc="The microphone to revert to after the spoken form tests are done. If not provided the previously active microphone will be restored.",
+    desc="The microphone to switch to after the spoken form tests are done. If unset, the microphone that was active before tests started is restored. (If you want to switch back to 'System Default', you should set that as the value here)",
 )
 
 ctx = Context()

--- a/cursorless-talon-dev/src/spoken_form_test.py
+++ b/cursorless-talon-dev/src/spoken_form_test.py
@@ -1,13 +1,20 @@
 import json
 from typing import Any, Optional
 
-from talon import Context, Module, actions, scope
+from talon import Context, Module, actions, scope, settings
 
 mod = Module()
 
 mod.mode(
     "cursorless_spoken_form_test",
     "Used to run tests on the Cursorless spoken forms/grammar",
+)
+
+mod.setting(
+    "cursorless_spoken_form_test_restore_default_microphone",
+    bool,
+    default=False,
+    desc="Instead of restoring the previously active microphonep use system default instead",
 )
 
 ctx = Context()
@@ -72,7 +79,12 @@ class Actions:
 
         if enable:
             saved_modes = scope.get("mode")
-            saved_microphone = actions.sound.active_microphone()
+            if settings.get(
+                "user.cursorless_spoken_form_test_restore_default_microphone"
+            ):
+                saved_microphone = "System Default"
+            else:
+                saved_microphone = actions.sound.active_microphone()
 
             disable_modes()
             actions.mode.enable("user.cursorless_spoken_form_test")

--- a/cursorless-talon-dev/src/spoken_form_test.py
+++ b/cursorless-talon-dev/src/spoken_form_test.py
@@ -11,10 +11,9 @@ mod.mode(
 )
 
 mod.setting(
-    "cursorless_spoken_form_test_restore_default_microphone",
-    bool,
-    default=False,
-    desc="Instead of restoring the previously active microphonep use system default instead",
+    "cursorless_spoken_form_test_restore_microphone",
+    str,
+    desc="The microphone to revert to after the spoken form tests are done. If not provided the previously active microphone will be restored.",
 )
 
 ctx = Context()
@@ -79,12 +78,10 @@ class Actions:
 
         if enable:
             saved_modes = scope.get("mode")
-            if settings.get(
-                "user.cursorless_spoken_form_test_restore_default_microphone"
-            ):
-                saved_microphone = "System Default"
-            else:
-                saved_microphone = actions.sound.active_microphone()
+            saved_microphone = settings.get(
+                "user.cursorless_spoken_form_test_restore_microphone",
+                actions.sound.active_microphone(),
+            )
 
             disable_modes()
             actions.mode.enable("user.cursorless_spoken_form_test")


### PR DESCRIPTION
There is no way of telling if Talon currently is using the system default microphone. Every time I run the Talon grammar tests this setting changes and I have to manually reset it which is really annoying.

## Checklist

- [/] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [/] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [/] I have not broken the cheatsheet
