### PR TITLE
Show better exception message when vscode settings json is not found

### DIFF
--- a/cursorless-talon/src/apps/vscode_settings.py
+++ b/cursorless-talon/src/apps/vscode_settings.py
@@ -69,7 +69,7 @@ def pick_path(paths: list[Path]) -> Path:
     existing_paths = [path for path in paths if path.exists()]
     if not existing_paths:
         raise FileNotFoundError(
-            f"Couldn't find vscode settings json in the following paths: {paths}"
+            f"Couldn't find VSCode's settings JSON. Tried these paths: {paths}"
         )
     return max(existing_paths, key=lambda path: path.stat().st_mtime)
 

--- a/cursorless-talon/src/apps/vscode_settings.py
+++ b/cursorless-talon/src/apps/vscode_settings.py
@@ -67,6 +67,10 @@ class Actions:
 
 def pick_path(paths: list[Path]) -> Path:
     existing_paths = [path for path in paths if path.exists()]
+    if not existing_paths:
+        raise FileNotFoundError(
+            f"Couldn't find vscode settings json in the following paths: {paths}"
+        )
     return max(existing_paths, key=lambda path: path.stat().st_mtime)
 
 

--- a/cursorless-talon/src/apps/vscode_settings.py
+++ b/cursorless-talon/src/apps/vscode_settings.py
@@ -68,8 +68,9 @@ class Actions:
 def pick_path(paths: list[Path]) -> Path:
     existing_paths = [path for path in paths if path.exists()]
     if not existing_paths:
+        paths_str = ", ".join(str(path) for path in paths)
         raise FileNotFoundError(
-            f"Couldn't find VSCode's settings JSON. Tried these paths: {paths}"
+            f"Couldn't find VSCode's settings JSON. Tried these paths: {paths_str}"
         )
     return max(existing_paths, key=lambda path: path.stat().st_mtime)
 


### PR DESCRIPTION
Today you get a `ValueError: max() arg is an empty sequence` message that is quite confusing.

## Checklist

- [/] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [/] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [/] I have not broken the cheatsheet
