### PR TITLE
Update check community message

### DIFF
--- a/cursorless-talon/src/check_community_repo.py
+++ b/cursorless-talon/src/check_community_repo.py
@@ -26,9 +26,10 @@ def on_ready():
     if missing_actions:
         errors.append(f"Missing actions: {', '.join(missing_actions)}")
     if errors:
-        print("\n".join(errors))
+        message = "\n".join(errors)
+        print(f"Cursorless: {message}")
         app.notify(
-            "Please install the community repository",
+            "Cursorless: Please install the community repository",
             body="https://github.com/talonhub/community",
         )
 


### PR DESCRIPTION
We should don't show notifications without telling the user it comes from Cursorless

## Checklist

- [/] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [/] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [/] I have not broken the cheatsheet
