### PR TITLE
Allow `"return@"` in Kotlin Tree sitter queries

### DIFF
--- a/packages/cursorless-engine/src/languages/TreeSitterQuery/validateQueryCaptures.test.ts
+++ b/packages/cursorless-engine/src/languages/TreeSitterQuery/validateQueryCaptures.test.ts
@@ -52,6 +52,11 @@ const testCases: { name: string; isOk: boolean; content: string }[] = [
     content: ";; (if_statement) @unknown",
   },
   {
+    name: "@ ending string",
+    isOk: true,
+    content: '"return@"',
+  },
+  {
     name: "Unknown capture",
     isOk: false,
     content: "(if_statement) @unknown",

--- a/packages/cursorless-engine/src/languages/TreeSitterQuery/validateQueryCaptures.ts
+++ b/packages/cursorless-engine/src/languages/TreeSitterQuery/validateQueryCaptures.ts
@@ -59,9 +59,9 @@ for (const captureName of captureNames) {
 }
 
 // Not a comment. ie line is not starting with `;;`
-// Not a string. ie line does not contain `@"`
+// Not a string.
 // Capture starts with `@` and is followed by words and/or dots
-const capturePattern = new RegExp(`^(?!;;|.*@").*@([\\w.]*)`, "gm");
+const capturePattern = /^(?!;;).*(?<!"\w*)@([\w.]*)/gm;
 
 export function validateQueryCaptures(file: string, rawQuery: string): void {
   const matches = rawQuery.matchAll(capturePattern);

--- a/packages/cursorless-engine/src/languages/TreeSitterQuery/validateQueryCaptures.ts
+++ b/packages/cursorless-engine/src/languages/TreeSitterQuery/validateQueryCaptures.ts
@@ -59,8 +59,9 @@ for (const captureName of captureNames) {
 }
 
 // Not a comment. ie line is not starting with `;;`
+// Not a string. ie line does not contain `@"`
 // Capture starts with `@` and is followed by words and/or dots
-const capturePattern = new RegExp(`^(?!;;).*@([\\w.]+)`, "gm");
+const capturePattern = new RegExp(`^(?!;;|.*@").*@([\\w.]*)`, "gm");
 
 export function validateQueryCaptures(file: string, rawQuery: string): void {
   const matches = rawQuery.matchAll(capturePattern);

--- a/packages/cursorless-engine/src/languages/TreeSitterQuery/validateQueryCaptures.ts
+++ b/packages/cursorless-engine/src/languages/TreeSitterQuery/validateQueryCaptures.ts
@@ -60,7 +60,7 @@ for (const captureName of captureNames) {
 
 // Not a comment. ie line is not starting with `;;`
 // Capture starts with `@` and is followed by words and/or dots
-const capturePattern = new RegExp(`^(?!;;).*@([\\w.]*)`, "gm");
+const capturePattern = new RegExp(`^(?!;;).*@([\\w.]+)`, "gm");
 
 export function validateQueryCaptures(file: string, rawQuery: string): void {
   const matches = rawQuery.matchAll(capturePattern);

--- a/queries/kotlin.scm
+++ b/queries/kotlin.scm
@@ -437,14 +437,13 @@
   (_) @value
 ) @_.domain
 
-;; Disabled due to Cursorless error ("invalid capture") caused by "return@"
-;; (jump_expression
-;;   "return@"
-;;   .
-;;   (label)
-;;   .
-;;   (_) @value
-;; ) @_.domain
+(jump_expression
+  "return@"
+  .
+  (label)
+  .
+  (_) @value
+) @_.domain
 
 (_
   (function_body


### PR DESCRIPTION
Fixes #2447

## Checklist

- [x] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [/] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [/] I have not broken the cheatsheet
