### PR TITLE
Added paired delimiter string to cheat sheet

### DIFF
--- a/cursorless-talon/src/cheatsheet/cheat_sheet.py
+++ b/cursorless-talon/src/cheatsheet/cheat_sheet.py
@@ -128,6 +128,7 @@ def cursorless_cheat_sheet_get_json():
                         "wrapper_only_paired_delimiter",
                         "wrapper_selectable_paired_delimiter",
                         "selectable_only_paired_delimiter",
+                        "surrounding_pair_scope_type",
                     ],
                     "pairedDelimiter",
                 ),


### PR DESCRIPTION
Fixes #1154

## Checklist

- [/] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [/] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [x] I have not broken the cheatsheet
