### PR TITLE
Increase performance for Tree sitter matches

### DIFF
--- a/packages/cursorless-engine/src/languages/LanguageDefinition.ts
+++ b/packages/cursorless-engine/src/languages/LanguageDefinition.ts
@@ -74,7 +74,7 @@ export class LanguageDefinition {
    * legacy pathways
    */
   getScopeHandler(scopeType: ScopeType) {
-    if (!this.query.captureNames.includes(scopeType.type)) {
+    if (!this.query.hasCapture(scopeType.type)) {
       return undefined;
     }
 

--- a/packages/cursorless-engine/src/languages/TreeSitterQuery/QueryCapture.ts
+++ b/packages/cursorless-engine/src/languages/TreeSitterQuery/QueryCapture.ts
@@ -50,17 +50,6 @@ export interface QueryCapture {
 }
 
 /**
- * A capture of a query pattern against a syntax tree that can be modified.
- */
-export interface ModifiableQueryCapture {
-  readonly name: string;
-  range: Range;
-  allowMultiple: boolean;
-  insertionDelimiter: string | undefined;
-  hasError(): boolean;
-}
-
-/**
  * A match of a query pattern against a syntax tree.
  */
 export interface QueryMatch {

--- a/packages/cursorless-engine/src/languages/TreeSitterQuery/QueryCapture.ts
+++ b/packages/cursorless-engine/src/languages/TreeSitterQuery/QueryCapture.ts
@@ -50,6 +50,17 @@ export interface QueryCapture {
 }
 
 /**
+ * A capture of a query pattern against a syntax tree that can be modified.
+ */
+export interface ModifiableQueryCapture {
+  readonly name: string;
+  range: Range;
+  allowMultiple: boolean;
+  insertionDelimiter: string | undefined;
+  hasError(): boolean;
+}
+
+/**
  * A match of a query pattern against a syntax tree.
  */
 export interface QueryMatch {

--- a/packages/cursorless-engine/src/languages/TreeSitterQuery/TreeSitterQuery.ts
+++ b/packages/cursorless-engine/src/languages/TreeSitterQuery/TreeSitterQuery.ts
@@ -1,7 +1,6 @@
 import type { Position, TextDocument } from "@cursorless/common";
 import { showError, type TreeSitter } from "@cursorless/common";
 import type Parser from "web-tree-sitter";
-import type { Query } from "web-tree-sitter";
 import { ide } from "../../singletons/ide.singleton";
 import { getNodeRange } from "../../util/nodeSelectors";
 import type {
@@ -32,7 +31,7 @@ export class TreeSitterQuery {
     /**
      * The raw tree-sitter query as parsed by tree-sitter from the query file
      */
-    private query: Query,
+    private query: Parser.Query,
 
     /**
      * The predicates for each pattern in the query. Each element of the outer
@@ -42,7 +41,11 @@ export class TreeSitterQuery {
     private patternPredicates: ((match: MutableQueryMatch) => boolean)[][],
   ) {}
 
-  static create(languageId: string, treeSitter: TreeSitter, query: Query) {
+  static create(
+    languageId: string,
+    treeSitter: TreeSitter,
+    query: Parser.Query,
+  ) {
     const { errors, predicates } = parsePredicates(query.predicates);
 
     if (errors.length > 0) {

--- a/packages/cursorless-engine/src/languages/TreeSitterQuery/TreeSitterQuery.ts
+++ b/packages/cursorless-engine/src/languages/TreeSitterQuery/TreeSitterQuery.ts
@@ -1,19 +1,25 @@
 import type { Position, TextDocument } from "@cursorless/common";
 import { showError, type TreeSitter } from "@cursorless/common";
-import { groupBy, uniq } from "lodash-es";
-import type { Point, Query } from "web-tree-sitter";
+import type Parser from "web-tree-sitter";
+import type { Query } from "web-tree-sitter";
 import { ide } from "../../singletons/ide.singleton";
 import { getNodeRange } from "../../util/nodeSelectors";
 import type {
+  ModifiableQueryCapture,
+  MutableQueryCapture,
   MutableQueryMatch,
-  QueryCapture,
   QueryMatch,
 } from "./QueryCapture";
 import { checkCaptureStartEnd } from "./checkCaptureStartEnd";
 import { isContainedInErrorNode } from "./isContainedInErrorNode";
+import { normalizeCaptureName } from "./normalizeCaptureName";
 import { parsePredicates } from "./parsePredicates";
+import { positionToPoint } from "./positionToPoint";
 import { predicateToString } from "./predicateToString";
-import { rewriteStartOfEndOf } from "./rewriteStartOfEndOf";
+import {
+  getStartOfEndOfRange,
+  rewriteStartOfEndOf,
+} from "./rewriteStartOfEndOf";
 import { treeSitterQueryCache } from "./treeSitterQueryCache";
 
 /**
@@ -67,6 +73,12 @@ export class TreeSitterQuery {
     return new TreeSitterQuery(treeSitter, query, predicates);
   }
 
+  hasCapture(name: string): boolean {
+    return this.query.captureNames.some(
+      (n) => normalizeCaptureName(n) === name,
+    );
+  }
+
   matches(
     document: TextDocument,
     start?: Position,
@@ -84,74 +96,111 @@ export class TreeSitterQuery {
     start?: Position,
     end?: Position,
   ): QueryMatch[] {
-    return this.query
-      .matches(this.treeSitter.getTree(document).rootNode, {
-        startPosition: start == null ? undefined : positionToPoint(start),
-        endPosition: end == null ? undefined : positionToPoint(end),
-      })
-      .map(
-        ({ pattern, captures }): MutableQueryMatch => ({
-          patternIdx: pattern,
-          captures: captures.map(({ name, node }) => ({
-            name,
-            node,
-            document,
-            range: getNodeRange(node),
-            insertionDelimiter: undefined,
-            allowMultiple: false,
-            hasError: () => isContainedInErrorNode(node),
-          })),
-        }),
-      )
-      .filter((match) =>
-        this.patternPredicates[match.patternIdx].every((predicate) =>
-          predicate(match),
-        ),
-      )
-      .map((match): QueryMatch => {
-        // Merge the ranges of all captures with the same name into a single
-        // range and return one capture with that name.  We consider captures
-        // with names `@foo`, `@foo.start`, and `@foo.end` to have the same
-        // name, for which we'd return a capture with name `foo`.
-        const captures: QueryCapture[] = Object.entries(
-          groupBy(match.captures, ({ name }) => normalizeCaptureName(name)),
-        ).map(([name, captures]) => {
-          captures = rewriteStartOfEndOf(captures);
-          const capturesAreValid = checkCaptureStartEnd(
-            captures,
-            ide().messages,
-          );
+    const results: QueryMatch[] = [];
+    const isTesting = ide().runMode === "test";
 
-          if (!capturesAreValid && ide().runMode === "test") {
-            throw new Error("Invalid captures");
-          }
+    const matches = this.query.matches(
+      this.treeSitter.getTree(document).rootNode,
+      {
+        startPosition: start != null ? positionToPoint(start) : undefined,
+        endPosition: end != null ? positionToPoint(end) : undefined,
+      },
+    );
 
-          return {
-            name,
-            range: captures
-              .map(({ range }) => range)
-              .reduce((accumulator, range) => range.union(accumulator)),
-            allowMultiple: captures.some((capture) => capture.allowMultiple),
-            insertionDelimiter: captures.find(
-              (capture) => capture.insertionDelimiter != null,
-            )?.insertionDelimiter,
-            hasError: () => captures.some((capture) => capture.hasError()),
-          };
-        });
+    for (const match of matches) {
+      const mutableMatch = createMutableQueryMatch(document, match);
 
-        return { ...match, captures };
+      if (this.runPredicates(mutableMatch)) {
+        results.push(createQueryMatch(mutableMatch, isTesting));
+      }
+    }
+
+    return results;
+  }
+
+  private runPredicates(match: MutableQueryMatch): boolean {
+    for (const predicate of this.patternPredicates[match.patternIdx]) {
+      if (!predicate(match)) {
+        return false;
+      }
+    }
+    return true;
+  }
+}
+
+function createMutableQueryMatch(
+  document: TextDocument,
+  match: Parser.QueryMatch,
+): MutableQueryMatch {
+  return {
+    patternIdx: match.pattern,
+    captures: match.captures.map(({ name, node }) => ({
+      name,
+      node,
+      document,
+      range: getNodeRange(node),
+      insertionDelimiter: undefined,
+      allowMultiple: false,
+      hasError: () => isContainedInErrorNode(node),
+    })),
+  };
+}
+
+function createQueryMatch(
+  match: MutableQueryMatch,
+  isTesting: boolean,
+): QueryMatch {
+  const result: ModifiableQueryCapture[] = [];
+  const resultMap = new Map<
+    string,
+    { acc: ModifiableQueryCapture; captures: MutableQueryCapture[] }
+  >();
+
+  // Merge the ranges of all captures with the same name into a single
+  // range and return one capture with that name.  We consider captures
+  // with names `@foo`, `@foo.start`, and `@foo.end` to have the same
+  // name, for which we'd return a capture with name `foo`.
+
+  for (const capture of match.captures) {
+    const name = normalizeCaptureName(capture.name);
+    const range = getStartOfEndOfRange(capture);
+    const existing = resultMap.get(name);
+
+    if (existing == null) {
+      const accumulator = {
+        name,
+        range,
+        allowMultiple: capture.allowMultiple,
+        insertionDelimiter: capture.insertionDelimiter,
+        hasError: () => capture.hasError(),
+      };
+      result.push(accumulator);
+      resultMap.set(name, {
+        acc: accumulator,
+        captures: [capture],
       });
+    } else {
+      existing.acc.range = existing.acc.range.union(range);
+      existing.acc.allowMultiple =
+        existing.acc.allowMultiple || capture.allowMultiple;
+      existing.acc.insertionDelimiter =
+        existing.acc.insertionDelimiter ?? capture.insertionDelimiter;
+      existing.acc.hasError = () => existing.captures.some((c) => c.hasError());
+      existing.captures.push(capture);
+    }
   }
 
-  get captureNames() {
-    return uniq(this.query.captureNames.map(normalizeCaptureName));
+  if (isTesting) {
+    for (const captureGroup of resultMap.values()) {
+      const capturesAreValid = checkCaptureStartEnd(
+        rewriteStartOfEndOf(captureGroup.captures),
+        ide().messages,
+      );
+      if (!capturesAreValid) {
+        throw new Error("Invalid captures");
+      }
+    }
   }
-}
 
-function normalizeCaptureName(name: string): string {
-  return name.replace(/(\.(start|end))?(\.(startOf|endOf))?$/, "");
-}
-
-function positionToPoint(start: Position): Point {
-  return { row: start.line, column: start.character };
+  return { captures: result };
 }

--- a/packages/cursorless-engine/src/languages/TreeSitterQuery/TreeSitterQuery.ts
+++ b/packages/cursorless-engine/src/languages/TreeSitterQuery/TreeSitterQuery.ts
@@ -1,6 +1,6 @@
 import type { Position, TextDocument } from "@cursorless/common";
 import { showError, type TreeSitter } from "@cursorless/common";
-import type Parser from "web-tree-sitter";
+import type * as treeSitter from "web-tree-sitter";
 import { ide } from "../../singletons/ide.singleton";
 import { getNodeRange } from "../../util/nodeSelectors";
 import type {
@@ -31,7 +31,7 @@ export class TreeSitterQuery {
     /**
      * The raw tree-sitter query as parsed by tree-sitter from the query file
      */
-    private query: Parser.Query,
+    private query: treeSitter.Query,
 
     /**
      * The predicates for each pattern in the query. Each element of the outer
@@ -44,7 +44,7 @@ export class TreeSitterQuery {
   static create(
     languageId: string,
     treeSitter: TreeSitter,
-    query: Parser.Query,
+    query: treeSitter.Query,
   ) {
     const { errors, predicates } = parsePredicates(query.predicates);
 
@@ -132,7 +132,7 @@ export class TreeSitterQuery {
 
 function createMutableQueryMatch(
   document: TextDocument,
-  match: Parser.QueryMatch,
+  match: treeSitter.QueryMatch,
 ): MutableQueryMatch {
   return {
     patternIdx: match.pattern,

--- a/packages/cursorless-engine/src/languages/TreeSitterQuery/TreeSitterQuery.ts
+++ b/packages/cursorless-engine/src/languages/TreeSitterQuery/TreeSitterQuery.ts
@@ -96,8 +96,8 @@ export class TreeSitterQuery {
     start?: Position,
     end?: Position,
   ): QueryMatch[] {
-    const results: QueryMatch[] = [];
     const isTesting = ide().runMode === "test";
+    const results: QueryMatch[] = [];
 
     const matches = this.query.matches(
       this.treeSitter.getTree(document).rootNode,

--- a/packages/cursorless-engine/src/languages/TreeSitterQuery/TreeSitterQuery.ts
+++ b/packages/cursorless-engine/src/languages/TreeSitterQuery/TreeSitterQuery.ts
@@ -5,7 +5,6 @@ import type { Query } from "web-tree-sitter";
 import { ide } from "../../singletons/ide.singleton";
 import { getNodeRange } from "../../util/nodeSelectors";
 import type {
-  ModifiableQueryCapture,
   MutableQueryCapture,
   MutableQueryMatch,
   QueryMatch,
@@ -150,10 +149,10 @@ function createQueryMatch(
   match: MutableQueryMatch,
   isTesting: boolean,
 ): QueryMatch {
-  const result: ModifiableQueryCapture[] = [];
+  const result: MutableQueryCapture[] = [];
   const resultMap = new Map<
     string,
-    { acc: ModifiableQueryCapture; captures: MutableQueryCapture[] }
+    { acc: MutableQueryCapture; captures: MutableQueryCapture[] }
   >();
 
   // Merge the ranges of all captures with the same name into a single
@@ -168,11 +167,9 @@ function createQueryMatch(
 
     if (existing == null) {
       const accumulator = {
+        ...capture,
         name,
         range,
-        allowMultiple: capture.allowMultiple,
-        insertionDelimiter: capture.insertionDelimiter,
-        hasError: () => capture.hasError(),
       };
       result.push(accumulator);
       resultMap.set(name, {

--- a/packages/cursorless-engine/src/languages/TreeSitterQuery/TreeSitterQuery.ts
+++ b/packages/cursorless-engine/src/languages/TreeSitterQuery/TreeSitterQuery.ts
@@ -169,9 +169,9 @@ export class TreeSitterQuery {
       }
     }
 
-    // if (this.shouldCheckCaptures) {
-    //   this.checkCaptures(Array.from(map.values()));
-    // }
+    if (this.shouldCheckCaptures) {
+      this.checkCaptures(Array.from(map.values()));
+    }
 
     return { captures: result };
   }

--- a/packages/cursorless-engine/src/languages/TreeSitterQuery/normalizeCaptureName.ts
+++ b/packages/cursorless-engine/src/languages/TreeSitterQuery/normalizeCaptureName.ts
@@ -1,0 +1,3 @@
+export function normalizeCaptureName(name: string): string {
+  return name.replace(/(\.(start|end))?(\.(startOf|endOf))?$/, "");
+}

--- a/packages/cursorless-engine/src/languages/TreeSitterQuery/parsePredicatesWithErrorHandling.ts
+++ b/packages/cursorless-engine/src/languages/TreeSitterQuery/parsePredicatesWithErrorHandling.ts
@@ -1,0 +1,38 @@
+import { showError } from "@cursorless/common";
+import type { Query } from "web-tree-sitter";
+import { ide } from "../../singletons/ide.singleton";
+import { parsePredicates } from "./parsePredicates";
+import { predicateToString } from "./predicateToString";
+
+export function parsePredicatesWithErrorHandling(
+  languageId: string,
+  query: Query,
+) {
+  const { errors, predicates } = parsePredicates(query.predicates);
+
+  if (errors.length > 0) {
+    for (const error of errors) {
+      const context = [
+        `language ${languageId}`,
+        `pattern ${error.patternIdx}`,
+        `predicate \`${predicateToString(
+          query.predicates[error.patternIdx][error.predicateIdx],
+        )}\``,
+      ].join(", ");
+
+      void showError(
+        ide().messages,
+        "TreeSitterQuery.parsePredicates",
+        `Error parsing predicate for ${context}: ${error.error}`,
+      );
+    }
+
+    // We show errors to the user, but we don't want to crash the extension
+    // unless we're in test mode
+    if (ide().runMode === "test") {
+      throw new Error("Invalid predicates");
+    }
+  }
+
+  return predicates;
+}

--- a/packages/cursorless-engine/src/languages/TreeSitterQuery/positionToPoint.ts
+++ b/packages/cursorless-engine/src/languages/TreeSitterQuery/positionToPoint.ts
@@ -1,0 +1,6 @@
+import type { Position } from "@cursorless/common";
+import type { Point } from "web-tree-sitter";
+
+export function positionToPoint(start: Position): Point {
+  return { row: start.line, column: start.character };
+}

--- a/packages/cursorless-engine/src/languages/TreeSitterQuery/rewriteStartOfEndOf.ts
+++ b/packages/cursorless-engine/src/languages/TreeSitterQuery/rewriteStartOfEndOf.ts
@@ -1,3 +1,4 @@
+import type { Range } from "@cursorless/common";
 import type { MutableQueryCapture } from "./QueryCapture";
 
 /**
@@ -11,22 +12,29 @@ import type { MutableQueryCapture } from "./QueryCapture";
 export function rewriteStartOfEndOf(
   captures: MutableQueryCapture[],
 ): MutableQueryCapture[] {
-  return captures.map((capture) => {
-    // Remove trailing .startOf and .endOf, adjusting ranges.
-    if (capture.name.endsWith(".startOf")) {
-      return {
-        ...capture,
-        name: capture.name.replace(/\.startOf$/, ""),
-        range: capture.range.start.toEmptyRange(),
-      };
-    }
-    if (capture.name.endsWith(".endOf")) {
-      return {
-        ...capture,
-        name: capture.name.replace(/\.endOf$/, ""),
-        range: capture.range.end.toEmptyRange(),
-      };
-    }
-    return capture;
-  });
+  return captures.map((capture) => ({
+    ...capture,
+    range: getStartOfEndOfRange(capture),
+    name: getStartOfEndOfName(capture),
+  }));
+}
+
+export function getStartOfEndOfRange(capture: MutableQueryCapture): Range {
+  if (capture.name.endsWith(".startOf")) {
+    return capture.range.start.toEmptyRange();
+  }
+  if (capture.name.endsWith(".endOf")) {
+    return capture.range.end.toEmptyRange();
+  }
+  return capture.range;
+}
+
+function getStartOfEndOfName(capture: MutableQueryCapture): string {
+  if (capture.name.endsWith(".startOf")) {
+    return capture.name.slice(0, -8);
+  }
+  if (capture.name.endsWith(".endOf")) {
+    return capture.name.slice(0, -6);
+  }
+  return capture.name;
 }


### PR DESCRIPTION
First, were checking the captures against the SCM files in production, which was an oversight - should only be happening in debugging.

Secondarily, the existing implementation multiple map and filters. This part of the code is very time sensitive and can run quite long for large files since we are iterating every capture in the entire file.

This implementation aims to reduce iteration steps

Fixes https://github.com/cursorless-dev/cursorless/issues/2656

## Checklist

- [/] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [/] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [/] I have not broken the cheatsheet
