### PR TITLE
Added Cursorless prefects to ordinal_or_last capture

### DIFF
--- a/cursorless-talon/src/modifiers/ordinal_scope.py
+++ b/cursorless-talon/src/modifiers/ordinal_scope.py
@@ -13,7 +13,7 @@ mod.list("cursorless_last_modifier", desc="Cursorless last modifiers")
 @mod.capture(
     rule="<user.ordinals_small> | [<user.ordinals_small>] {user.cursorless_last_modifier}"
 )
-def ordinal_or_last(m) -> int:
+def cursorless_ordinal_or_last(m) -> int:
     """An ordinal or the word 'last'"""
     if m[-1] == "last":
         return -getattr(m, "ordinals_small", 1)
@@ -21,16 +21,16 @@ def ordinal_or_last(m) -> int:
 
 
 @mod.capture(
-    rule="<user.ordinal_or_last> [<user.cursorless_range_connective> <user.ordinal_or_last>] <user.cursorless_scope_type>"
+    rule="<user.cursorless_ordinal_or_last> [<user.cursorless_range_connective> <user.cursorless_ordinal_or_last>] <user.cursorless_scope_type>"
 )
 def cursorless_ordinal_range(m) -> dict[str, Any]:
     """Ordinal range"""
     anchor = create_ordinal_scope_modifier(
-        m.cursorless_scope_type, m.ordinal_or_last_list[0]
+        m.cursorless_scope_type, m.cursorless_ordinal_or_last_list[0]
     )
-    if len(m.ordinal_or_last_list) > 1:
+    if len(m.cursorless_ordinal_or_last_list) > 1:
         active = create_ordinal_scope_modifier(
-            m.cursorless_scope_type, m.ordinal_or_last_list[1]
+            m.cursorless_scope_type, m.cursorless_ordinal_or_last_list[1]
         )
         range_connective: RangeConnective = m.cursorless_range_connective
         return {


### PR DESCRIPTION
This capture was missing our Cursorless prefix 

## Checklist

- [/] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [/] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [/] I have not broken the cheatsheet
