### PR TITLE
Added triple backtics matching pair to markdown language

### DIFF
--- a/data/fixtures/recorded/languages/markdown/changePair.yml
+++ b/data/fixtures/recorded/languages/markdown/changePair.yml
@@ -1,0 +1,26 @@
+languageId: markdown
+command:
+  version: 7
+  spokenForm: change pair
+  action:
+    name: clearAndSetSelection
+    target:
+      type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: surroundingPair, delimiter: any}
+  usePrePhraseSnapshot: false
+initialState:
+  documentContents: |-
+    ```python
+    a = 2
+    ```
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  marks: {}
+finalState:
+  documentContents: ""
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}

--- a/packages/common/src/types/command/PartialTargetDescriptor.types.ts
+++ b/packages/common/src/types/command/PartialTargetDescriptor.types.ts
@@ -118,6 +118,7 @@ export const simpleSurroundingPairNames = [
   "parentheses",
   "singleQuotes",
   "squareBrackets",
+  "tripleBacktickQuotes",
   "tripleDoubleQuotes",
   "tripleSingleQuotes",
 ] as const;

--- a/packages/cursorless-engine/src/generateSpokenForm/defaultSpokenForms/surroundingPairsDelimiters.ts
+++ b/packages/cursorless-engine/src/generateSpokenForm/defaultSpokenForms/surroundingPairsDelimiters.ts
@@ -15,6 +15,7 @@ export const surroundingPairsDelimiters: Record<
   backtickQuotes: ["`", "`"],
   squareBrackets: ["[", "]"],
   singleQuotes: ["'", "'"],
+  tripleBacktickQuotes: ["```", "```"],
   tripleDoubleQuotes: ['"""', '"""'],
   tripleSingleQuotes: ["'''", "'''"],
   whitespace: [" ", " "],

--- a/packages/cursorless-engine/src/processTargets/modifiers/scopeHandlers/SurroundingPairScopeHandler/delimiterMaps.ts
+++ b/packages/cursorless-engine/src/processTargets/modifiers/scopeHandlers/SurroundingPairScopeHandler/delimiterMaps.ts
@@ -22,13 +22,15 @@ type DelimiterMap = Record<
   | [IndividualDelimiterText, IndividualDelimiterText, Options]
 >;
 
+// Note that the order here is important since we are creating a regex from the key order.
+// For example triple quotes need to come before single quotes.
 const delimiterToText: DelimiterMap = Object.freeze({
   angleBrackets: [
     ["</", "<"],
     [">", "/>"],
   ],
-  backtickQuotes: ["`", "`"],
   curlyBrackets: [["{", "${"], "}"],
+  tripleBacktickQuotes: [[], []],
   tripleDoubleQuotes: [[], []],
   tripleSingleQuotes: [[], []],
   doubleQuotes: ['"', '"', { isSingleLine: true }],
@@ -37,6 +39,7 @@ const delimiterToText: DelimiterMap = Object.freeze({
   escapedSquareBrackets: ["\\[", "\\]"],
   escapedSingleQuotes: ["\\'", "\\'", { isSingleLine: true }],
   parentheses: [["(", "$("], ")"],
+  backtickQuotes: ["`", "`"],
   singleQuotes: ["'", "'", { isSingleLine: true }],
   squareBrackets: ["[", "]"],
 });
@@ -63,6 +66,10 @@ const delimiterToTextOverrides: Record<string, Partial<DelimiterMap>> = {
     tripleDoubleQuotes: ['"""', '"""'],
   },
 
+  markdown: {
+    tripleBacktickQuotes: ["```", "```"],
+  },
+
   ruby: {
     tripleDoubleQuotes: ["%Q(", ")"],
   },
@@ -84,6 +91,7 @@ export const complexDelimiterMap: Record<
   string: [
     "tripleDoubleQuotes",
     "tripleSingleQuotes",
+    "tripleBacktickQuotes",
     "doubleQuotes",
     "singleQuotes",
     "backtickQuotes",

--- a/packages/cursorless-engine/src/spokenForms/defaultSpokenFormMapCore.ts
+++ b/packages/cursorless-engine/src/spokenForms/defaultSpokenFormMapCore.ts
@@ -30,6 +30,7 @@ export const defaultSpokenFormMapCore: DefaultSpokenFormMapDefinition = {
     singleQuotes: "twin",
     tripleDoubleQuotes: isPrivate("triple quad"),
     tripleSingleQuotes: isPrivate("triple twin"),
+    tripleBacktickQuotes: isPrivate("triple skis"),
     any: "pair",
     string: "string",
     whitespace: "void",


### PR DESCRIPTION
Triple backticks wasn't supported as a matching pair

## Checklist

- [x] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [/] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [/] I have not broken the cheatsheet
