### PR TITLE
Properly name collection item textual iteration scope handler

### DIFF
--- a/packages/cursorless-engine/src/processTargets/modifiers/scopeHandlers/CollectionItemScopeHandler/CollectionItemTextualScopeHandler.ts
+++ b/packages/cursorless-engine/src/processTargets/modifiers/scopeHandlers/CollectionItemScopeHandler/CollectionItemTextualScopeHandler.ts
@@ -16,7 +16,7 @@ import type {
 import type { ScopeHandlerFactory } from "../ScopeHandlerFactory";
 import { OneWayNestedRangeFinder } from "../util/OneWayNestedRangeFinder";
 import { OneWayRangeFinder } from "../util/OneWayRangeFinder";
-import { collectionItemIterationScopeHandler } from "./collectionItemIterationScopeHandler";
+import { collectionItemTextualIterationScopeHandler } from "./collectionItemTextualIterationScopeHandler";
 import { createTargetScope } from "./createTargetScope";
 import { getInteriorRanges } from "./getInteriorRanges";
 import { getSeparatorOccurrences } from "./getSeparatorOccurrences";
@@ -26,7 +26,7 @@ export class CollectionItemTextualScopeHandler extends BaseScopeHandler {
   protected isHierarchical = true;
 
   get iterationScopeType(): ComplexScopeType {
-    return collectionItemIterationScopeHandler;
+    return collectionItemTextualIterationScopeHandler;
   }
 
   constructor(

--- a/packages/cursorless-engine/src/processTargets/modifiers/scopeHandlers/CollectionItemScopeHandler/collectionItemTextualIterationScopeHandler.ts
+++ b/packages/cursorless-engine/src/processTargets/modifiers/scopeHandlers/CollectionItemScopeHandler/collectionItemTextualIterationScopeHandler.ts
@@ -3,7 +3,7 @@ import type { TargetScope } from "../scope.types";
 import type { ComplexScopeType } from "../scopeHandler.types";
 import { separatorRegex } from "./getSeparatorOccurrences";
 
-export const collectionItemIterationScopeHandler: ComplexScopeType = {
+export const collectionItemTextualIterationScopeHandler: ComplexScopeType = {
   type: "fallback",
   scopeTypes: [
     {


### PR DESCRIPTION
The previous name was missing the word textual. This is the iteration scope handler only for the textual collection item. The parse tree based collection item defines its own iteration.

## Checklist

- [/] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [/] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [/] I have not broken the cheatsheet
