### PR TITLE
Use containing scope stage in preferred scope stage

### DIFF
--- a/data/fixtures/recorded/modifiers/preferredScope/clearItem.yml
+++ b/data/fixtures/recorded/modifiers/preferredScope/clearItem.yml
@@ -1,0 +1,24 @@
+languageId: plaintext
+command:
+  version: 7
+  spokenForm: clear item
+  action:
+    name: clearAndSetSelection
+    target:
+      type: primitive
+      modifiers:
+        - type: preferredScope
+          scopeType: {type: collectionItem}
+  usePrePhraseSnapshot: true
+spokenFormError: Modifier 'preferredScope'
+initialState:
+  documentContents: foo, bar
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  marks: {}
+finalState:
+  documentContents: ", bar"
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}

--- a/packages/cursorless-engine/src/processTargets/modifiers/PreferredScopeStage.ts
+++ b/packages/cursorless-engine/src/processTargets/modifiers/PreferredScopeStage.ts
@@ -35,7 +35,7 @@ export class PreferredScopeStage implements ModifierStage {
     try {
       return containingScopeStage.run(target);
     } catch (ex) {
-      // NoContainingScopeError is thrown if no containing scope was found.
+      // NoContainingScopeError is thrown if no containing scope was found, which is fine.
       if (!(ex instanceof NoContainingScopeError)) {
         throw ex;
       }

--- a/packages/cursorless-engine/src/processTargets/modifiers/PreferredScopeStage.ts
+++ b/packages/cursorless-engine/src/processTargets/modifiers/PreferredScopeStage.ts
@@ -2,7 +2,7 @@ import { type Position, type PreferredScopeModifier } from "@cursorless/common";
 import type { Target } from "../../typings/target.types";
 import type { ModifierStageFactory } from "../ModifierStageFactory";
 import type { ModifierStage } from "../PipelineStages.types";
-import { getContainingScopeTarget } from "./getContainingScopeTarget";
+import { ContainingScopeStage } from "./ContainingScopeStage";
 import type { TargetScope } from "./scopeHandlers/scope.types";
 import type { ScopeHandler } from "./scopeHandlers/scopeHandler.types";
 import type { ScopeHandlerFactory } from "./scopeHandlers/ScopeHandlerFactory";
@@ -22,6 +22,18 @@ export class PreferredScopeStage implements ModifierStage {
   run(target: Target): Target[] {
     const { scopeType } = this.modifier;
 
+    const containingScopeStage = new ContainingScopeStage(
+      this.modifierStageFactory,
+      this.scopeHandlerFactory,
+      { type: "containingScope", scopeType },
+    );
+
+    try {
+      return containingScopeStage.run(target);
+    } catch (_ex) {
+      // Do nothing
+    }
+
     const scopeHandler = this.scopeHandlerFactory.create(
       this.modifier.scopeType,
       target.editor.document.languageId,
@@ -31,17 +43,13 @@ export class PreferredScopeStage implements ModifierStage {
       throw Error(`Couldn't create scope handler for: ${scopeType.type}`);
     }
 
-    const containingTargets = getContainingScopeTarget(target, scopeHandler);
-    if (containingTargets != null) {
-      return containingTargets;
-    }
-
     const closestTargets = getClosestScopeTargets(target, scopeHandler);
-    if (closestTargets != null) {
-      return closestTargets;
+
+    if (closestTargets == null) {
+      throw Error(`No scopes found for scope type: ${scopeType.type}`);
     }
 
-    throw Error(`No scopes found for scope type: ${scopeType.type}`);
+    return closestTargets;
   }
 }
 

--- a/packages/cursorless-engine/src/processTargets/modifiers/PreferredScopeStage.ts
+++ b/packages/cursorless-engine/src/processTargets/modifiers/PreferredScopeStage.ts
@@ -1,4 +1,8 @@
-import { type Position, type PreferredScopeModifier } from "@cursorless/common";
+import {
+  NoContainingScopeError,
+  type Position,
+  type PreferredScopeModifier,
+} from "@cursorless/common";
 import type { Target } from "../../typings/target.types";
 import type { ModifierStageFactory } from "../ModifierStageFactory";
 import type { ModifierStage } from "../PipelineStages.types";
@@ -30,8 +34,11 @@ export class PreferredScopeStage implements ModifierStage {
 
     try {
       return containingScopeStage.run(target);
-    } catch (_ex) {
-      // Do nothing. We'll try the closest scope next.
+    } catch (ex) {
+      // NoContainingScopeError is thrown if no containing scope was found.
+      if (!(ex instanceof NoContainingScopeError)) {
+        throw ex;
+      }
     }
 
     const scopeHandler = this.scopeHandlerFactory.create(

--- a/packages/cursorless-engine/src/processTargets/modifiers/PreferredScopeStage.ts
+++ b/packages/cursorless-engine/src/processTargets/modifiers/PreferredScopeStage.ts
@@ -31,7 +31,7 @@ export class PreferredScopeStage implements ModifierStage {
     try {
       return containingScopeStage.run(target);
     } catch (_ex) {
-      // Do nothing
+      // Do nothing. We'll try the closest scope next.
     }
 
     const scopeHandler = this.scopeHandlerFactory.create(


### PR DESCRIPTION
ContainingScopeStage have some logic around how to treat legacy scopes that we were missing from PreferredScopeStage. 

## Checklist

- [x] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [/] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [/] I have not broken the cheatsheet
