### PR TITLE
Increase sleep to fix mac breakages in ci tests

### DIFF
--- a/packages/cursorless-vscode-e2e/src/suite/scopeProvider/runCustomSpokenFormScopeInfoTest.ts
+++ b/packages/cursorless-vscode-e2e/src/suite/scopeProvider/runCustomSpokenFormScopeInfoTest.ts
@@ -60,7 +60,7 @@ export async function runCustomSpokenFormScopeInfoTest() {
       await unlink(cursorlessTalonStateJsonPath);
       // Sleep to ensure that the scope support provider has time to update
       // before the next test starts
-      await sleep(250);
+      await sleep(400);
     } catch (_e) {
       // Do nothing
     }


### PR DESCRIPTION
Errors like this
https://github.com/cursorless-dev/cursorless/actions/runs/12454094525/job/34764966216#step:10:8885

I ran the test three times and everything appears to be working now.

## Checklist

- [/] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [/] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [/] I have not broken the cheatsheet
