### PR TITLE
Added range concise one based function

### DIFF
--- a/packages/common/src/types/Position.ts
+++ b/packages/common/src/types/Position.ts
@@ -152,7 +152,7 @@ export class Position {
    * Return a concise string representation of the position. 1-based.
    * @returns concise representation
    **/
-  public conciseOneBase(): string {
+  public conciseOneBased(): string {
     return `${this.line + 1}:${this.character + 1}`;
   }
 

--- a/packages/common/src/types/Position.ts
+++ b/packages/common/src/types/Position.ts
@@ -141,11 +141,19 @@ export class Position {
   }
 
   /**
-   * Return a concise string representation of the position.
+   * Return a concise string representation of the position. 0-based.
    * @returns concise representation
    **/
   public concise(): string {
     return `${this.line}:${this.character}`;
+  }
+
+  /**
+   * Return a concise string representation of the position. 1-based.
+   * @returns concise representation
+   **/
+  public conciseOneBase(): string {
+    return `${this.line + 1}:${this.character + 1}`;
   }
 
   public toString(): string {

--- a/packages/common/src/types/Range.ts
+++ b/packages/common/src/types/Range.ts
@@ -155,8 +155,8 @@ export class Range {
    * Return a concise string representation of the range. 1-based.
    * @returns concise representation
    **/
-  public conciseOneBase(): string {
-    return `${this.start.conciseOneBase()}-${this.end.conciseOneBase()}`;
+  public conciseOneBased(): string {
+    return `${this.start.conciseOneBased()}-${this.end.conciseOneBased()}`;
   }
 
   public toString(): string {

--- a/packages/common/src/types/Range.ts
+++ b/packages/common/src/types/Range.ts
@@ -144,14 +144,22 @@ export class Range {
   }
 
   /**
-   * Return a concise string representation of the range
+   * Return a concise string representation of the range. 0-based.
    * @returns concise representation
    **/
   public concise(): string {
     return `${this.start.concise()}-${this.end.concise()}`;
   }
 
+  /**
+   * Return a concise string representation of the range. 1-based.
+   * @returns concise representation
+   **/
+  public conciseOneBase(): string {
+    return `${this.start.conciseOneBase()}-${this.end.conciseOneBase()}`;
+  }
+
   public toString(): string {
-    return this.concise();
+    return `${this.start.concise()}-${this.end.concise()}`;
   }
 }

--- a/packages/common/src/types/Selection.ts
+++ b/packages/common/src/types/Selection.ts
@@ -85,8 +85,8 @@ export class Selection extends Range {
    * Return a concise string representation of the selection. 1-based.
    * @returns concise representation
    **/
-  public conciseOneBase(): string {
-    return `${this.start.conciseOneBase()}->${this.end.conciseOneBase()}`;
+  public conciseOneBased(): string {
+    return `${this.start.conciseOneBased()}->${this.end.conciseOneBased()}`;
   }
 
   public toString(): string {

--- a/packages/common/src/types/Selection.ts
+++ b/packages/common/src/types/Selection.ts
@@ -74,11 +74,19 @@ export class Selection extends Range {
   }
 
   /**
-   * Return a concise string representation of the selection
+   * Return a concise string representation of the selection. 0-based.
    * @returns concise representation
    **/
   public concise(): string {
     return `${this.anchor.concise()}->${this.active.concise()}`;
+  }
+
+  /**
+   * Return a concise string representation of the selection. 1-based.
+   * @returns concise representation
+   **/
+  public conciseOneBase(): string {
+    return `${this.start.conciseOneBase()}->${this.end.conciseOneBase()}`;
   }
 
   public toString(): string {

--- a/packages/common/src/types/position.test.ts
+++ b/packages/common/src/types/position.test.ts
@@ -71,6 +71,6 @@ suite("Position", () => {
 
   test("concise", () => {
     assert.equal(new Position(1, 2).concise(), "1:2");
-    assert.equal(new Position(1, 2).conciseOneBase(), "2:3");
+    assert.equal(new Position(1, 2).conciseOneBased(), "2:3");
   });
 });

--- a/packages/common/src/types/position.test.ts
+++ b/packages/common/src/types/position.test.ts
@@ -68,4 +68,9 @@ suite("Position", () => {
       new Position(1, 1).translate(undefined, 5).isEqual(new Position(1, 6)),
     );
   });
+
+  test("concise", () => {
+    assert.equal(new Position(1, 2).concise(), "1:2");
+    assert.equal(new Position(1, 2).conciseOneBase(), "2:3");
+  });
 });

--- a/packages/common/src/types/range.test.ts
+++ b/packages/common/src/types/range.test.ts
@@ -113,4 +113,9 @@ suite("Range", () => {
     assert.ok(new Range(1, 2, 3, 4).toSelection(true).isReversed);
     assert.ok(!new Range(1, 2, 3, 4).toSelection(false).isReversed);
   });
+
+  test("concise", () => {
+    assert.equal(new Range(1, 2, 3, 4).concise(), "1:2-3:4");
+    assert.equal(new Range(1, 2, 3, 4).conciseOneBase(), "2:3-4:5");
+  });
 });

--- a/packages/common/src/types/range.test.ts
+++ b/packages/common/src/types/range.test.ts
@@ -116,6 +116,6 @@ suite("Range", () => {
 
   test("concise", () => {
     assert.equal(new Range(1, 2, 3, 4).concise(), "1:2-3:4");
-    assert.equal(new Range(1, 2, 3, 4).conciseOneBase(), "2:3-4:5");
+    assert.equal(new Range(1, 2, 3, 4).conciseOneBased(), "2:3-4:5");
   });
 });

--- a/packages/common/src/types/selection.test.ts
+++ b/packages/common/src/types/selection.test.ts
@@ -52,6 +52,6 @@ suite("Selection", () => {
 
   test("concise", () => {
     assert.equal(new Selection(1, 2, 3, 4).concise(), "1:2->3:4");
-    assert.equal(new Selection(1, 2, 3, 4).conciseOneBase(), "2:3->4:5");
+    assert.equal(new Selection(1, 2, 3, 4).conciseOneBased(), "2:3->4:5");
   });
 });

--- a/packages/common/src/types/selection.test.ts
+++ b/packages/common/src/types/selection.test.ts
@@ -49,4 +49,9 @@ suite("Selection", () => {
     assert.ok(new Selection(1, 2, 3, 4).toSelection(true).isReversed);
     assert.ok(!new Selection(1, 2, 3, 4).toSelection(false).isReversed);
   });
+
+  test("concise", () => {
+    assert.equal(new Selection(1, 2, 3, 4).concise(), "1:2->3:4");
+    assert.equal(new Selection(1, 2, 3, 4).conciseOneBase(), "2:3->4:5");
+  });
 });


### PR DESCRIPTION
The current concise function is 0-based,  but sometimes when doing debug prints it's easier to have the positions be 1-based to match vscode ui.

## Checklist

- [x] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [/] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [/] I have not broken the cheatsheet
