### PR TITLE
Change default head/tail scope to be line bounded by matching pairs

### DIFF
--- a/changelog/2024-08-boundedHeadTail.md
+++ b/changelog/2024-08-boundedHeadTail.md
@@ -3,4 +3,4 @@ tags: [enhancement]
 pullRequest: 2652
 ---
 
-If no scope is specified for head/tail instead of defaulting to just line we now use the smallest of line or surrounding pair interior. This means that "take head" would be bounded by the surrounding pair just like "short paint". If there is no surrounding pair the line is used just like today. You can also override this behavior by specifying line. "take head line" would always use the line regardless if you are in a surrounding pair or not.
+If you're inside of a surrounding pair, the "head" and "tail" modifiers now only expand to the interior of that pair, instead of the whole line. This is more useful, akin to how "short paint" works. You can explicitly say "head line" or "tail line" to get the old behavior.

--- a/changelog/2024-08-boundedHeadTail.md
+++ b/changelog/2024-08-boundedHeadTail.md
@@ -1,0 +1,6 @@
+---
+tags: [enhancement]
+pullRequest: 2652
+---
+
+If no scope is specified for head/tail instead of defaulting to just line we now use the smallest of line or surrounding pair interior. This means that "take head" would be bounded by the surrounding pair just like "short paint". If there is no surrounding pair the line is used just like today. You can also override this behavior by specifying line. "take head line" would always use the line regardless if you are in a surrounding pair or not.

--- a/data/fixtures/recorded/headTail/changeHead.yml
+++ b/data/fixtures/recorded/headTail/changeHead.yml
@@ -1,0 +1,22 @@
+languageId: plaintext
+command:
+  version: 7
+  spokenForm: change head
+  action:
+    name: clearAndSetSelection
+    target:
+      type: primitive
+      modifiers:
+        - {type: extendThroughStartOf}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: foo bar
+  selections:
+    - anchor: {line: 0, character: 4}
+      active: {line: 0, character: 4}
+  marks: {}
+finalState:
+  documentContents: bar
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}

--- a/data/fixtures/recorded/headTail/changeHead2.yml
+++ b/data/fixtures/recorded/headTail/changeHead2.yml
@@ -1,0 +1,22 @@
+languageId: plaintext
+command:
+  version: 7
+  spokenForm: change head
+  action:
+    name: clearAndSetSelection
+    target:
+      type: primitive
+      modifiers:
+        - {type: extendThroughStartOf}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: "'foo bar'"
+  selections:
+    - anchor: {line: 0, character: 5}
+      active: {line: 0, character: 5}
+  marks: {}
+finalState:
+  documentContents: "'bar'"
+  selections:
+    - anchor: {line: 0, character: 1}
+      active: {line: 0, character: 1}

--- a/data/fixtures/recorded/headTail/changeTail.yml
+++ b/data/fixtures/recorded/headTail/changeTail.yml
@@ -1,0 +1,22 @@
+languageId: plaintext
+command:
+  version: 7
+  spokenForm: change tail
+  action:
+    name: clearAndSetSelection
+    target:
+      type: primitive
+      modifiers:
+        - {type: extendThroughEndOf}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: foo bar
+  selections:
+    - anchor: {line: 0, character: 3}
+      active: {line: 0, character: 3}
+  marks: {}
+finalState:
+  documentContents: foo
+  selections:
+    - anchor: {line: 0, character: 3}
+      active: {line: 0, character: 3}

--- a/data/fixtures/recorded/headTail/changeTail2.yml
+++ b/data/fixtures/recorded/headTail/changeTail2.yml
@@ -1,0 +1,22 @@
+languageId: plaintext
+command:
+  version: 7
+  spokenForm: change tail
+  action:
+    name: clearAndSetSelection
+    target:
+      type: primitive
+      modifiers:
+        - {type: extendThroughEndOf}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: "'foo bar'"
+  selections:
+    - anchor: {line: 0, character: 4}
+      active: {line: 0, character: 4}
+  marks: {}
+finalState:
+  documentContents: "'foo'"
+  selections:
+    - anchor: {line: 0, character: 4}
+      active: {line: 0, character: 4}

--- a/data/fixtures/recorded/headTail/clearHeadLine.yml
+++ b/data/fixtures/recorded/headTail/clearHeadLine.yml
@@ -1,0 +1,26 @@
+languageId: plaintext
+command:
+  version: 7
+  spokenForm: clear head line
+  action:
+    name: clearAndSetSelection
+    target:
+      type: primitive
+      modifiers:
+        - type: extendThroughStartOf
+          modifiers:
+            - type: preferredScope
+              scopeType: {type: line}
+  usePrePhraseSnapshot: true
+spokenFormError: Modifier 'preferredScope'
+initialState:
+  documentContents: "'foo bar'"
+  selections:
+    - anchor: {line: 0, character: 5}
+      active: {line: 0, character: 5}
+  marks: {}
+finalState:
+  documentContents: bar'
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}

--- a/data/fixtures/recorded/headTail/clearTailLine.yml
+++ b/data/fixtures/recorded/headTail/clearTailLine.yml
@@ -1,0 +1,26 @@
+languageId: plaintext
+command:
+  version: 7
+  spokenForm: clear tail line
+  action:
+    name: clearAndSetSelection
+    target:
+      type: primitive
+      modifiers:
+        - type: extendThroughEndOf
+          modifiers:
+            - type: preferredScope
+              scopeType: {type: line}
+  usePrePhraseSnapshot: true
+spokenFormError: Modifier 'preferredScope'
+initialState:
+  documentContents: "'foo bar'"
+  selections:
+    - anchor: {line: 0, character: 4}
+      active: {line: 0, character: 4}
+  marks: {}
+finalState:
+  documentContents: "'foo"
+  selections:
+    - anchor: {line: 0, character: 4}
+      active: {line: 0, character: 4}

--- a/packages/cursorless-engine/src/processTargets/modifiers/HeadTailStage.ts
+++ b/packages/cursorless-engine/src/processTargets/modifiers/HeadTailStage.ts
@@ -1,4 +1,4 @@
-import type { HeadModifier, TailModifier } from "@cursorless/common";
+import type { HeadModifier, Modifier, TailModifier } from "@cursorless/common";
 import type { Target } from "../../typings/target.types";
 import type { ModifierStageFactory } from "../ModifierStageFactory";
 import type { ModifierStage } from "../PipelineStages.types";
@@ -15,10 +15,21 @@ export class HeadTailStage implements ModifierStage {
   ) {}
 
   run(target: Target): Target[] {
-    const modifiers = this.modifier.modifiers ?? [
+    const modifiers: Modifier[] = this.modifier.modifiers ?? [
       {
         type: "containingScope",
-        scopeType: { type: "line" },
+        scopeType: {
+          type: "oneOf",
+          scopeTypes: [
+            {
+              type: "line",
+            },
+            {
+              type: "surroundingPairInterior",
+              delimiter: "any",
+            },
+          ],
+        },
       },
     ];
 


### PR DESCRIPTION
If no scope is specified for head/tail instead of defaulting to just line we now use the smallest of line or surrounding pair interior. This means that `"take head"` would be bounded by the surrounding pair just like `"short paint"`. If there is no surrounding pair the line is used just like today. You can also override this behavior by specifying line. `"take head line"` would always use the line regardless if you are in a surrounding pair or not.

Fixes #2434

The issue mentions a tag for this. I guess since this change is fully extension side it would be a vscode setting, but in tempted to just have this be enabled by default since it's a really useful feature.

## Checklist

- [x] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [/] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [/] I have not broken the cheatsheet
