### PR TITLE
add `"short block"` section to reference page

### DIFF
--- a/packages/cursorless-org-docs/src/docs/user/README.md
+++ b/packages/cursorless-org-docs/src/docs/user/README.md
@@ -289,7 +289,7 @@ For example, given the text...
 }
 ```
 
-`"take short block bat"` would select the two lines with `bbb` and `ccc`.  See [short paint](#short-paint) for a more detailed walkthrough of a scope not exiting surrounding pairs.
+`"take short block bat"` would select the two lines with `bbb` and `ccc`. See [short paint](#short-paint) for a more detailed walkthrough of a scope not exiting surrounding pairs.
 
 ##### `"file"`
 

--- a/packages/cursorless-org-docs/src/docs/user/README.md
+++ b/packages/cursorless-org-docs/src/docs/user/README.md
@@ -274,6 +274,23 @@ The `"block"` modifier expands to above and below the target to select lines unt
 - `"take block"`
 - `"take block <TARGET>"`
 
+##### `"short block"`
+
+The `"short block"` scope is like `"block"`, but stops not only at empty lines but also stops if it would exit the nearest [surrounding pair](#surrounding-pair).
+For example, given the text...
+
+```
+{
+  aaa
+  {
+    bbb
+    ccc
+  }
+}
+```
+
+`"take short block bat"` would select the two lines with `bbb` and `ccc`.  See [short paint](#short-paint) for a more detailed walkthrough of a scope not exiting surrounding pairs.
+
 ##### `"file"`
 
 The word '`"file"` can be used to expand the target to refer to the entire file.


### PR DESCRIPTION
`"short block"` is a live feature and is in the cheatsheet but not in the main reference page.

Sidenote: y'all open to the cheatsheet being more explanatory than simply "bounded paragraph"?  `"short paint"` has "Non whitespace sequence stopped by surrounding pair delimeters".  I'm thinking "block stopped by surrounding pair delimiters".  If yes, I can submit a PR for that.


## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet
