### PR TITLE
Remove our own implementation of the match predicate

### DIFF
--- a/packages/cursorless-engine/src/languages/TreeSitterQuery/queryPredicateOperators.ts
+++ b/packages/cursorless-engine/src/languages/TreeSitterQuery/queryPredicateOperators.ts
@@ -62,21 +62,6 @@ class HasMultipleChildrenOfType extends QueryPredicateOperator<HasMultipleChildr
   }
 }
 
-/**
- * A predicate operator that returns true if the nodes text matched the regular expression
- */
-class Match extends QueryPredicateOperator<Match> {
-  name = "match?" as const;
-  schema = z.tuple([q.node, q.string]);
-
-  run(nodeInfo: MutableQueryCapture, pattern: string) {
-    const { document, range } = nodeInfo;
-    const regex = new RegExp(pattern, "ds");
-    const text = document.getText(range);
-    return regex.test(text);
-  }
-}
-
 class ChildRange extends QueryPredicateOperator<ChildRange> {
   name = "child-range!" as const;
   schema = z.union([
@@ -292,5 +277,4 @@ export const queryPredicateOperators = [
   new InsertionDelimiter(),
   new SingleOrMultilineDelimiter(),
   new HasMultipleChildrenOfType(),
-  new Match(),
 ];


### PR DESCRIPTION
The match predicate is built into Tree sitter and our own code was actually never running

## Checklist

- [/] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [/] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [/] I have not broken the cheatsheet
