### PR TITLE
Added performance test for `select previous scope`

### DIFF
--- a/packages/cursorless-vscode-e2e/src/suite/performance.vscode.test.ts
+++ b/packages/cursorless-vscode-e2e/src/suite/performance.vscode.test.ts
@@ -101,7 +101,7 @@ async function removeToken(thresholdMs: number) {
 async function selectScopeType(
   scopeType: ScopeType,
   thresholdMs: number,
-  modifierType: ModifierType = "containing",
+  modifierType?: ModifierType,
 ) {
   await testPerformance(thresholdMs, {
     name: "setSelection",
@@ -114,7 +114,7 @@ async function selectScopeType(
 
 function getModifier(
   scopeType: ScopeType,
-  modifierType: ModifierType,
+  modifierType: ModifierType = "containing",
 ): Modifier {
   switch (modifierType) {
     case "containing":

--- a/packages/cursorless-vscode-e2e/src/suite/performance.vscode.test.ts
+++ b/packages/cursorless-vscode-e2e/src/suite/performance.vscode.test.ts
@@ -51,16 +51,16 @@ suite("Performance", async function () {
     ["paragraph", smallThresholdMs],
     ["document", smallThresholdMs],
     ["nonWhitespaceSequence", smallThresholdMs],
-    // Parse tree based, containing scope
+    // Parse tree based, containing/every scope
     ["string", smallThresholdMs],
     ["map", smallThresholdMs],
     ["collectionKey", smallThresholdMs],
     ["value", smallThresholdMs],
+    ["collectionKey", smallThresholdMs, "every"],
+    ["value", smallThresholdMs, "every"],
     // Parse tree based, relative scope
     ["collectionKey", largeThresholdMs, "previous"],
     ["value", largeThresholdMs, "previous"],
-    ["collectionKey", largeThresholdMs, "every"],
-    ["value", largeThresholdMs, "every"],
     // Text based, but utilizes surrounding pair
     ["boundedParagraph", largeThresholdMs],
     ["boundedNonWhitespaceSequence", largeThresholdMs],

--- a/packages/cursorless-vscode-e2e/src/suite/performance.vscode.test.ts
+++ b/packages/cursorless-vscode-e2e/src/suite/performance.vscode.test.ts
@@ -1,6 +1,7 @@
 import {
   asyncSafety,
   type ActionDescriptor,
+  type Modifier,
   type ScopeType,
   type SimpleScopeTypeType,
 } from "@cursorless/common";
@@ -11,9 +12,10 @@ import { endToEndTestSetup } from "../endToEndTestSetup";
 
 const testData = generateTestData(100);
 
-const textBasedThresholdMs = 100;
-const parseTreeThresholdMs = 500;
-const surroundingPairThresholdMs = 500;
+const smallThresholdMs = 100;
+const largeThresholdMs = 500;
+
+type ModifierType = "previous";
 
 suite("Performance", async function () {
   endToEndTestSetup(this);
@@ -32,42 +34,53 @@ suite("Performance", async function () {
 
   test(
     "Remove token",
-    asyncSafety(() => removeToken(textBasedThresholdMs)),
+    asyncSafety(() => removeToken(smallThresholdMs)),
   );
 
-  const fixtures: [SimpleScopeTypeType | ScopeType, number][] = [
+  const fixtures: (
+    | [SimpleScopeTypeType | ScopeType, number]
+    | [SimpleScopeTypeType | ScopeType, number, ModifierType]
+  )[] = [
     // Text based
-    ["character", textBasedThresholdMs],
-    ["word", textBasedThresholdMs],
-    ["token", textBasedThresholdMs],
-    ["identifier", textBasedThresholdMs],
-    ["line", textBasedThresholdMs],
-    ["sentence", textBasedThresholdMs],
-    ["paragraph", textBasedThresholdMs],
-    ["document", textBasedThresholdMs],
-    ["nonWhitespaceSequence", textBasedThresholdMs],
-    // Parse tree based
-    ["string", parseTreeThresholdMs],
-    ["map", parseTreeThresholdMs],
-    ["collectionKey", parseTreeThresholdMs],
-    ["value", parseTreeThresholdMs],
+    ["character", smallThresholdMs],
+    ["word", smallThresholdMs],
+    ["token", smallThresholdMs],
+    ["identifier", smallThresholdMs],
+    ["line", smallThresholdMs],
+    ["sentence", smallThresholdMs],
+    ["paragraph", smallThresholdMs],
+    ["document", smallThresholdMs],
+    ["nonWhitespaceSequence", smallThresholdMs],
+    // Parse tree based, containing scope
+    ["string", smallThresholdMs],
+    ["map", smallThresholdMs],
+    ["collectionKey", smallThresholdMs],
+    ["value", smallThresholdMs],
+    // Parse tree based, relative scope
+    ["collectionKey", largeThresholdMs, "previous"],
+    ["value", largeThresholdMs, "previous"],
     // Text based, but utilizes surrounding pair
-    ["boundedParagraph", surroundingPairThresholdMs],
-    ["boundedNonWhitespaceSequence", surroundingPairThresholdMs],
-    ["collectionItem", surroundingPairThresholdMs],
+    ["boundedParagraph", largeThresholdMs],
+    ["boundedNonWhitespaceSequence", largeThresholdMs],
+    ["collectionItem", largeThresholdMs],
     // Surrounding pair
-    [{ type: "surroundingPair", delimiter: "any" }, surroundingPairThresholdMs],
+    [{ type: "surroundingPair", delimiter: "any" }, largeThresholdMs],
+    [{ type: "surroundingPair", delimiter: "curlyBrackets" }, largeThresholdMs],
     [
-      { type: "surroundingPair", delimiter: "curlyBrackets" },
-      surroundingPairThresholdMs,
+      { type: "surroundingPair", delimiter: "any" },
+      largeThresholdMs,
+      "previous",
     ],
   ];
 
-  for (const [scope, threshold] of fixtures) {
-    const [scopeType, title] = getScopeTypeAndTitle(scope);
+  for (const [scope, threshold, modifierType] of fixtures) {
+    const [scopeType, scopeTitle] = getScopeTypeAndTitle(scope);
+    const title = modifierType
+      ? `${modifierType} ${scopeTitle}`
+      : `${scopeTitle}`;
     test(
       `Select ${title}`,
-      asyncSafety(() => selectScopeType(scopeType, threshold)),
+      asyncSafety(() => selectScopeType(scopeType, threshold, modifierType)),
     );
   }
 });
@@ -82,14 +95,36 @@ async function removeToken(thresholdMs: number) {
   });
 }
 
-async function selectScopeType(scopeType: ScopeType, thresholdMs: number) {
+async function selectScopeType(
+  scopeType: ScopeType,
+  thresholdMs: number,
+  modifierType?: ModifierType,
+) {
   await testPerformance(thresholdMs, {
     name: "setSelection",
     target: {
       type: "primitive",
-      modifiers: [{ type: "containingScope", scopeType }],
+      modifiers: [getModifier(scopeType, modifierType)],
     },
   });
+}
+
+function getModifier(
+  scopeType: ScopeType,
+  modifierType?: ModifierType,
+): Modifier {
+  switch (modifierType) {
+    case "previous":
+      return {
+        type: "relativeScope",
+        direction: "backward",
+        offset: 1,
+        length: 1,
+        scopeType,
+      };
+    default:
+      return { type: "containingScope", scopeType };
+  }
 }
 
 async function testPerformance(thresholdMs: number, action: ActionDescriptor) {

--- a/packages/cursorless-vscode-e2e/src/suite/performance.vscode.test.ts
+++ b/packages/cursorless-vscode-e2e/src/suite/performance.vscode.test.ts
@@ -15,7 +15,7 @@ const testData = generateTestData(100);
 const smallThresholdMs = 100;
 const largeThresholdMs = 500;
 
-type ModifierType = "previous";
+type ModifierType = "containing" | "previous" | "every";
 
 suite("Performance", async function () {
   endToEndTestSetup(this);
@@ -59,6 +59,8 @@ suite("Performance", async function () {
     // Parse tree based, relative scope
     ["collectionKey", largeThresholdMs, "previous"],
     ["value", largeThresholdMs, "previous"],
+    ["collectionKey", largeThresholdMs, "every"],
+    ["value", largeThresholdMs, "every"],
     // Text based, but utilizes surrounding pair
     ["boundedParagraph", largeThresholdMs],
     ["boundedNonWhitespaceSequence", largeThresholdMs],
@@ -71,6 +73,7 @@ suite("Performance", async function () {
       largeThresholdMs,
       "previous",
     ],
+    [{ type: "surroundingPair", delimiter: "any" }, largeThresholdMs, "every"],
   ];
 
   for (const [scope, threshold, modifierType] of fixtures) {
@@ -98,7 +101,7 @@ async function removeToken(thresholdMs: number) {
 async function selectScopeType(
   scopeType: ScopeType,
   thresholdMs: number,
-  modifierType?: ModifierType,
+  modifierType: ModifierType = "containing",
 ) {
   await testPerformance(thresholdMs, {
     name: "setSelection",
@@ -111,9 +114,13 @@ async function selectScopeType(
 
 function getModifier(
   scopeType: ScopeType,
-  modifierType?: ModifierType,
+  modifierType: ModifierType,
 ): Modifier {
   switch (modifierType) {
+    case "containing":
+      return { type: "containingScope", scopeType };
+    case "every":
+      return { type: "everyScope", scopeType };
     case "previous":
       return {
         type: "relativeScope",
@@ -122,8 +129,6 @@ function getModifier(
         length: 1,
         scopeType,
       };
-    default:
-      return { type: "containingScope", scopeType };
   }
 }
 

--- a/packages/cursorless-vscode-e2e/src/suite/performance.vscode.test.ts
+++ b/packages/cursorless-vscode-e2e/src/suite/performance.vscode.test.ts
@@ -68,12 +68,12 @@ suite("Performance", async function () {
     // Surrounding pair
     [{ type: "surroundingPair", delimiter: "any" }, largeThresholdMs],
     [{ type: "surroundingPair", delimiter: "curlyBrackets" }, largeThresholdMs],
+    [{ type: "surroundingPair", delimiter: "any" }, largeThresholdMs, "every"],
     [
       { type: "surroundingPair", delimiter: "any" },
       largeThresholdMs,
       "previous",
     ],
-    [{ type: "surroundingPair", delimiter: "any" }, largeThresholdMs, "every"],
   ];
 
   for (const [scope, threshold, modifierType] of fixtures) {


### PR DESCRIPTION
With our latest performance updates there is a clear difference in performance between containing and relative scopes. To keep track of this I have added relative scopes to the performance tests. I also added a few tests for every scope.

## Checklist

- [x] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [/] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [/] I have not broken the cheatsheet
