### PR TITLE
Default value for preferred scope setting

### DIFF
--- a/cursorless-talon/src/modifiers/simple_scope_modifier.py
+++ b/cursorless-talon/src/modifiers/simple_scope_modifier.py
@@ -17,6 +17,7 @@ mod.list(
 mod.setting(
     "private_cursorless_use_preferred_scope",
     bool,
+    default=False,
     desc="Use preferred scope instead of containing scope for all scopes by default (EXPERIMENTAL)",
 )
 
@@ -42,7 +43,7 @@ def cursorless_simple_scope_modifier(m) -> dict[str, Any]:
             "ancestorIndex": 1,
         }
 
-    if settings.get("user.private_cursorless_use_preferred_scope", False):
+    if settings.get("user.private_cursorless_use_preferred_scope"):
         return {
             "type": "preferredScope",
             "scopeType": m.cursorless_scope_type,

--- a/cursorless-talon/src/modifiers/simple_scope_modifier.py
+++ b/cursorless-talon/src/modifiers/simple_scope_modifier.py
@@ -16,7 +16,7 @@ mod.list(
 # This is a private setting and should not be used by non Cursorless developers
 mod.setting(
     "private_cursorless_use_preferred_scope",
-    bool,
+    type=bool,
     default=False,
     desc="Use preferred scope instead of containing scope for all scopes by default (EXPERIMENTAL)",
 )


### PR DESCRIPTION
I got unreliable behavior when we didn't have a default value here. Turns out that if you don't have a default value `settings.get(id, default)` will not actually return none or your specified default value. It will return a `NoValueType` object and that is evaluated to true in the if statements so everybody probably has preferred scope on now. This might be a change to Talon because I can't believe we didn't catch this earlier.

## Checklist

- [/] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [/] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [/] I have not broken the cheatsheet
