### PR TITLE
docs: Exclude language docs from crawler

### DIFF
--- a/packages/cursorless-org-docs/config/algolia/crawler-settings.js
+++ b/packages/cursorless-org-docs/config/algolia/crawler-settings.js
@@ -9,7 +9,10 @@ new Crawler({
   actions: [
     {
       indexName: "cursorless",
-      pathsToMatch: ["https://www.cursorless.org/docs/**"],
+      pathsToMatch: [
+        "https://www.cursorless.org/docs/**",
+        "!https://www.cursorless.org/docs/user/languages/**",
+      ],
       recordExtractor: ({ $, helpers }) => {
         // priority order: deepest active sub list header -> navbar active item -> 'Documentation'
         const lvl0 =


### PR DESCRIPTION
I've already applied this change to the production crawler. We'll remove this exclusion as part of https://github.com/cursorless-dev/cursorless/issues/1642

## Checklist

- [-] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [-] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [-] I have not broken the cheatsheet
