### PR TITLE
Support grand grand scope

### DIFF
--- a/cursorless-talon/src/modifiers/simple_scope_modifier.py
+++ b/cursorless-talon/src/modifiers/simple_scope_modifier.py
@@ -24,7 +24,7 @@ mod.setting(
 
 @mod.capture(
     rule=(
-        "[{user.cursorless_every_scope_modifier} | {user.cursorless_ancestor_scope_modifier}] "
+        "[{user.cursorless_every_scope_modifier} | {user.cursorless_ancestor_scope_modifier}+] "
         "<user.cursorless_scope_type>"
     ),
 )
@@ -40,7 +40,7 @@ def cursorless_simple_scope_modifier(m) -> dict[str, Any]:
         return {
             "type": "containingScope",
             "scopeType": m.cursorless_scope_type,
-            "ancestorIndex": 1,
+            "ancestorIndex": len(m.cursorless_ancestor_scope_modifier_list),
         }
 
     if settings.get("user.private_cursorless_use_preferred_scope"):

--- a/data/fixtures/recorded/containingScope/changeGrandGrandState.yml
+++ b/data/fixtures/recorded/containingScope/changeGrandGrandState.yml
@@ -1,0 +1,29 @@
+languageId: javascript
+command:
+  version: 7
+  spokenForm: change grand grand state
+  action:
+    name: clearAndSetSelection
+    target:
+      type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: statement}
+          ancestorIndex: 2
+  usePrePhraseSnapshot: false
+initialState:
+  documentContents: |-
+    class MyClass {
+        myFunk() {
+            console.log("");
+        }
+    }
+  selections:
+    - anchor: {line: 2, character: 8}
+      active: {line: 2, character: 8}
+  marks: {}
+finalState:
+  documentContents: ""
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}

--- a/packages/cursorless-engine/src/generateSpokenForm/primitiveTargetToSpokenForm.ts
+++ b/packages/cursorless-engine/src/generateSpokenForm/primitiveTargetToSpokenForm.ts
@@ -52,15 +52,12 @@ export class PrimitiveTargetSpokenFormGenerator {
         if (modifier.ancestorIndex == null || modifier.ancestorIndex === 0) {
           return this.handleScopeType(modifier.scopeType);
         }
-        if (modifier.ancestorIndex === 1) {
-          return [
+        return [
+          new Array(modifier.ancestorIndex).fill(
             this.spokenFormMap.modifierExtra.ancestor,
-            this.handleScopeType(modifier.scopeType),
-          ];
-        }
-        throw new NoSpokenFormError(
-          `Modifier '${modifier.type}' with ancestor index ${modifier.ancestorIndex}`,
-        );
+          ),
+          this.handleScopeType(modifier.scopeType),
+        ];
 
       case "everyScope":
         return [

--- a/packages/cursorless-org-docs/src/docs/user/README.md
+++ b/packages/cursorless-org-docs/src/docs/user/README.md
@@ -235,6 +235,10 @@ The modifier `"grand"` can be used to select the parent of the containing syntac
 
 For example, the command `"take grand statement [blue] air"` will select that parent statement of the statement containing the token with a blue hat over the letter 'a'.
 
+You can also repeat `"grand"` multiple times.
+
+For example, the command `"take grand grand statement [blue] air"` will select that parent statement of parent the statement of the statement containing the token with a blue hat over the letter 'a'.
+
 ##### Sub-token modifiers
 
 ###### `"sub"`

--- a/packages/cursorless-org-docs/src/docs/user/README.md
+++ b/packages/cursorless-org-docs/src/docs/user/README.md
@@ -233,11 +233,11 @@ The modifier `"grand"` can be used to select the parent of the containing syntac
 - `"take grand statement air"`
 - `"take grand funk air"`
 
-For example, the command `"take grand statement [blue] air"` will select that parent statement of the statement containing the token with a blue hat over the letter 'a'.
+For example, the command `"take grand statement [blue] air"` will select the parent statement of the statement containing the token with a blue hat over the letter 'a'.
 
 You can also repeat `"grand"` multiple times.
 
-For example, the command `"take grand grand statement [blue] air"` will select that parent statement of parent the statement of the statement containing the token with a blue hat over the letter 'a'.
+For example, the command `"take grand grand statement [blue] air"` will select the parent statement of the parent statement of the statement containing the token with a blue hat over the letter 'a'.
 
 ##### Sub-token modifiers
 


### PR DESCRIPTION
Allows you to say grand multiple times. eg `"take grand grand state"`

Fixes #2152

## Checklist

- [x] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [x] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [x] I have not broken the cheatsheet
