### PR TITLE
Disqualify arrow delimiter in function type

### DIFF
--- a/data/fixtures/recorded/languages/typescript/changeInside.yml
+++ b/data/fixtures/recorded/languages/typescript/changeInside.yml
@@ -1,0 +1,22 @@
+languageId: typescript
+command:
+  version: 7
+  spokenForm: change inside
+  action:
+    name: clearAndSetSelection
+    target:
+      type: primitive
+      modifiers:
+        - {type: interiorOnly}
+  usePrePhraseSnapshot: false
+initialState:
+  documentContents: Promise<() => number>;
+  selections:
+    - anchor: {line: 0, character: 14}
+      active: {line: 0, character: 14}
+  marks: {}
+finalState:
+  documentContents: Promise<>;
+  selections:
+    - anchor: {line: 0, character: 8}
+      active: {line: 0, character: 8}

--- a/data/fixtures/scopes/typescript.core/disqualifyDelimiter.scope
+++ b/data/fixtures/scopes/typescript.core/disqualifyDelimiter.scope
@@ -1,0 +1,5 @@
+Promise<() => number>
+---
+[Content] = 0:11-0:13
+             >--<
+0| Promise<() => number>

--- a/packages/common/src/scopeSupportFacets/scopeSupportFacets.types.ts
+++ b/packages/common/src/scopeSupportFacets/scopeSupportFacets.types.ts
@@ -171,7 +171,6 @@ export const scopeSupportFacets = [
   // FIXME: Still in legacy
   // selector
   // unit
-  // collectionItem
 ] as const;
 
 export interface ScopeSupportFacetInfo {

--- a/packages/common/src/scopeSupportFacets/typescript.ts
+++ b/packages/common/src/scopeSupportFacets/typescript.ts
@@ -24,4 +24,6 @@ export const typescriptScopeSupport: LanguageScopeSupportFacetMap = {
 
   "value.field": supported,
   "value.typeAlias": supported,
+
+  disqualifyDelimiter: supported,
 };

--- a/queries/typescript.core.scm
+++ b/queries/typescript.core.scm
@@ -382,3 +382,8 @@
   .
   ";"? @statement.end
 )
+
+;; () => number
+(function_type
+  "=>" @disqualifyDelimiter
+)


### PR DESCRIPTION
Disqualified `=>` in typescript function type definitions to be used in a matching pair delimiter.

## Checklist

- [x] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [/] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [/] I have not broken the cheatsheet
