### PR TITLE
Added performance tests

### DIFF
--- a/packages/cursorless-vscode-e2e/src/suite/performance.vscode.test.ts
+++ b/packages/cursorless-vscode-e2e/src/suite/performance.vscode.test.ts
@@ -1,0 +1,125 @@
+import {
+  asyncSafety,
+  type ActionDescriptor,
+  type ScopeType,
+  type SimpleScopeTypeType,
+} from "@cursorless/common";
+import { openNewEditor, runCursorlessCommand } from "@cursorless/vscode-common";
+import assert from "assert";
+import * as vscode from "vscode";
+import { endToEndTestSetup } from "../endToEndTestSetup";
+
+const obj = Object.fromEntries(
+  new Array(100)
+    .fill("")
+    .map((_, i) => [
+      i.toString(),
+      Object.fromEntries(
+        new Array(100).fill("").map((_, i) => [i.toString(), "value"]),
+      ),
+    ]),
+);
+const content = JSON.stringify(obj, null, 2);
+const numLines = content.split("\n").length;
+
+suite(`Performance: ${numLines} lines JSON`, async function () {
+  endToEndTestSetup(this);
+
+  this.beforeEach(function () {
+    // console.log("before");
+    // console.log(a.name);
+    console.log(this.test?.title);
+    console.log(this.test?.id);
+  });
+
+  this.afterAll(() => {
+    console.log("Done!");
+  });
+
+  const scopeTypeTypes: Partial<Record<SimpleScopeTypeType, number>> = {
+    character: 100,
+    word: 100,
+    token: 100,
+    identifier: 100,
+    line: 100,
+    sentence: 100,
+    paragraph: 100,
+    // boundedParagraph: 100,
+    document: 100,
+    nonWhitespaceSequence: 100,
+    // boundedNonWhitespaceSequence: 300,
+    // string: 100,
+    map: 100,
+    // collectionKey: 300,
+    // value: 15000,
+  };
+
+  for (const [scopeTypeType, threshold] of Object.entries(scopeTypeTypes)) {
+    test(
+      `Select ${scopeTypeType}`,
+      asyncSafety(() =>
+        selectScopeType(
+          { type: scopeTypeType as SimpleScopeTypeType },
+          threshold,
+        ),
+      ),
+    );
+  }
+
+  //   test(
+  //     "Select any surrounding pair",
+  //     asyncSafety(() =>
+  //       selectScopeType({ type: "surroundingPair", delimiter: "any" }, 300),
+  //     ),
+  //   );
+
+  test(
+    "Remove token",
+    asyncSafety(() => removeToken()),
+  );
+});
+
+async function removeToken() {
+  await testPerformance(100, {
+    name: "remove",
+    target: {
+      type: "primitive",
+      modifiers: [{ type: "containingScope", scopeType: { type: "token" } }],
+    },
+  });
+}
+
+async function selectScopeType(scopeType: ScopeType, threshold: number) {
+  await testPerformance(threshold, {
+    name: "setSelection",
+    target: {
+      type: "primitive",
+      modifiers: [{ type: "containingScope", scopeType }],
+    },
+  });
+}
+
+async function testPerformance(threshold: number, action: ActionDescriptor) {
+  const editor = await openNewEditor(content, { languageId: "json" });
+  const position = new vscode.Position(editor.document.lineCount - 3, 5);
+  const selection = new vscode.Selection(position, position);
+  editor.selections = [selection];
+  editor.revealRange(selection);
+
+  const start = performance.now();
+
+  await runCursorlessCommand({
+    version: 7,
+    usePrePhraseSnapshot: false,
+    action,
+  });
+
+  const duration = Math.round(performance.now() - start);
+
+  console.debug(`\t${duration} ms`);
+
+  assert.ok(
+    duration < threshold,
+    `Duration ${duration}ms exceeds threshold ${threshold}ms`,
+  );
+}


### PR DESCRIPTION
This is the result from running it locally on my desktop.
```
  Performance: 10202 lines JSON
    * Remove token
        22 ms
    √ Remove token (116ms)
    * Select character
        14 ms
    √ Select character (120ms)
    * Select word
        9 ms
    √ Select word (118ms)
    * Select token
        9 ms
    √ Select token (110ms)
    * Select identifier
        6 ms
    √ Select identifier (117ms)
    * Select line
        8 ms
    √ Select line (103ms)
    * Select sentence
        16 ms
    √ Select sentence (115ms)
    * Select paragraph
        5 ms
    √ Select paragraph (112ms)
    * Select document
        13 ms
    √ Select document (114ms)
    * Select nonWhitespaceSequence
        6 ms
    √ Select nonWhitespaceSequence (106ms)
    * Select string
        194 ms
    √ Select string (294ms)
    * Select map
        164 ms
    √ Select map (246ms)
    * Select collectionKey
        142 ms
    √ Select collectionKey (231ms)
    * Select value
        134 ms
    √ Select value (214ms)
    * Select boundedParagraph
        11931 ms
    √ Select boundedParagraph (12011ms)
    * Select boundedNonWhitespaceSequence
        10908 ms
    √ Select boundedNonWhitespaceSequence (10998ms)
    * Select any surrounding pair
        10670 ms
    √ Select any surrounding pair (10768ms)
  17 passing (36s)

```

## Checklist

- [x] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [-] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [-] I have not broken the cheatsheet
