### PR TITLE
cursorless everywhere: add the ability to asynchronous values from Python

### DIFF
--- a/cursorless-everywhere-talon/cursorless_everywhere_talon.py
+++ b/cursorless-everywhere-talon/cursorless_everywhere_talon.py
@@ -1,4 +1,4 @@
-from typing import TypedDict
+from typing import Any, TypedDict
 
 from talon import Module
 
@@ -48,3 +48,6 @@ class Actions:
         edit: EditorEdit,  # pyright: ignore [reportGeneralTypeIssues]
     ):
         """Edit focused element text"""
+
+    def private_cursorless_talonjs_get_response() -> Any:
+        """Returns the response from the last Cursorless RPC command"""

--- a/cursorless-everywhere-talon/cursorless_everywhere_talon.py
+++ b/cursorless-everywhere-talon/cursorless_everywhere_talon.py
@@ -2,6 +2,7 @@ from typing import Any, TypedDict
 
 from talon import Context, Module, actions
 
+import json
 
 class SelectionOffsets(TypedDict):
     anchor: int
@@ -66,7 +67,9 @@ class Actions:
     def private_cursorless_talonjs_get_response() -> Any:
         """Returns the response from the last Cursorless command"""
 
+
 ctx = Context()
+
 
 @ctx.action_class("user")
 class Actions:
@@ -90,5 +93,4 @@ class Actions:
         arg2: Any = None,
     ) -> Any:
         actions.user.private_cursorless_talonjs_run_and_wait(command_id, arg1, arg2)
-        # TODO: convert to Python object
-        return actions.user.private_cursorless_talonjs_get_response()
+        return json.loads(actions.user.private_cursorless_talonjs_get_response())

--- a/cursorless-everywhere-talon/cursorless_everywhere_talon.py
+++ b/cursorless-everywhere-talon/cursorless_everywhere_talon.py
@@ -1,8 +1,8 @@
+import json
 from typing import Any, TypedDict
 
 from talon import Context, Module, actions
 
-import json
 
 class SelectionOffsets(TypedDict):
     anchor: int
@@ -72,7 +72,7 @@ ctx = Context()
 
 
 @ctx.action_class("user")
-class Actions:
+class UserActions:
     def private_cursorless_run_rpc_command_and_wait(
         command_id: str,  # pyright: ignore [reportGeneralTypeIssues]
         arg1: Any = None,

--- a/cursorless-everywhere-talon/cursorless_everywhere_talon.py
+++ b/cursorless-everywhere-talon/cursorless_everywhere_talon.py
@@ -1,6 +1,6 @@
 from typing import Any, TypedDict
 
-from talon import Module
+from talon import Context, Module, actions
 
 
 class SelectionOffsets(TypedDict):
@@ -49,5 +49,46 @@ class Actions:
     ):
         """Edit focused element text"""
 
+    def private_cursorless_talonjs_run_and_wait(
+        command_id: str,  # pyright: ignore [reportGeneralTypeIssues]
+        arg1: Any = None,
+        arg2: Any = None,
+    ):
+        """Executes a Cursorless command, waits for its completion, but does not return the response"""
+
+    def private_cursorless_talonjs_run_no_wait(
+        command_id: str,  # pyright: ignore [reportGeneralTypeIssues]
+        arg1: Any = None,
+        arg2: Any = None,
+    ):
+        """Executes a Cursorless command, but does not wait for it to finish, nor return the response"""
+
     def private_cursorless_talonjs_get_response() -> Any:
-        """Returns the response from the last Cursorless RPC command"""
+        """Returns the response from the last Cursorless command"""
+
+ctx = Context()
+
+@ctx.action_class("user")
+class Actions:
+    def private_cursorless_run_rpc_command_and_wait(
+        command_id: str,  # pyright: ignore [reportGeneralTypeIssues]
+        arg1: Any = None,
+        arg2: Any = None,
+    ):
+        actions.user.private_cursorless_talonjs_run_and_wait(command_id, arg1, arg2)
+
+    def private_cursorless_run_rpc_command_no_wait(
+        command_id: str,  # pyright: ignore [reportGeneralTypeIssues]
+        arg1: Any = None,
+        arg2: Any = None,
+    ):
+        actions.user.private_cursorless_talonjs_run_no_wait(command_id, arg1, arg2)
+
+    def private_cursorless_run_rpc_command_get(
+        command_id: str,  # pyright: ignore [reportGeneralTypeIssues]
+        arg1: Any = None,
+        arg2: Any = None,
+    ) -> Any:
+        actions.user.private_cursorless_talonjs_run_and_wait(command_id, arg1, arg2)
+        # TODO: convert to Python object
+        return actions.user.private_cursorless_talonjs_get_response()

--- a/packages/cursorless-everywhere-talon-core/src/registerCommands.ts
+++ b/packages/cursorless-everywhere-talon-core/src/registerCommands.ts
@@ -11,7 +11,17 @@ export function registerCommands(
   const ctx = new talon.Context();
   ctx.matches = "tag: user.cursorless_everywhere_talon";
 
+  let lastCommandResponse: unknown = null;
+
   ctx.action_class("user", {
+    /**
+     * Executes an RPC command without waiting for the result.
+     * This function is useful for fire-and-forget operations where
+     * the result is not immediately needed.
+     *
+     * @param commandId - The identifier of the command to be executed.
+     * @param command - The command object containing necessary parameters.
+     */
     private_cursorless_run_rpc_command_no_wait(
       commandId: string,
       command: unknown,
@@ -19,11 +29,35 @@ export function registerCommands(
       void runCommand(commandId, command);
     },
 
+    /**
+     * Retrieves the response from the last RPC command execution.
+     *
+     * This is useful because TalonJS doesn't have a way to read the responses from promises,
+     * but it does wait for them, so we store the response in a global variable and let it be
+     * read by this action.
+     *
+     * @returns The most recent response from an RPC command, or null if no
+     *          command has been executed yet.
+     */
+    private_cursorless_talonjs_get_response(): unknown {
+      return lastCommandResponse;
+    },
+
+    /**
+     * Executes an RPC command and waits for the result.
+     * This function is useful when the result of the command is needed
+     * immediately after execution.
+     *
+     * @param commandId - The identifier of the command to be executed.
+     * @param command - The command object containing necessary parameters.
+     * @returns A Promise that resolves with the result of the command execution.
+     */
     async private_cursorless_run_rpc_command_get(
       commandId: string,
       command: unknown,
     ): Promise<unknown> {
-      return await runCommand(commandId, command);
+      lastCommandResponse = await runCommand(commandId, command);
+      return lastCommandResponse;
     },
   });
 

--- a/packages/cursorless-everywhere-talon-core/src/registerCommands.ts
+++ b/packages/cursorless-everywhere-talon-core/src/registerCommands.ts
@@ -30,7 +30,9 @@ export function registerCommands(
     },
 
     private_cursorless_talonjs_get_response(): unknown {
-      return lastCommandResponse;
+      // Talon JS doesn't convert JS objects to Python objects, and also doesn't provide
+      // a way to inspect types, so just serialize the response to JSON
+      return JSON.stringify(lastCommandResponse);
     },
   });
 

--- a/packages/cursorless-everywhere-talon-core/src/registerCommands.ts
+++ b/packages/cursorless-everywhere-talon-core/src/registerCommands.ts
@@ -14,49 +14,22 @@ export function registerCommands(
   let lastCommandResponse: unknown = null;
 
   ctx.action_class("user", {
-    /**
-     * Executes an RPC command without waiting for the result.
-     * This function is useful for fire-and-forget operations where
-     * the result is not immediately needed.
-     *
-     * @param commandId - The identifier of the command to be executed.
-     * @param command - The command object containing necessary parameters.
-     */
-    private_cursorless_run_rpc_command_no_wait(
+    async private_cursorless_talonjs_run_and_wait(
+      commandId: string,
+      command: unknown,
+    ): Promise<void> {
+      lastCommandResponse = await runCommand(commandId, command);
+    },
+
+    private_cursorless_talonjs_run_no_wait(
       commandId: string,
       command: unknown,
     ): void {
       void runCommand(commandId, command);
+      lastCommandResponse = null;
     },
 
-    /**
-     * Retrieves the response from the last RPC command execution.
-     *
-     * This is useful because TalonJS doesn't have a way to read the responses from promises,
-     * but it does wait for them, so we store the response in a global variable and let it be
-     * read by this action.
-     *
-     * @returns The most recent response from an RPC command, or null if no
-     *          command has been executed yet.
-     */
     private_cursorless_talonjs_get_response(): unknown {
-      return lastCommandResponse;
-    },
-
-    /**
-     * Executes an RPC command and waits for the result.
-     * This function is useful when the result of the command is needed
-     * immediately after execution.
-     *
-     * @param commandId - The identifier of the command to be executed.
-     * @param command - The command object containing necessary parameters.
-     * @returns A Promise that resolves with the result of the command execution.
-     */
-    async private_cursorless_run_rpc_command_get(
-      commandId: string,
-      command: unknown,
-    ): Promise<unknown> {
-      lastCommandResponse = await runCommand(commandId, command);
       return lastCommandResponse;
     },
   });

--- a/packages/cursorless-everywhere-talon-core/src/types/talon.types.ts
+++ b/packages/cursorless-everywhere-talon-core/src/types/talon.types.ts
@@ -25,6 +25,7 @@ export interface TalonContextActions {
     commandId: string,
     command: unknown,
   ): void;
+  private_cursorless_talonjs_get_response(): unknown;
   private_cursorless_run_rpc_command_get(
     commandId: string,
     command: unknown,

--- a/packages/cursorless-everywhere-talon-core/src/types/talon.types.ts
+++ b/packages/cursorless-everywhere-talon-core/src/types/talon.types.ts
@@ -21,15 +21,42 @@ export interface TalonActions {
 }
 
 export interface TalonContextActions {
-  private_cursorless_run_rpc_command_no_wait(
+  /**
+   * Executes an RPC command and waits for the result.
+   * This function is useful when the result of the command is needed
+   * immediately after execution.
+   *
+   * @param commandId - The identifier of the command to be executed.
+   * @param command - The command object containing necessary parameters.
+   * @returns A Promise that resolves with the result of the command execution.
+   */
+  private_cursorless_talonjs_run_and_wait(
+    commandId: string,
+    command: unknown,
+  ): Promise<void>;
+  /**
+   * Executes an RPC command without waiting for the result.
+   * This function is useful for fire-and-forget operations where
+   * the result is not immediately needed.
+   *
+   * @param commandId - The identifier of the command to be executed.
+   * @param command - The command object containing necessary parameters.
+   */
+  private_cursorless_talonjs_run_no_wait(
     commandId: string,
     command: unknown,
   ): void;
+  /**
+   * Retrieves the response from the last RPC command execution.
+   *
+   * This is useful because TalonJS doesn't have a way to read the responses from promises,
+   * but it does wait for them, so we store the response in a global variable and let it be
+   * read by this action.
+   *
+   * @returns The most recent response from an RPC command, or null if no
+   *          command has been executed yet.
+   */
   private_cursorless_talonjs_get_response(): unknown;
-  private_cursorless_run_rpc_command_get(
-    commandId: string,
-    command: unknown,
-  ): Promise<unknown>;
 }
 
 export interface TalonContext {

--- a/packages/cursorless-everywhere-talon-e2e/src/quickjsTest.ts
+++ b/packages/cursorless-everywhere-talon-e2e/src/quickjsTest.ts
@@ -66,18 +66,21 @@ async function testChuck() {
   assert.equal(selections[0].active, 0);
 }
 
-function runAction(action: ActionDescriptor) {
+async function runAction(action: ActionDescriptor) {
   const command: CommandLatest = {
     version: 7,
     usePrePhraseSnapshot: false,
     action,
   };
-  return talonMock
+  await talonMock
     .getTestHelpers()
-    .contextActions.private_cursorless_run_rpc_command_get(
+    .contextActions.private_cursorless_talonjs_run_and_wait(
       "cursorless.command",
       command,
     );
+  return talonMock
+    .getTestHelpers()
+    .contextActions.private_cursorless_talonjs_get_response();
 }
 
 const assert = {


### PR DESCRIPTION

## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet
