### PR TITLE
Try to fix CI flakiness by adding sleep in custom regex scope test

### DIFF
--- a/packages/cursorless-vscode-e2e/src/suite/scopeProvider/runCustomRegexScopeInfoTest.ts
+++ b/packages/cursorless-vscode-e2e/src/suite/scopeProvider/runCustomRegexScopeInfoTest.ts
@@ -33,6 +33,10 @@ export async function runCustomRegexScopeInfoTest() {
     await assertCalledWithScopeInfo(fake, unsupported);
 
     await openNewEditor(contents);
+    // The scope provider relies on the open document event (among others) to
+    // update available scopes. Add a short sleep here to give it time to
+    // trigger.
+    await sleep(100);
     await assertCalledWithScopeInfo(fake, present);
 
     await unlink(cursorlessTalonStateJsonPath);


### PR DESCRIPTION
Possible solution to https://github.com/cursorless-dev/cursorless/issues/2538

As of this writing this seems to be required for mac CI, but not other platforms

## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet
