### PR TITLE
Properly handle exception from missing vscode config json file

### DIFF
--- a/cursorless-talon/src/apps/vscode_settings.py
+++ b/cursorless-talon/src/apps/vscode_settings.py
@@ -61,7 +61,6 @@ class Actions:
             return actions.user.vscode_get_setting(key, default_value), False
         except Exception:
             print(fallback_message)
-            traceback.print_exc()
             return fallback_value, True
 
 

--- a/cursorless-talon/src/marks/decorated_mark.py
+++ b/cursorless-talon/src/marks/decorated_mark.py
@@ -153,7 +153,11 @@ slow_reload_job = None
 def init_hats(hat_colors: dict[str, str], hat_shapes: dict[str, str]):
     setup_hat_styles_csv(hat_colors, hat_shapes)
 
-    vscode_settings_path: Path = actions.user.vscode_settings_path().resolve()
+    try:
+        vscode_settings_path: Path = actions.user.vscode_settings_path().resolve()
+    except Exception as ex:
+        print(ex)
+        return lambda: None
 
     def on_watch(path, flags):
         global fast_reload_job, slow_reload_job

--- a/cursorless-talon/src/marks/decorated_mark.py
+++ b/cursorless-talon/src/marks/decorated_mark.py
@@ -153,11 +153,12 @@ slow_reload_job = None
 def init_hats(hat_colors: dict[str, str], hat_shapes: dict[str, str]):
     setup_hat_styles_csv(hat_colors, hat_shapes)
 
+    vscode_settings_path: Path | None = None
+
     try:
-        vscode_settings_path: Path = actions.user.vscode_settings_path().resolve()
+        vscode_settings_path = actions.user.vscode_settings_path().resolve()
     except Exception as ex:
         print(ex)
-        return lambda: None
 
     def on_watch(path, flags):
         global fast_reload_job, slow_reload_job
@@ -170,10 +171,12 @@ def init_hats(hat_colors: dict[str, str], hat_shapes: dict[str, str]):
             "10s", lambda: setup_hat_styles_csv(hat_colors, hat_shapes)
         )
 
-    fs.watch(str(vscode_settings_path), on_watch)
+    if vscode_settings_path is not None:
+        fs.watch(vscode_settings_path, on_watch)
 
     def unsubscribe():
-        fs.unwatch(str(vscode_settings_path), on_watch)
+        if vscode_settings_path is not None:
+            fs.unwatch(vscode_settings_path, on_watch)
         if unsubscribe_hat_styles is not None:
             unsubscribe_hat_styles()
 


### PR DESCRIPTION
Today on main this exception is not caught and the Cursorless list containing all the scopes is not filled which means that Cursorless is not working if we can't find the vscode json config file.

## Checklist

- [/] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [/] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [/] I have not broken the cheatsheet
