### PR TITLE
Use generalized ranges in breakpoint action

### DIFF
--- a/packages/common/src/types/TextEditor.ts
+++ b/packages/common/src/types/TextEditor.ts
@@ -1,5 +1,6 @@
 import type {
   Edit,
+  GeneralizedRange,
   Range,
   RevealLineAt,
   Selection,
@@ -154,9 +155,9 @@ export interface EditableTextEditor extends TextEditor {
    * remove all breakpoints overlapping with the given descriptor if it overlaps
    * with any existing breakpoint, otherwise add a new breakpoint at the given
    * location.
-   * @param descriptors A list of breakpoint descriptors
+   * @param ranges A list of breakpoint ranges
    */
-  toggleBreakpoint(descriptors?: BreakpointDescriptor[]): Promise<void>;
+  toggleBreakpoint(ranges?: GeneralizedRange[]): Promise<void>;
 
   /**
    * Toggle line comments
@@ -237,21 +238,3 @@ export interface EditableTextEditor extends TextEditor {
    */
   extractVariable(range?: Range): Promise<void>;
 }
-
-interface LineBreakpointDescriptor {
-  type: "line";
-  startLine: number;
-  /**
-   * Last line, inclusive
-   */
-  endLine: number;
-}
-
-interface InlineBreakpointDescriptor {
-  type: "inline";
-  range: Range;
-}
-
-export type BreakpointDescriptor =
-  | LineBreakpointDescriptor
-  | InlineBreakpointDescriptor;

--- a/packages/cursorless-engine/src/actions/ToggleBreakpoint.ts
+++ b/packages/cursorless-engine/src/actions/ToggleBreakpoint.ts
@@ -25,9 +25,7 @@ export default class ToggleBreakpoint implements SimpleAction {
     await flashTargets(ide(), thatTargets, FlashStyle.referenced);
 
     await runOnTargetsForEachEditor(targets, async (editor, targets) => {
-      const generalizedRanges = targets.map((target) =>
-        toGeneralizedRange(target),
-      );
+      const generalizedRanges = targets.map(toGeneralizedRange);
 
       await ide()
         .getEditableTextEditor(editor)

--- a/packages/cursorless-engine/src/actions/ToggleBreakpoint.ts
+++ b/packages/cursorless-engine/src/actions/ToggleBreakpoint.ts
@@ -1,11 +1,14 @@
-import type { BreakpointDescriptor } from "@cursorless/common";
 import { FlashStyle } from "@cursorless/common";
 import type { ModifierStageFactory } from "../processTargets/ModifierStageFactory";
 import { containingLineIfUntypedModifier } from "../processTargets/modifiers/commonContainingScopeIfUntypedModifiers";
 import { ide } from "../singletons/ide.singleton";
 import type { Target } from "../typings/target.types";
-import { flashTargets, runOnTargetsForEachEditor } from "../util/targetUtils";
-import type { SimpleAction, ActionReturnValue } from "./actions.types";
+import {
+  flashTargets,
+  runOnTargetsForEachEditor,
+  toGeneralizedRange,
+} from "../util/targetUtils";
+import type { ActionReturnValue, SimpleAction } from "./actions.types";
 
 export default class ToggleBreakpoint implements SimpleAction {
   getFinalStages = () => [
@@ -22,25 +25,13 @@ export default class ToggleBreakpoint implements SimpleAction {
     await flashTargets(ide(), thatTargets, FlashStyle.referenced);
 
     await runOnTargetsForEachEditor(targets, async (editor, targets) => {
-      const breakpointDescriptors: BreakpointDescriptor[] = targets.map(
-        (target) => {
-          const range = target.contentRange;
-          return target.isLine
-            ? {
-                type: "line",
-                startLine: range.start.line,
-                endLine: range.end.line,
-              }
-            : {
-                type: "inline",
-                range,
-              };
-        },
+      const generalizedRanges = targets.map((target) =>
+        toGeneralizedRange(target),
       );
 
       await ide()
         .getEditableTextEditor(editor)
-        .toggleBreakpoint(breakpointDescriptors);
+        .toggleBreakpoint(generalizedRanges);
     });
 
     return {

--- a/packages/cursorless-everywhere-talon-core/src/ide/TalonJsEditor.ts
+++ b/packages/cursorless-everywhere-talon-core/src/ide/TalonJsEditor.ts
@@ -1,8 +1,8 @@
 import {
   selectionsEqual,
-  type BreakpointDescriptor,
   type Edit,
   type EditableTextEditor,
+  type GeneralizedRange,
   type InMemoryTextDocument,
   type OpenLinkOptions,
   type Range,
@@ -100,9 +100,7 @@ export class TalonJsEditor implements EditableTextEditor {
     throw new Error("unfold not implemented.");
   }
 
-  toggleBreakpoint(
-    _descriptors?: BreakpointDescriptor[] | undefined,
-  ): Promise<void> {
+  toggleBreakpoint(_ranges?: GeneralizedRange[]): Promise<void> {
     throw new Error("toggleBreakpoint not implemented.");
   }
 

--- a/packages/cursorless-vscode/src/ide/vscode/VscodeTextEditorImpl.ts
+++ b/packages/cursorless-vscode/src/ide/vscode/VscodeTextEditorImpl.ts
@@ -1,7 +1,7 @@
 import type {
-  BreakpointDescriptor,
   Edit,
   EditableTextEditor,
+  GeneralizedRange,
   OpenLinkOptions,
   Range,
   RevealLineAt,
@@ -164,8 +164,8 @@ export class VscodeTextEditorImpl implements EditableTextEditor {
     return vscodeUnfold(this.ide, this, ranges);
   }
 
-  public toggleBreakpoint(descriptors?: BreakpointDescriptor[]): Promise<void> {
-    return vscodeToggleBreakpoint(this, descriptors);
+  public toggleBreakpoint(ranges?: GeneralizedRange[]): Promise<void> {
+    return vscodeToggleBreakpoint(this, ranges);
   }
 
   public async toggleLineComment(_ranges?: Range[]): Promise<void> {

--- a/packages/cursorless-vscode/src/ide/vscode/VscodeToggleBreakpoint.ts
+++ b/packages/cursorless-vscode/src/ide/vscode/VscodeToggleBreakpoint.ts
@@ -41,14 +41,14 @@ export async function vscodeToggleBreakpoint(
 }
 
 function getBreakpoints(uri: vscode.Uri, range: GeneralizedRange) {
-  let rangeInterceptPredict: (range: vscode.Range) => boolean;
+  let rangeInterceptPredicate: (range: vscode.Range) => boolean;
 
   if (range.type === "line") {
-    rangeInterceptPredict = ({ start, end }) =>
+    rangeInterceptPredicate = ({ start, end }) =>
       range.start <= end.line && range.end >= start.line;
   } else {
     const descriptorRange = toVscodeRange(range.start, range.end);
-    rangeInterceptPredict = (range) =>
+    rangeInterceptPredicate = (range) =>
       range.intersection(descriptorRange) != null;
   }
 
@@ -56,7 +56,7 @@ function getBreakpoints(uri: vscode.Uri, range: GeneralizedRange) {
     (breakpoint) =>
       breakpoint instanceof vscode.SourceBreakpoint &&
       breakpoint.location.uri.toString() === uri.toString() &&
-      rangeInterceptPredict(breakpoint.location.range),
+      rangeInterceptPredicate(breakpoint.location.range),
   );
 }
 

--- a/packages/cursorless-vscode/src/ide/vscode/VscodeToggleBreakpoint.ts
+++ b/packages/cursorless-vscode/src/ide/vscode/VscodeToggleBreakpoint.ts
@@ -41,14 +41,14 @@ export async function vscodeToggleBreakpoint(
 }
 
 function getBreakpoints(uri: vscode.Uri, range: GeneralizedRange) {
-  let rangeInterceptsDescriptor: (range: vscode.Range) => boolean;
+  let rangeInterceptPredict: (range: vscode.Range) => boolean;
 
   if (range.type === "line") {
-    rangeInterceptsDescriptor = ({ start, end }) =>
+    rangeInterceptPredict = ({ start, end }) =>
       range.start <= end.line && range.end >= start.line;
   } else {
     const descriptorRange = toVscodeRange(range.start, range.end);
-    rangeInterceptsDescriptor = (range) =>
+    rangeInterceptPredict = (range) =>
       range.intersection(descriptorRange) != null;
   }
 
@@ -56,7 +56,7 @@ function getBreakpoints(uri: vscode.Uri, range: GeneralizedRange) {
     (breakpoint) =>
       breakpoint instanceof vscode.SourceBreakpoint &&
       breakpoint.location.uri.toString() === uri.toString() &&
-      rangeInterceptsDescriptor(breakpoint.location.range),
+      rangeInterceptPredict(breakpoint.location.range),
   );
 }
 

--- a/packages/cursorless-vscode/src/ide/vscode/VscodeToggleBreakpoint.ts
+++ b/packages/cursorless-vscode/src/ide/vscode/VscodeToggleBreakpoint.ts
@@ -1,13 +1,13 @@
-import type { BreakpointDescriptor } from "@cursorless/common";
-import { toVscodeRange } from "@cursorless/vscode-common";
+import type { GeneralizedRange, Position } from "@cursorless/common";
+import { toVscodePosition } from "@cursorless/vscode-common";
 import * as vscode from "vscode";
 import type { VscodeTextEditorImpl } from "./VscodeTextEditorImpl";
 
 export async function vscodeToggleBreakpoint(
   editor: VscodeTextEditorImpl,
-  descriptors: BreakpointDescriptor[] | undefined,
+  ranges?: GeneralizedRange[] | undefined,
 ): Promise<void> {
-  if (descriptors == null) {
+  if (ranges == null) {
     return await vscode.commands.executeCommand(
       "editor.debug.action.toggleBreakpoint",
     );
@@ -17,8 +17,9 @@ export async function vscodeToggleBreakpoint(
   const toAdd: vscode.Breakpoint[] = [];
   const toRemove: vscode.Breakpoint[] = [];
 
-  descriptors.forEach((descriptor) => {
-    const existing = getBreakpoints(uri, descriptor);
+  ranges.forEach((range) => {
+    const existing = getBreakpoints(uri, range);
+
     if (existing.length > 0) {
       toRemove.push(...existing);
     } else {
@@ -26,9 +27,9 @@ export async function vscodeToggleBreakpoint(
         new vscode.SourceBreakpoint(
           new vscode.Location(
             uri,
-            descriptor.type === "line"
-              ? new vscode.Range(descriptor.startLine, 0, descriptor.endLine, 0)
-              : toVscodeRange(descriptor.range),
+            range.type === "line"
+              ? new vscode.Range(range.start, 0, range.end, 0)
+              : toVscodeRange(range.start, range.end),
           ),
         ),
       );
@@ -39,14 +40,14 @@ export async function vscodeToggleBreakpoint(
   vscode.debug.removeBreakpoints(toRemove);
 }
 
-function getBreakpoints(uri: vscode.Uri, descriptor: BreakpointDescriptor) {
+function getBreakpoints(uri: vscode.Uri, range: GeneralizedRange) {
   let rangeInterceptsDescriptor: (range: vscode.Range) => boolean;
 
-  if (descriptor.type === "line") {
+  if (range.type === "line") {
     rangeInterceptsDescriptor = ({ start, end }) =>
-      descriptor.startLine <= end.line && descriptor.endLine >= start.line;
+      range.start <= end.line && range.end >= start.line;
   } else {
-    const descriptorRange = toVscodeRange(descriptor.range);
+    const descriptorRange = toVscodeRange(range.start, range.end);
     rangeInterceptsDescriptor = (range) =>
       range.intersection(descriptorRange) != null;
   }
@@ -57,4 +58,8 @@ function getBreakpoints(uri: vscode.Uri, descriptor: BreakpointDescriptor) {
       breakpoint.location.uri.toString() === uri.toString() &&
       rangeInterceptsDescriptor(breakpoint.location.range),
   );
+}
+
+function toVscodeRange(start: Position, end: Position): vscode.Range {
+  return new vscode.Range(toVscodePosition(start), toVscodePosition(end));
 }

--- a/packages/neovim-common/src/ide/neovim/NeovimTextEditorImpl.ts
+++ b/packages/neovim-common/src/ide/neovim/NeovimTextEditorImpl.ts
@@ -1,7 +1,7 @@
 import type {
-  BreakpointDescriptor,
   Edit,
   EditableTextEditor,
+  GeneralizedRange,
   OpenLinkOptions,
   Range,
   RevealLineAt,
@@ -127,9 +127,7 @@ export class NeovimTextEditorImpl implements EditableTextEditor {
     throw Error("unfold Not implemented");
   }
 
-  public toggleBreakpoint(
-    _descriptors?: BreakpointDescriptor[],
-  ): Promise<void> {
+  public toggleBreakpoint(_ranges?: GeneralizedRange[]): Promise<void> {
     throw Error("toggleBreakpoint Not implemented");
   }
 


### PR DESCRIPTION
We had a specific type for breakpoint descriptions which is more or less the same format as our generalized ranges that we use in other places. 

## Checklist

- [/] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [/] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [/] I have not broken the cheatsheet
