### PR TITLE
Updates scope support test for new parse tree version

### DIFF
--- a/packages/cursorless-vscode-e2e/src/suite/scopeProvider/runBasicScopeInfoTest.ts
+++ b/packages/cursorless-vscode-e2e/src/suite/scopeProvider/runBasicScopeInfoTest.ts
@@ -54,11 +54,14 @@ function helloWorld() {
 }
 `;
 
-function getExpectedScope(scopeSupport: ScopeSupport): ScopeSupportInfo {
+function getExpectedScope(
+  scopeSupport: ScopeSupport,
+  iterationScopeSupport?: ScopeSupport,
+): ScopeSupportInfo {
   return {
     humanReadableName: "named function",
     isLanguageSpecific: true,
-    iterationScopeSupport: scopeSupport,
+    iterationScopeSupport: iterationScopeSupport ?? scopeSupport,
     scopeType: {
       type: "namedFunction",
     },
@@ -71,5 +74,8 @@ function getExpectedScope(scopeSupport: ScopeSupport): ScopeSupportInfo {
 }
 
 const unsupported = getExpectedScope(ScopeSupport.unsupported);
-const supported = getExpectedScope(ScopeSupport.supportedButNotPresentInEditor);
+const supported = getExpectedScope(
+  ScopeSupport.supportedButNotPresentInEditor,
+  ScopeSupport.supportedAndPresentInEditor,
+);
 const present = getExpectedScope(ScopeSupport.supportedAndPresentInEditor);


### PR DESCRIPTION
With the new scope tree version this test broke. The iteration scope for functions is the entire program I guess it's reasonable that an empty document is still considered a function iteration scope

https://github.com/cursorless-dev/cursorless/blob/ec914cad1e4c73d67a9d31054573b12450d1b7cd/queries/javascript.function.scm#L162

## Checklist

- [x] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [/] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [/] I have not broken the cheatsheet
