### PR TITLE
Fix for markdown cells

### DIFF
--- a/data/fixtures/recorded/languages/markdown/changeCell.yml
+++ b/data/fixtures/recorded/languages/markdown/changeCell.yml
@@ -1,0 +1,27 @@
+languageId: markdown
+command:
+  version: 7
+  spokenForm: change cell
+  action:
+    name: clearAndSetSelection
+    target:
+      type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: notebookCell}
+  usePrePhraseSnapshot: false
+initialState:
+  documentContents: |
+    ```
+    code
+    ```
+  selections:
+    - anchor: {line: 1, character: 0}
+      active: {line: 1, character: 0}
+  marks: {}
+finalState:
+  documentContents: |+
+
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}

--- a/packages/cursorless-engine/src/processTargets/modifiers/scopeHandlers/LineScopeHandler.ts
+++ b/packages/cursorless-engine/src/processTargets/modifiers/scopeHandlers/LineScopeHandler.ts
@@ -15,7 +15,7 @@ export class LineScopeHandler extends BaseScopeHandler {
     type: "paragraph",
   } as const;
   protected readonly isHierarchical = false;
-  public readonly includeAdjacentInEvery: boolean = true;
+  public readonly includeAdjacentInEvery = true;
 
   constructor(_scopeType: ScopeType, _languageId: string) {
     super();

--- a/packages/cursorless-engine/src/processTargets/modifiers/scopeHandlers/NotebookCellApiScopeHandler.ts
+++ b/packages/cursorless-engine/src/processTargets/modifiers/scopeHandlers/NotebookCellApiScopeHandler.ts
@@ -12,7 +12,7 @@ import type { TargetScope } from "./scope.types";
 import type { ScopeIteratorRequirements } from "./scopeHandler.types";
 
 /**
- * This is the scope handler for the actual notebook api in the ide.
+ * This is the scope handler for the actual notebook API in the IDE.
  */
 export class NotebookCellApiScopeHandler extends BaseScopeHandler {
   public readonly scopeType = { type: "notebookCell" } as const;

--- a/packages/cursorless-engine/src/processTargets/modifiers/scopeHandlers/NotebookCellApiScopeHandler.ts
+++ b/packages/cursorless-engine/src/processTargets/modifiers/scopeHandlers/NotebookCellApiScopeHandler.ts
@@ -1,0 +1,116 @@
+import {
+  Range,
+  type Direction,
+  type NotebookCell,
+  type Position,
+  type TextEditor,
+} from "@cursorless/common";
+import { ide } from "../../../singletons/ide.singleton";
+import { NotebookCellTarget } from "../../targets";
+import { BaseScopeHandler } from "./BaseScopeHandler";
+import type { TargetScope } from "./scope.types";
+import type { ScopeIteratorRequirements } from "./scopeHandler.types";
+
+/**
+ * This is the scope handler for the actual notebook api in the ide.
+ */
+export class NotebookCellApiScopeHandler extends BaseScopeHandler {
+  public readonly scopeType = { type: "notebookCell" } as const;
+  public readonly iterationScopeType = { type: "document" } as const;
+  protected isHierarchical = false;
+
+  constructor() {
+    super();
+  }
+
+  *generateScopeCandidates(
+    editor: TextEditor,
+    position: Position,
+    direction: Direction,
+    hints: ScopeIteratorRequirements,
+  ): Iterable<TargetScope> {
+    const cells = getNotebookCells(editor, position, direction, hints);
+
+    for (const cell of cells) {
+      yield createTargetScope(cell);
+    }
+  }
+}
+
+function getNotebookCells(
+  editor: TextEditor,
+  position: Position,
+  direction: Direction,
+  hints: ScopeIteratorRequirements,
+) {
+  const nb = getNotebook(editor);
+
+  if (nb == null) {
+    return [];
+  }
+
+  const { notebook, cell } = nb;
+
+  if (hints.containment === "required") {
+    return [cell];
+  }
+
+  if (
+    hints.containment === "disallowed" ||
+    hints.containment === "disallowedIfStrict"
+  ) {
+    return direction === "forward"
+      ? notebook.cells.slice(cell.index + 1)
+      : notebook.cells.slice(0, cell.index).reverse();
+  }
+
+  // Every scope
+  if (hints.distalPosition != null) {
+    const searchRange = new Range(position, hints.distalPosition);
+    if (searchRange.isRangeEqual(editor.document.range)) {
+      return notebook.cells;
+    }
+  }
+
+  return direction === "forward"
+    ? notebook.cells.slice(cell.index)
+    : notebook.cells.slice(0, cell.index + 1).reverse();
+}
+
+function getNotebook(editor: TextEditor) {
+  const uri = editor.document.uri.toString();
+  for (const notebook of ide().visibleNotebookEditors) {
+    for (const cell of notebook.cells) {
+      if (cell.document.uri.toString() === uri) {
+        return { notebook, cell };
+      }
+    }
+  }
+  return undefined;
+}
+
+function createTargetScope(cell: NotebookCell): TargetScope {
+  const editor = getEditor(cell);
+  const contentRange = editor.document.range;
+  return {
+    editor,
+    domain: contentRange,
+    getTargets: (isReversed: boolean) => [
+      new NotebookCellTarget({
+        editor,
+        isReversed,
+        contentRange,
+      }),
+    ],
+  };
+}
+
+function getEditor(cell: NotebookCell) {
+  const uri = cell.document.uri.toString();
+  for (const editor of ide().visibleTextEditors) {
+    if (editor.document.uri.toString() === uri) {
+      return editor;
+    }
+  }
+  throw new Error("Editor not found notebook cell");
+}

--- a/packages/cursorless-engine/src/processTargets/modifiers/scopeHandlers/NotebookCellScopeHandler.ts
+++ b/packages/cursorless-engine/src/processTargets/modifiers/scopeHandlers/NotebookCellScopeHandler.ts
@@ -1,143 +1,70 @@
 import {
-  Range,
   type Direction,
-  type NotebookCell,
   type Position,
   type ScopeType,
   type TextEditor,
 } from "@cursorless/common";
 import type { LanguageDefinitions } from "../../../languages/LanguageDefinitions";
-import { ide } from "../../../singletons/ide.singleton";
-import { NotebookCellTarget } from "../../targets";
 import { BaseScopeHandler } from "./BaseScopeHandler";
+import { NotebookCellApiScopeHandler } from "./NotebookCellApiScopeHandler";
+import { OneOfScopeHandler } from "./OneOfScopeHandler";
 import type { TargetScope } from "./scope.types";
 import type {
   ComplexScopeType,
   ScopeHandler,
   ScopeIteratorRequirements,
 } from "./scopeHandler.types";
+import type { ScopeHandlerFactory } from "./ScopeHandlerFactory";
 
 export class NotebookCellScopeHandler extends BaseScopeHandler {
   public readonly scopeType = { type: "notebookCell" } as const;
   protected isHierarchical = false;
-  private readonly languageScopeHandler: ScopeHandler | undefined;
+  private readonly scopeHandler: ScopeHandler;
+
+  get iterationScopeType(): ScopeType | ComplexScopeType {
+    return this.scopeHandler.iterationScopeType;
+  }
 
   constructor(
+    scopeHandlerFactory: ScopeHandlerFactory,
     languageDefinitions: LanguageDefinitions,
     _scopeType: ScopeType,
-    private languageId: string,
+    languageId: string,
   ) {
     super();
 
-    this.languageScopeHandler = languageDefinitions
-      .get(this.languageId)
-      ?.getScopeHandler(this.scopeType);
+    this.scopeHandler = (() => {
+      const apiScopeHandler = new NotebookCellApiScopeHandler();
+
+      const languageScopeHandler = languageDefinitions
+        .get(languageId)
+        ?.getScopeHandler(this.scopeType);
+
+      if (languageScopeHandler == null) {
+        return apiScopeHandler;
+      }
+
+      return OneOfScopeHandler.createFromScopeHandlers(
+        scopeHandlerFactory,
+        {
+          type: "oneOf",
+          scopeTypes: [
+            languageScopeHandler.scopeType,
+            apiScopeHandler.scopeType,
+          ],
+        },
+        [languageScopeHandler, apiScopeHandler],
+        languageId,
+      );
+    })();
   }
 
-  get iterationScopeType(): ScopeType | ComplexScopeType {
-    if (this.languageScopeHandler != null) {
-      return this.languageScopeHandler.iterationScopeType;
-    }
-    return { type: "document" };
-  }
-
-  *generateScopeCandidates(
+  generateScopeCandidates(
     editor: TextEditor,
     position: Position,
     direction: Direction,
     hints: ScopeIteratorRequirements,
   ): Iterable<TargetScope> {
-    if (this.languageScopeHandler != null) {
-      yield* this.languageScopeHandler.generateScopes(
-        editor,
-        position,
-        direction,
-        hints,
-      );
-    }
-
-    const cells = getNotebookCells(editor, position, direction, hints);
-
-    for (const cell of cells) {
-      yield createTargetScope(cell);
-    }
+    return this.scopeHandler.generateScopes(editor, position, direction, hints);
   }
-}
-
-function getNotebookCells(
-  editor: TextEditor,
-  position: Position,
-  direction: Direction,
-  hints: ScopeIteratorRequirements,
-) {
-  const nb = getNotebook(editor);
-
-  if (nb == null) {
-    return [];
-  }
-
-  const { notebook, cell } = nb;
-
-  if (hints.containment === "required") {
-    return [cell];
-  }
-
-  if (
-    hints.containment === "disallowed" ||
-    hints.containment === "disallowedIfStrict"
-  ) {
-    return direction === "forward"
-      ? notebook.cells.slice(cell.index + 1)
-      : notebook.cells.slice(0, cell.index).reverse();
-  }
-
-  // Every scope
-  if (hints.distalPosition != null) {
-    const searchRange = new Range(position, hints.distalPosition);
-    if (searchRange.isRangeEqual(editor.document.range)) {
-      return notebook.cells;
-    }
-  }
-
-  return direction === "forward"
-    ? notebook.cells.slice(cell.index)
-    : notebook.cells.slice(0, cell.index + 1).reverse();
-}
-
-function getNotebook(editor: TextEditor) {
-  const uri = editor.document.uri.toString();
-  for (const notebook of ide().visibleNotebookEditors) {
-    for (const cell of notebook.cells) {
-      if (cell.document.uri.toString() === uri) {
-        return { notebook, cell };
-      }
-    }
-  }
-  return undefined;
-}
-
-function createTargetScope(cell: NotebookCell): TargetScope {
-  const editor = getEditor(cell);
-  const contentRange = editor.document.range;
-  return {
-    editor,
-    domain: contentRange,
-    getTargets: (isReversed: boolean) => [
-      new NotebookCellTarget({
-        editor,
-        isReversed,
-        contentRange,
-      }),
-    ],
-  };
-}
-
-function getEditor(cell: NotebookCell) {
-  const uri = cell.document.uri.toString();
-  for (const editor of ide().visibleTextEditors) {
-    if (editor.document.uri.toString() === uri) {
-      return editor;
-    }
-  }
-  throw new Error("Editor not found notebook cell");
 }

--- a/packages/cursorless-engine/src/processTargets/modifiers/scopeHandlers/ScopeHandlerFactoryImpl.ts
+++ b/packages/cursorless-engine/src/processTargets/modifiers/scopeHandlers/ScopeHandlerFactoryImpl.ts
@@ -114,6 +114,7 @@ export class ScopeHandlerFactoryImpl implements ScopeHandlerFactory {
         );
       case "notebookCell":
         return new NotebookCellScopeHandler(
+          this,
           this.languageDefinitions,
           scopeType,
           languageId,


### PR DESCRIPTION
The latest update for the notebook cell handler broke cells in markdown.
Also implements notebook scope handler with a one of scope handler the same way we do for collection item. We can have both language specific implementations as well as the ide notebook api so this is a more proper implementation.

## Checklist

- [x] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [/] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [/] I have not broken the cheatsheet
