### PR TITLE
Disable Cursorless for vscode file dialogs

### DIFF
--- a/cursorless-talon/src/apps/cursorless_vscode.py
+++ b/cursorless-talon/src/apps/cursorless_vscode.py
@@ -4,7 +4,7 @@ ctx = Context()
 
 ctx.matches = r"""
 app: vscode
-# Disable Cursorless for vscode file dialogs
+# Disable Cursorless for VS Code file dialogs (at least on Windows)
 not win.title: /^(Open Folder|Open File|Save As|Open Workspace from File|Add Folder to Workspace|Save Workspace)$/i
 """
 

--- a/cursorless-talon/src/apps/cursorless_vscode.py
+++ b/cursorless-talon/src/apps/cursorless_vscode.py
@@ -4,7 +4,8 @@ ctx = Context()
 
 ctx.matches = r"""
 app: vscode
-# Disable Cursorless for VS Code file dialogs (at least on Windows)
+# Disable Cursorless when VS Code is displaying a native OS dialog during which the command server
+# hotkey will not work.
 not win.title: /^(Open Folder|Open File|Save As|Open Workspace from File|Add Folder to Workspace|Save Workspace)$/i
 """
 

--- a/cursorless-talon/src/apps/cursorless_vscode.py
+++ b/cursorless-talon/src/apps/cursorless_vscode.py
@@ -4,6 +4,8 @@ ctx = Context()
 
 ctx.matches = r"""
 app: vscode
+# Disable Cursorless for vscode file dialogs
+not title: /^(Open Folder|Open File|Save As|Open Workspace from file|Add Folder to Workspace|Save Workspace)$/i
 """
 
 ctx.tags = ["user.cursorless"]

--- a/cursorless-talon/src/apps/cursorless_vscode.py
+++ b/cursorless-talon/src/apps/cursorless_vscode.py
@@ -5,7 +5,7 @@ ctx = Context()
 ctx.matches = r"""
 app: vscode
 # Disable Cursorless for vscode file dialogs
-not title: /^(Open Folder|Open File|Save As|Open Workspace from file|Add Folder to Workspace|Save Workspace)$/i
+not win.title: /^(Open Folder|Open File|Save As|Open Workspace from File|Add Folder to Workspace|Save Workspace)$/i
 """
 
 ctx.tags = ["user.cursorless"]


### PR DESCRIPTION
File dialogs interfere with the command server keypress. Commands like `"paste to line"` just ends up with a timeout error in the talon log and nothing happens. 

I have been running with this in my own fork of cursorless Talon for a while to test it out and I'm happy with the result. 

## Checklist

- [/] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [/] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [/] I have not broken the cheatsheet
