### PR TITLE
Fix surrounding pair performance

### DIFF
--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -76,6 +76,7 @@ export * from "./types/Selection";
 export * from "./types/snippet.types";
 export * from "./types/SpokenForm";
 export * from "./types/SpokenFormType";
+export * from "./types/StringRecord";
 export * from "./types/TalonSpokenForms";
 export * from "./types/TestCaseFixture";
 export * from "./types/TestHelpers";

--- a/packages/cursorless-engine/src/languages/LanguageDefinition.ts
+++ b/packages/cursorless-engine/src/languages/LanguageDefinition.ts
@@ -3,6 +3,7 @@ import type {
   ScopeType,
   SimpleScopeType,
   SimpleScopeTypeType,
+  StringRecord,
   TreeSitter,
 } from "@cursorless/common";
 import {
@@ -97,6 +98,28 @@ export class LanguageDefinition {
       .matches(document)
       .map((match) => match.captures.find(({ name }) => name === captureName))
       .filter((capture) => capture != null);
+  }
+
+  getMultipleCaptures(
+    document: TextDocument,
+    captureNames: SimpleScopeTypeType[],
+  ): StringRecord<QueryCapture[]> {
+    const matches = this.query.matches(document);
+    const result: StringRecord<QueryCapture[]> = {};
+    const captureNamesSet = new Set<string>(captureNames);
+
+    for (const match of matches) {
+      for (const capture of match.captures) {
+        if (captureNamesSet.has(capture.name)) {
+          if (result[capture.name] == null) {
+            result[capture.name] = [];
+          }
+          result[capture.name]!.push(capture);
+        }
+      }
+    }
+
+    return result;
   }
 }
 

--- a/packages/cursorless-engine/src/processTargets/modifiers/scopeHandlers/SurroundingPairScopeHandler/RangeIterator.ts
+++ b/packages/cursorless-engine/src/processTargets/modifiers/scopeHandlers/SurroundingPairScopeHandler/RangeIterator.ts
@@ -6,7 +6,14 @@ import type { Range } from "@cursorless/common";
 export class RangeIterator<T extends { range: Range }> {
   private index = 0;
 
-  constructor(public items: T[]) {}
+  constructor(
+    public items: T[],
+    sortItems = false,
+  ) {
+    if (sortItems) {
+      this.items.sort((a, b) => a.range.start.compareTo(b.range.start));
+    }
+  }
 
   contains(searchItem: Range): boolean {
     return this.advance(searchItem);

--- a/packages/cursorless-engine/src/processTargets/modifiers/scopeHandlers/SurroundingPairScopeHandler/RangeIterator.ts
+++ b/packages/cursorless-engine/src/processTargets/modifiers/scopeHandlers/SurroundingPairScopeHandler/RangeIterator.ts
@@ -1,0 +1,41 @@
+import type { Range } from "@cursorless/common";
+
+/**
+ * An iterator that allows for efficient lookup of ranges that contain a search item.
+ */
+export class RangeIterator<T extends { range: Range }> {
+  private index = 0;
+
+  constructor(public items: T[]) {}
+
+  contains(searchItem: Range): boolean {
+    return this.advance(searchItem);
+  }
+
+  getContaining(searchItem: Range): T | undefined {
+    if (!this.advance(searchItem)) {
+      return undefined;
+    }
+
+    return this.items[this.index];
+  }
+
+  private advance(searchItem: Range): boolean {
+    while (this.index < this.items.length) {
+      const range = this.items[this.index].range;
+
+      if (range.contains(searchItem)) {
+        return true;
+      }
+
+      // Search item is before the range. Since the ranges are sorted, we can stop here.
+      if (searchItem.end.isBefore(range.start)) {
+        return false;
+      }
+
+      this.index++;
+    }
+
+    return false;
+  }
+}

--- a/packages/cursorless-engine/src/processTargets/modifiers/scopeHandlers/SurroundingPairScopeHandler/getDelimiterOccurrences.ts
+++ b/packages/cursorless-engine/src/processTargets/modifiers/scopeHandlers/SurroundingPairScopeHandler/getDelimiterOccurrences.ts
@@ -27,11 +27,14 @@ export function getDelimiterOccurrences(
     "disqualifyDelimiter",
     "textFragment",
   ]);
-  const disqualifyDelimiters = captures?.disqualifyDelimiter ?? [];
-  const textFragments = captures?.textFragment ?? [];
-
-  const disqualifyDelimitersIterator = new RangeIterator(disqualifyDelimiters);
-  const textFragmentsIterator = new RangeIterator(textFragments);
+  const disqualifyDelimitersIterator = new RangeIterator(
+    captures?.disqualifyDelimiter ?? [],
+    true, // Sort items
+  );
+  const textFragmentsIterator = new RangeIterator(
+    captures?.textFragment ?? [],
+    true,
+  );
 
   const delimiterTextToDelimiterInfoMap = Object.fromEntries(
     individualDelimiters.map((individualDelimiter) => [


### PR DESCRIPTION
With a ~10000 line json. `"take pair"` went from about 12 seconds to 200ms on my computer

## Checklist

- [/] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [/] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [/] I have not broken the cheatsheet
