### PR TITLE
Fixed bug where we tried to read missing custom regex list

### DIFF
--- a/cursorless-talon/src/get_grapheme_spoken_form_entries.py
+++ b/cursorless-talon/src/get_grapheme_spoken_form_entries.py
@@ -14,16 +14,6 @@ grapheme_capture_name = "user.any_alphanumeric_key"
 def get_grapheme_spoken_form_entries(
     grapheme_talon_list: dict[str, str],
 ) -> list[SpokenFormOutputEntry]:
-    if grapheme_capture_name not in registry.captures:
-        # We require this capture, and expect it to be defined. We want to show a user friendly error if it isn't present (usually indicating a problem with their community.git setup) and we think the user is going to use Cursorless.
-        # However, sometimes users use different dictation engines (Vosk, Webspeech) with entirely different/smaller grammars that don't have the capture, and this code will run then, and falsely error. We don't want to show an error in that case because they don't plan to actually use Cursorless.
-        if "en" in scope.get("language", {}):
-            app.notify(f"Capture <{grapheme_capture_name}> isn't defined")
-            print(
-                f"Capture <{grapheme_capture_name}> isn't defined, which is required by Cursorless. Please check your community setup"
-            )
-        return []
-
     return [
         {
             "type": "grapheme",
@@ -37,6 +27,16 @@ def get_grapheme_spoken_form_entries(
 
 
 def get_graphemes_talon_list() -> dict[str, str]:
+    if grapheme_capture_name not in registry.captures:
+        # We require this capture, and expect it to be defined. We want to show a user friendly error if it isn't present (usually indicating a problem with their community.git setup) and we think the user is going to use Cursorless.
+        # However, sometimes users use different dictation engines (Vosk, Webspeech) with entirely different/smaller grammars that don't have the capture, and this code will run then, and falsely error. We don't want to show an error in that case because they don't plan to actually use Cursorless.
+        if "en" in scope.get("language", {}):
+            app.notify(f"Capture <{grapheme_capture_name}> isn't defined")
+            print(
+                f"Capture <{grapheme_capture_name}> isn't defined, which is required by Cursorless. Please check your community setup"
+            )
+        return {}
+
     return {
         spoken_form: id
         for symbol_list in generate_lists_from_capture(grapheme_capture_name)

--- a/cursorless-talon/src/spoken_forms.py
+++ b/cursorless-talon/src/spoken_forms.py
@@ -197,6 +197,7 @@ def update():
         ),
     ]
 
+    init_scope_spoken_forms(graphemes_talon_list)
     update_spoken_forms_output()
     initialized = True
 

--- a/cursorless-talon/src/spoken_forms.py
+++ b/cursorless-talon/src/spoken_forms.py
@@ -125,6 +125,7 @@ def update():
         if initialized:
             # On first run, we just do one update at the end, so we suppress
             # writing until we get there
+            init_scope_spoken_forms(graphemes_talon_list)
             update_spoken_forms_output()
 
     handle_csv = auto_construct_defaults(
@@ -196,7 +197,6 @@ def update():
         ),
     ]
 
-    init_scope_spoken_forms(graphemes_talon_list)
     update_spoken_forms_output()
     initialized = True
 

--- a/cursorless-talon/src/spoken_scope_forms.py
+++ b/cursorless-talon/src/spoken_scope_forms.py
@@ -4,25 +4,20 @@ from .csv_overrides import csv_get_ctx, csv_get_normalized_ctx
 
 
 def init_scope_spoken_forms(graphemes_talon_list: dict[str, str]):
-    create_flattened_talon_list(
-        csv_get_ctx(), graphemes_talon_list, include_custom_regex=True
-    )
+    create_flattened_talon_list(csv_get_ctx(), graphemes_talon_list)
     if is_cursorless_test_mode():
-        create_flattened_talon_list(
-            csv_get_normalized_ctx(), graphemes_talon_list, include_custom_regex=False
-        )
+        create_flattened_talon_list(csv_get_normalized_ctx(), graphemes_talon_list)
 
 
-def create_flattened_talon_list(
-    ctx: Context, graphemes_talon_list: dict[str, str], include_custom_regex: bool
-):
+def create_flattened_talon_list(ctx: Context, graphemes_talon_list: dict[str, str]):
     lists_to_merge = {
         "cursorless_scope_type": "simple",
         "cursorless_surrounding_pair_scope_type": "surroundingPair",
         "cursorless_selectable_only_paired_delimiter": "surroundingPair",
         "cursorless_wrapper_selectable_paired_delimiter": "surroundingPair",
     }
-    if include_custom_regex:
+    # If the user have no custom regex scope type, then that list is missing from the context
+    if "user.cursorless_custom_regex_scope_type" in ctx.lists.keys():  # noqa: SIM118
         lists_to_merge["cursorless_custom_regex_scope_type"] = "customRegex"
 
     scope_types_singular: dict[str, str] = {}


### PR DESCRIPTION


## Checklist

- [/] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [/] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [/] I have not broken the cheatsheet
