### PR TITLE
Remove unnecessary catch which caused confusing error when iteration scopes were missing

### DIFF
--- a/packages/cursorless-engine/src/processTargets/modifiers/EveryScopeStage.ts
+++ b/packages/cursorless-engine/src/processTargets/modifiers/EveryScopeStage.ts
@@ -73,20 +73,13 @@ export class EveryScopeStage implements ModifierStage {
     if (scopes == null) {
       // If target had no explicit range, or was contained by a single target
       // instance, expand to iteration scope before overlapping
-      try {
-        scopes = this.getDefaultIterationRange(
-          scopeHandler,
-          this.scopeHandlerFactory,
-          target,
-        ).flatMap((iterationRange) =>
-          getScopesOverlappingRange(scopeHandler, editor, iterationRange),
-        );
-      } catch (error) {
-        if (!(error instanceof NoContainingScopeError)) {
-          throw error;
-        }
-        scopes = [];
-      }
+      scopes = this.getDefaultIterationRange(
+        scopeHandler,
+        this.scopeHandlerFactory,
+        target,
+      ).flatMap((iterationRange) =>
+        getScopesOverlappingRange(scopeHandler, editor, iterationRange),
+      );
     }
 
     if (scopes.length === 0) {


### PR DESCRIPTION
Today's implementation when you say something like `take every item` will show an error message `Couldn't find containing collectionItem.` even if it's the iteration scope that is missing. 

This change makes it so that we get the error message `Couldn't find containing iteration scope for collectionItem.` instead. This greatly helps us with diagnosing what actually went wrong.

For program languages were a scope is defined in Tree sitter the current error message makes little sense. You could use `take scope` and it works fine, but when you say `take every scope` you get an error message that there is no scope. Much better to actually show that this language is missing an iteration scope.

## Checklist

- [/] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [/] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [/] I have not broken the cheatsheet
