### PR TITLE
Hide legacy scope from scope visualizer in fully migrated languages

### DIFF
--- a/packages/cursorless-vscode/src/ScopeTreeProvider.ts
+++ b/packages/cursorless-vscode/src/ScopeTreeProvider.ts
@@ -112,7 +112,7 @@ export class ScopeTreeProvider implements TreeDataProvider<MyTreeItem> {
   getChildren(element?: MyTreeItem): MyTreeItem[] {
     if (element == null) {
       void this.possiblyShowUpdateTalonMessage();
-      return getSupportCategories();
+      return getSupportCategories(this.hasLegacyScopes());
     }
 
     if (element instanceof SupportCategoryTreeItem) {
@@ -156,7 +156,15 @@ export class ScopeTreeProvider implements TreeDataProvider<MyTreeItem> {
     }
   }
 
-  getScopeTypesWithSupport(scopeSupport: ScopeSupport): ScopeSupportTreeItem[] {
+  private hasLegacyScopes(): boolean {
+    return this.supportLevels.some(
+      (supportLevel) => supportLevel.support === ScopeSupport.supportedLegacy,
+    );
+  }
+
+  private getScopeTypesWithSupport(
+    scopeSupport: ScopeSupport,
+  ): ScopeSupportTreeItem[] {
     return this.supportLevels
       .filter(
         (supportLevel) =>
@@ -202,13 +210,25 @@ export class ScopeTreeProvider implements TreeDataProvider<MyTreeItem> {
   }
 }
 
-function getSupportCategories(): SupportCategoryTreeItem[] {
-  return [
-    new SupportCategoryTreeItem(ScopeSupport.supportedAndPresentInEditor),
-    new SupportCategoryTreeItem(ScopeSupport.supportedButNotPresentInEditor),
-    new SupportCategoryTreeItem(ScopeSupport.supportedLegacy),
-    new SupportCategoryTreeItem(ScopeSupport.unsupported),
-  ];
+function getSupportCategories(
+  includeLegacy: boolean,
+): SupportCategoryTreeItem[] {
+  return includeLegacy
+    ? [
+        new SupportCategoryTreeItem(ScopeSupport.supportedAndPresentInEditor),
+        new SupportCategoryTreeItem(
+          ScopeSupport.supportedButNotPresentInEditor,
+        ),
+        new SupportCategoryTreeItem(ScopeSupport.supportedLegacy),
+        new SupportCategoryTreeItem(ScopeSupport.unsupported),
+      ]
+    : [
+        new SupportCategoryTreeItem(ScopeSupport.supportedAndPresentInEditor),
+        new SupportCategoryTreeItem(
+          ScopeSupport.supportedButNotPresentInEditor,
+        ),
+        new SupportCategoryTreeItem(ScopeSupport.unsupported),
+      ];
 }
 
 class ScopeSupportTreeItem extends TreeItem {


### PR DESCRIPTION
When using the scope visualizer for a language that is fully migrated to our scope handlers I thought it was unnecessary that we showed a empty legacy category in the scope visualizer.

## Checklist

- [/] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [/] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [/] I have not broken the cheatsheet
