### PR TITLE
Add declare to class fields in child class that overrides a base clas…

### DIFF
--- a/packages/cursorless-vscode/src/ScopeTreeProvider.ts
+++ b/packages/cursorless-vscode/src/ScopeTreeProvider.ts
@@ -212,7 +212,7 @@ function getSupportCategories(): SupportCategoryTreeItem[] {
 }
 
 class ScopeSupportTreeItem extends TreeItem {
-  public readonly label!: TreeItemLabel;
+  public readonly declare label!: TreeItemLabel;
 
   /**
    * @param scopeTypeInfo The scope type info


### PR DESCRIPTION
…s field without explicitly reinitializing the field

According to an internal Google audit of TS code: When public class fields are enabled and target output is set to ES2022, TypeScript reports the following error -

```
class A {
    x: SomeType = new SomeType();
}

class B extends A {

    override x!: NarrowType;      // Property 'x' will overwrite the base property in 'A'. If this is intentional, add an initializer. Otherwise, add a 'declare' modifier or remove the redundant declaration.

}
```