### PR TITLE
Add `.DS_Store` to `.gitignore` for `cursorless-talon`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ node_modules
 .vscode-test/
 *.vsix
 /package-lock.json
-*.DS_Store
+.DS_Store
 meta.json
 .luacheckcache
 

--- a/cursorless-talon/.gitignore
+++ b/cursorless-talon/.gitignore
@@ -1,3 +1,4 @@
 *.flac
 data/
 .vscode/settings.json
+.DS_Store


### PR DESCRIPTION
When this is synced to [`cursorless-talon`](https://github.com/cursorless-dev/cursorless-talon) the `.gitignore` in the monorepo doesn't apply so copy the `.DS_Store` ignore for those on macOS to prevent spurious `untracked content` messages in `git`.

I don't think the checklist below applies in this case.

## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [x] I have not broken the cheatsheet
