### PR TITLE
Changed order surrounding pair lists were combined for spoken scope forms

### DIFF
--- a/cursorless-talon/src/spoken_scope_forms.py
+++ b/cursorless-talon/src/spoken_scope_forms.py
@@ -12,9 +12,9 @@ def init_scope_spoken_forms(graphemes_talon_list: dict[str, str]):
 def create_flattened_talon_list(ctx: Context, graphemes_talon_list: dict[str, str]):
     lists_to_merge = {
         "cursorless_scope_type": "simple",
-        "cursorless_surrounding_pair_scope_type": "surroundingPair",
         "cursorless_selectable_only_paired_delimiter": "surroundingPair",
         "cursorless_wrapper_selectable_paired_delimiter": "surroundingPair",
+        "cursorless_surrounding_pair_scope_type": "surroundingPair",
     }
     # If the user have no custom regex scope type, then that list is missing from the context
     if "user.cursorless_custom_regex_scope_type" in ctx.lists.keys():  # noqa: SIM118

--- a/data/fixtures/recorded/surroundingPair/changeString.yml
+++ b/data/fixtures/recorded/surroundingPair/changeString.yml
@@ -1,0 +1,23 @@
+languageId: typescript
+command:
+  version: 7
+  spokenForm: change string
+  action:
+    name: clearAndSetSelection
+    target:
+      type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: surroundingPair, delimiter: string}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: "`hello`"
+  selections:
+    - anchor: {line: 0, character: 1}
+      active: {line: 0, character: 1}
+  marks: {}
+finalState:
+  documentContents: ""
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}


### PR DESCRIPTION
I have a on purpose conflict where I have `string: doubleQuotes` pair and `string: string` scope. This allows me to do `string wrap` that will do double quotes, but `take string` should be all strings not just double quotes. This worked fine before the dfa optimization where we flattened the scope types in #2628

Just rearranging the lists so the one with scope types has higher priority than the list of wrappers fixes this. 

## Checklist

- [x] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [/] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [/] I have not broken the cheatsheet
