### PR TITLE
Deprecate tag `user.cursorless_custom_number_small`

### DIFF
--- a/cursorless-talon/src/cursorless.talon
+++ b/cursorless-talon/src/cursorless.talon
@@ -45,5 +45,5 @@ tutorial (previous | last): user.private_cursorless_tutorial_previous()
 tutorial restart: user.private_cursorless_tutorial_restart()
 tutorial resume: user.private_cursorless_tutorial_resume()
 tutorial (list | close): user.private_cursorless_tutorial_list()
-tutorial <user.private_cursorless_number_small>:
-    user.private_cursorless_tutorial_start_by_number(private_cursorless_number_small)
+tutorial <number_small>:
+    user.private_cursorless_tutorial_start_by_number(number_small)

--- a/cursorless-talon/src/marks/lines_number.py
+++ b/cursorless-talon/src/marks/lines_number.py
@@ -31,13 +31,13 @@ directions_map = {d.cursorlessIdentifier: d for d in directions}
 
 @mod.capture(
     rule=(
-        "{user.cursorless_line_direction} <user.private_cursorless_number_small> "
-        "[<user.cursorless_range_connective> <user.private_cursorless_number_small>]"
+        "{user.cursorless_line_direction} <number_small> "
+        "[<user.cursorless_range_connective> <number_small>]"
     )
 )
 def cursorless_line_number(m) -> LineNumber:
     direction = directions_map[m.cursorless_line_direction]
-    numbers: list[int] = m.private_cursorless_number_small_list
+    numbers: list[int] = m.number_small_list
     anchor = create_line_number_mark(direction.type, direction.formatter(numbers[0]))
     if len(numbers) > 1:
         active = create_line_number_mark(

--- a/cursorless-talon/src/modifiers/ordinal_scope.py
+++ b/cursorless-talon/src/modifiers/ordinal_scope.py
@@ -47,7 +47,7 @@ def cursorless_ordinal_range(m) -> dict[str, Any]:
     rule=(
         "[{user.cursorless_every_scope_modifier}] "
         "({user.cursorless_first_modifier} | {user.cursorless_last_modifier}) "
-        "<user.private_cursorless_number_small> <user.cursorless_scope_type_plural>"
+        "<number_small> <user.cursorless_scope_type_plural>"
     ),
 )
 def cursorless_first_last(m) -> dict[str, Any]:
@@ -57,13 +57,13 @@ def cursorless_first_last(m) -> dict[str, Any]:
         return create_ordinal_scope_modifier(
             m.cursorless_scope_type_plural,
             0,
-            m.private_cursorless_number_small,
+            m.number_small,
             is_every,
         )
     return create_ordinal_scope_modifier(
         m.cursorless_scope_type_plural,
-        -m.private_cursorless_number_small,
-        m.private_cursorless_number_small,
+        -m.number_small,
+        m.number_small,
         is_every,
     )
 

--- a/cursorless-talon/src/modifiers/relative_scope.py
+++ b/cursorless-talon/src/modifiers/relative_scope.py
@@ -31,28 +31,28 @@ def cursorless_relative_scope_singular(m) -> dict[str, Any]:
 
 
 @mod.capture(
-    rule="[{user.cursorless_every_scope_modifier}] <user.cursorless_relative_direction> <user.private_cursorless_number_small> <user.cursorless_scope_type_plural>"
+    rule="[{user.cursorless_every_scope_modifier}] <user.cursorless_relative_direction> <number_small> <user.cursorless_scope_type_plural>"
 )
 def cursorless_relative_scope_plural(m) -> dict[str, Any]:
     """Relative previous/next plural scope. `next three funks`"""
     return create_relative_scope_modifier(
         m.cursorless_scope_type_plural,
         1,
-        m.private_cursorless_number_small,
+        m.number_small,
         m.cursorless_relative_direction,
         hasattr(m, "cursorless_every_scope_modifier"),
     )
 
 
 @mod.capture(
-    rule="[{user.cursorless_every_scope_modifier}] <user.private_cursorless_number_small> <user.cursorless_scope_type_plural> [{user.cursorless_forward_backward_modifier}]"
+    rule="[{user.cursorless_every_scope_modifier}] <number_small> <user.cursorless_scope_type_plural> [{user.cursorless_forward_backward_modifier}]"
 )
 def cursorless_relative_scope_count(m) -> dict[str, Any]:
     """Relative count scope. `three funks`"""
     return create_relative_scope_modifier(
         m.cursorless_scope_type_plural,
         0,
-        m.private_cursorless_number_small,
+        m.number_small,
         getattr(m, "cursorless_forward_backward_modifier", "forward"),
         hasattr(m, "cursorless_every_scope_modifier"),
     )

--- a/cursorless-talon/src/number_small.py
+++ b/cursorless-talon/src/number_small.py
@@ -1,46 +1,20 @@
 """
-This file allows us to use a custom `number_small` capture.  See #1021 for more
-info.
+DEPRECATED!
+This file allows us to use a custom `number_small` capture.  See #1021 for more info.
 """
 
-from talon import Context, Module
+from talon import app, Module, registry
 
 mod = Module()
-mod.tag(
-    "cursorless_custom_number_small",
-    "This tag causes Cursorless to use the global <number_small> capture",
-)
 
-ctx = Context()
-ctx.matches = """
-not tag: user.cursorless_custom_number_small
-"""
+mod.tag("cursorless_custom_number_small", "DEPRECATED!")
 
 
-@mod.capture(rule="<number_small>")
-def private_cursorless_number_small(m) -> int:
-    return m.number_small
+def on_ready():
+    if "user.cursorless_custom_number_small" in registry.tags:
+        print(
+            "WARNING tag: 'user.cursorless_custom_number_small' is deprecated and should not be used anymore"
+        )
 
 
-digit_list = "zero one two three four five six seven eight nine".split()
-teens = "ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen".split()
-tens = "twenty thirty forty fifty sixty seventy eighty ninety".split()
-
-number_small_list = [*digit_list, *teens]
-for ten in tens:
-    number_small_list.append(ten)
-    number_small_list.extend(f"{ten} {digit}" for digit in digit_list[1:])
-number_small_map = {n: i for i, n in enumerate(number_small_list)}
-
-mod.list("private_cursorless_number_small", desc="List of small numbers")
-# FIXME: Remove type ignore once Talon supports list types
-# See https://github.com/talonvoice/talon/issues/654
-ctx.lists["self.private_cursorless_number_small"] = number_small_map.keys()  # pyright: ignore [reportArgumentType]
-
-
-@ctx.capture(
-    "user.private_cursorless_number_small",
-    rule="{user.private_cursorless_number_small}",
-)
-def override_private_cursorless_number_small(m) -> int:
-    return number_small_map[m.private_cursorless_number_small]
+app.register("ready", on_ready)

--- a/cursorless-talon/src/number_small.py
+++ b/cursorless-talon/src/number_small.py
@@ -1,5 +1,5 @@
 """
-DEPRECATED!
+DEPRECATED @ 2024-12-21
 This file allows us to use a custom `number_small` capture.  See #1021 for more info.
 """
 

--- a/cursorless-talon/src/number_small.py
+++ b/cursorless-talon/src/number_small.py
@@ -13,7 +13,7 @@ mod.tag("cursorless_custom_number_small", "DEPRECATED!")
 def on_ready():
     if "user.cursorless_custom_number_small" in registry.tags:
         print(
-            "WARNING tag: 'user.cursorless_custom_number_small' is deprecated and should not be used anymore"
+            "WARNING tag: 'user.cursorless_custom_number_small' is deprecated and should not be used anymore, as Cursorless now uses community number_small"
         )
 
 


### PR DESCRIPTION
Community has had a good version of number_small for two years now.

Talon grammar tests passed

## Checklist

- / ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [/] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [/] I have not broken the cheatsheet
