### PR TITLE
Highlight word when setting selection

### DIFF
--- a/packages/common/src/types/TextEditor.ts
+++ b/packages/common/src/types/TextEditor.ts
@@ -55,6 +55,7 @@ export interface TextEditor {
 export interface SetSelectionsOpts {
   focusEditor?: boolean;
   revealRange?: boolean;
+  highlightWord?: boolean;
 }
 
 export type OpenLinkOptions = {

--- a/packages/cursorless-engine/src/actions/SetSelection.ts
+++ b/packages/cursorless-engine/src/actions/SetSelection.ts
@@ -21,9 +21,14 @@ abstract class SetSelectionBase implements SimpleAction {
         ? editor.selections.concat(targetSelections)
         : targetSelections;
 
+    const highlightWord =
+      this.selectionMode === "set" &&
+      selections.length === 1 &&
+      selections[0].isEmpty;
+
     await ide()
       .getEditableTextEditor(editor)
-      .setSelections(selections, { focusEditor: true });
+      .setSelections(selections, { focusEditor: true, highlightWord });
 
     return {
       thatTargets: targets,

--- a/packages/cursorless-vscode/src/ide/vscode/VscodeTextEditorImpl.ts
+++ b/packages/cursorless-vscode/src/ide/vscode/VscodeTextEditorImpl.ts
@@ -51,7 +51,11 @@ export class VscodeTextEditorImpl implements EditableTextEditor {
 
   async setSelections(
     rawSelections: Selection[],
-    { focusEditor = false, revealRange = true }: SetSelectionsOpts = {},
+    {
+      focusEditor = false,
+      revealRange = true,
+      highlightWord = false,
+    }: SetSelectionsOpts = {},
   ): Promise<void> {
     const selections = uniqWithHash(
       rawSelections,
@@ -84,6 +88,10 @@ export class VscodeTextEditorImpl implements EditableTextEditor {
 
     if (revealRange) {
       await this.revealRange(this.selections[0]);
+    }
+
+    if (highlightWord) {
+      vscode.commands.executeCommand("editor.action.wordHighlight.trigger");
     }
   }
 


### PR DESCRIPTION
In vscode if you click on a word with the mouse corresponding words are highlighted. When using cursorless to set selection this doesn't happen on main.

Fixes #2604

## Checklist

- [/] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [/] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [/] I have not broken the cheatsheet
