### PR TITLE
Don't use multiline pairs for head/tail modifier.

### DIFF
--- a/cursorless-talon/src/apps/vscode_settings.py
+++ b/cursorless-talon/src/apps/vscode_settings.py
@@ -67,6 +67,11 @@ class Actions:
 
 def pick_path(paths: list[Path]) -> Path:
     existing_paths = [path for path in paths if path.exists()]
+    if not existing_paths:
+        paths_str = ", ".join(str(path) for path in paths)
+        raise FileNotFoundError(
+            f"Couldn't find VSCode's settings JSON. Tried these paths: {paths_str}"
+        )
     return max(existing_paths, key=lambda path: path.stat().st_mtime)
 
 

--- a/data/fixtures/recorded/headTail/changeTail3.yml
+++ b/data/fixtures/recorded/headTail/changeTail3.yml
@@ -1,0 +1,28 @@
+languageId: python
+command:
+  version: 7
+  spokenForm: change tail
+  action:
+    name: clearAndSetSelection
+    target:
+      type: primitive
+      modifiers:
+        - {type: extendThroughEndOf}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    """foo
+    bar
+    """
+  selections:
+    - anchor: {line: 0, character: 3}
+      active: {line: 0, character: 3}
+  marks: {}
+finalState:
+  documentContents: |-
+    """
+    bar
+    """
+  selections:
+    - anchor: {line: 0, character: 3}
+      active: {line: 0, character: 3}

--- a/packages/common/src/types/command/PartialTargetDescriptor.types.ts
+++ b/packages/common/src/types/command/PartialTargetDescriptor.types.ts
@@ -251,6 +251,8 @@ export interface SurroundingPairScopeType {
 export interface SurroundingPairInteriorScopeType {
   type: "surroundingPairInterior";
   delimiter: SurroundingPairName;
+  // If true don't yield multiline pairs
+  requireSingleLine?: boolean;
 }
 
 export interface OneOfScopeType {

--- a/packages/cursorless-engine/src/processTargets/modifiers/HeadTailStage.ts
+++ b/packages/cursorless-engine/src/processTargets/modifiers/HeadTailStage.ts
@@ -27,6 +27,7 @@ export class HeadTailStage implements ModifierStage {
             {
               type: "surroundingPairInterior",
               delimiter: "any",
+              requireSingleLine: true,
             },
           ],
         },

--- a/packages/cursorless-engine/src/processTargets/modifiers/scopeHandlers/SurroundingPairScopeHandler/SurroundingPairInteriorScopeHandler.ts
+++ b/packages/cursorless-engine/src/processTargets/modifiers/scopeHandlers/SurroundingPairScopeHandler/SurroundingPairInteriorScopeHandler.ts
@@ -45,17 +45,19 @@ export class SurroundingPairInteriorScopeHandler extends BaseScopeHandler {
     );
 
     for (const scope of scopes) {
-      if (!this.scopeType.requireSingleLine || scope.domain.isSingleLine) {
-        yield {
-          editor,
-          domain: scope.domain,
-          getTargets(isReversed) {
-            return scope
-              .getTargets(isReversed)
-              .flatMap((target) => target.getInterior()!);
-          },
-        };
+      if (this.scopeType.requireSingleLine && !scope.domain.isSingleLine) {
+        continue;
       }
+
+      yield {
+        editor,
+        domain: scope.domain,
+        getTargets(isReversed) {
+          return scope
+            .getTargets(isReversed)
+            .flatMap((target) => target.getInterior()!);
+        },
+      };
     }
   }
 }


### PR DESCRIPTION
`change tail` did the wrong thing in this case
```py
"""|foo
 bar
"""
```


## Checklist

- [x] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [/] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [/] I have not broken the cheatsheet
