### PR TITLE
Exclude binary operator from Talon name and value scopes

### DIFF
--- a/data/fixtures/scopes/talon/name.field.scope
+++ b/data/fixtures/scopes/talon/name.field.scope
@@ -1,0 +1,13 @@
+aaa [bbb]: bbb or ""
+---
+
+[Content] =
+[Removal] = 0:0-0:9
+  >---------<
+0| aaa [bbb]: bbb or ""
+
+[Domain] = 0:0-0:20
+  >--------------------<
+0| aaa [bbb]: bbb or ""
+
+[Insertion delimiter] = " "

--- a/data/fixtures/scopes/talon/value.field.scope
+++ b/data/fixtures/scopes/talon/value.field.scope
@@ -1,0 +1,20 @@
+aaa [bbb]: bbb or ""
+---
+
+[Content] = 0:11-0:20
+             >---------<
+0| aaa [bbb]: bbb or ""
+
+[Removal] = 0:10-0:20
+            >----------<
+0| aaa [bbb]: bbb or ""
+
+[Leading delimiter] = 0:10-0:11
+            >-<
+0| aaa [bbb]: bbb or ""
+
+[Domain] = 0:0-0:20
+  >--------------------<
+0| aaa [bbb]: bbb or ""
+
+[Insertion delimiter] = " "

--- a/packages/common/src/scopeSupportFacets/talon.ts
+++ b/packages/common/src/scopeSupportFacets/talon.ts
@@ -5,4 +5,6 @@ const { supported } = ScopeSupportFacetLevel;
 
 export const talonScopeSupport: LanguageScopeSupportFacetMap = {
   command: supported,
+  "name.field": supported,
+  "value.field": supported,
 };

--- a/queries/talon.scm
+++ b/queries/talon.scm
@@ -39,9 +39,12 @@
 ;;!  ^^^^------------
 ;;!! tag(): user.cursorless
 ;;!  ^^^^^-----------------
-(_
-  left: _ @name
-) @_.domain
+(
+  (_
+    left: _ @name
+  ) @_.domain
+  (#not-type? @_.domain "binary_operator")
+)
 
 ;;!! not mode: command
 ;;!  ^^^^^^^^---------
@@ -49,18 +52,24 @@
 ;;!  ^^^^------------
 ;;!! tag(): user.cursorless
 ;;!  ^^^^^-----------------
-(_
-  modifiers: (_)? @collectionKey.start
-  left: _ @collectionKey.end
-) @_.domain
+(
+  (_
+    modifiers: (_)? @collectionKey.start
+    left: _ @collectionKey.end
+  ) @_.domain
+  (#not-type? @_.domain "binary_operator")
+)
 
 ;;!! not mode: command
 ;;!  ----------^^^^^^^
 ;;!! slap: key(enter)
 ;;!  ------^^^^^^^^^^
-(_
-  right: (_) @value
-) @_.domain
+(
+  (_
+    right: (_) @value
+  ) @_.domain
+  (#not-type? @_.domain "binary_operator")
+)
 
 ;;!!   mode: command
 ;;!   <*************


### PR DESCRIPTION
Fixes #1781

## Checklist

- [x] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [/] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [/] I have not broken the cheatsheet
