### PR TITLE
README.md: actually link the instructions

### DIFF
--- a/cursorless-talon/README.md
+++ b/cursorless-talon/README.md
@@ -21,6 +21,10 @@ Cursorless is a spoken language for structural code editing, enabling developers
 
 This repository holds the Talon side of Cursorless. If you've arrived here as part of the [Cursorless installation process](https://www.cursorless.org/docs/user/installation/), then you're in the right place!
 
+# Installation
+
+See [Cursorless Installation](https://www.cursorless.org/docs/user/installation/#installing-the-talon-side) ("Installing the Talon side") for how to clone this repo into your Talon user folder.
+
 # Contributing
 
 If you're looking to improve Cursorless, note that Cursorless is now maintained as a monorepo, so if you're here in a browser, and your address bar points to https://github.com/cursorless-dev/cursorless-talon, then you're probably in the wrong place. The monorepo is hosted at [`cursorless`](https://github.com/cursorless-dev/cursorless), and the source of truth for these talon files is in the [`cursorless-talon`](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon) subdirectory.


### PR DESCRIPTION
Came up during https://github.com/cursorless-dev/cursorless/pull/2720; if you land on the README it doesn't actually tell you what to do.

## Checklist

- [/] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [/] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [/] I have not broken the cheatsheet
