### PR TITLE
Migrate snippets follow up

### DIFF
--- a/cursorless-talon/src/actions/generate_snippet.py
+++ b/cursorless-talon/src/actions/generate_snippet.py
@@ -1,7 +1,7 @@
 import glob
 from pathlib import Path
 
-from talon import Context, Module, actions, settings
+from talon import Context, Module, actions, registry, settings
 
 from ..targets.target_types import CursorlessExplicitTarget
 
@@ -20,6 +20,15 @@ class Actions:
         actions.user.private_cursorless_run_rpc_command_no_wait(
             "cursorless.migrateSnippets",
             str(get_directory_path()),
+            {
+                "insertion": registry.lists[
+                    "user.cursorless_insertion_snippet_no_phrase"
+                ][-1],
+                "insertionWithPhrase": registry.lists[
+                    "user.cursorless_insertion_snippet_single_phrase"
+                ][-1],
+                "wrapper": registry.lists["user.cursorless_wrapper_snippet"][-1],
+            },
         )
 
     def private_cursorless_generate_snippet_action(target: CursorlessExplicitTarget):  # pyright: ignore [reportGeneralTypeIssues]

--- a/packages/cursorless-vscode/src/migrateSnippets.ts
+++ b/packages/cursorless-vscode/src/migrateSnippets.ts
@@ -165,14 +165,14 @@ async function openResultDocument(
     `From: ${sourceDirectory}`,
     `To:   ${targetDirectory}`,
     "",
-    `## Migrated ${migratedKeys.length} snippet files`,
+    `## Migrated ${migratedKeys.length} snippet files:`,
     ...migratedKeys.map((key) => `- ${key} -> ${result.migrated[key]}`),
     "",
   ];
 
   if (migratedPartiallyKeys.length > 0) {
     content.push(
-      `## Migrated ${migratedPartiallyKeys.length} snippet files partially`,
+      `## Migrated ${migratedPartiallyKeys.length} snippet files partially:`,
       skipMessage,
       ...migratedPartiallyKeys.map(
         (key) => `- ${key} -> ${result.migratedPartially[key]}`,
@@ -182,7 +182,7 @@ async function openResultDocument(
 
   if (result.skipped.length > 0) {
     content.push(
-      `## Skipped ${result.skipped.length} snippet files`,
+      `## Skipped ${result.skipped.length} snippet files:`,
       skipMessage,
       ...result.skipped.map((key) => `- ${key}`),
     );

--- a/packages/cursorless-vscode/src/migrateSnippets.ts
+++ b/packages/cursorless-vscode/src/migrateSnippets.ts
@@ -159,7 +159,7 @@ async function openResultDocument(
   const skipMessage =
     "Snippets containing `scopeTypes` and/or `excludeDescendantScopeTypes` attributes are not supported by community snippets.";
 
-  const contentParts: string[] = [
+  const content: string[] = [
     `# Snippets migrated from Cursorless`,
     "",
     `From: ${sourceDirectory}`,
@@ -171,7 +171,7 @@ async function openResultDocument(
   ];
 
   if (migratedPartiallyKeys.length > 0) {
-    contentParts.push(
+    content.push(
       `## Migrated ${migratedPartiallyKeys.length} snippet files partially`,
       skipMessage,
       ...migratedPartiallyKeys.map(
@@ -181,7 +181,7 @@ async function openResultDocument(
   }
 
   if (result.skipped.length > 0) {
-    contentParts.push(
+    content.push(
       `## Skipped ${result.skipped.length} snippet files`,
       skipMessage,
       ...result.skipped.map((key) => `- ${key}`),
@@ -189,7 +189,7 @@ async function openResultDocument(
   }
 
   const textDocument = await vscode.workspace.openTextDocument({
-    content: contentParts.join("\n"),
+    content: content.join("\n"),
     language: "markdown",
   });
   await vscode.window.showTextDocument(textDocument);

--- a/packages/cursorless-vscode/src/migrateSnippets.ts
+++ b/packages/cursorless-vscode/src/migrateSnippets.ts
@@ -157,7 +157,7 @@ async function openResultDocument(
   const migratedKeys = Object.keys(result.migrated).sort();
   const migratedPartiallyKeys = Object.keys(result.migratedPartially).sort();
   const skipMessage =
-    "Snippets containing `scopeTypes` and/or `excludeDescendantScopeTypes` attributes are not supported by community snippets.";
+    "(Snippets containing `scopeTypes` and/or `excludeDescendantScopeTypes` attributes are not supported by community snippets.)";
 
   const content: string[] = [
     `# Snippets migrated from Cursorless`,
@@ -173,18 +173,18 @@ async function openResultDocument(
   if (migratedPartiallyKeys.length > 0) {
     content.push(
       `## Migrated ${migratedPartiallyKeys.length} snippet files partially:`,
-      skipMessage,
       ...migratedPartiallyKeys.map(
         (key) => `- ${key} -> ${result.migratedPartially[key]}`,
       ),
+      skipMessage,
     );
   }
 
   if (result.skipped.length > 0) {
     content.push(
       `## Skipped ${result.skipped.length} snippet files:`,
-      skipMessage,
       ...result.skipped.map((key) => `- ${key}`),
+      skipMessage,
     );
   }
 

--- a/packages/cursorless-vscode/src/registerCommands.ts
+++ b/packages/cursorless-vscode/src/registerCommands.ts
@@ -89,7 +89,7 @@ export function registerCommands(
     ["cursorless.showDocumentation"]: showDocumentation,
     ["cursorless.showInstallationDependencies"]: installationDependencies.show,
 
-    ["cursorless.migrateSnippets"]: (dir) => migrateSnippets(snippets, dir),
+    ["cursorless.migrateSnippets"]: migrateSnippets.bind(null, snippets),
 
     ["cursorless.private.logQuickActions"]: logQuickActions,
 


### PR DESCRIPTION
1. Skip snippets with fields we cannot migrate instead of just discarding those fields
2. Show a untitled markdown document with the migration results
3. Use spoken forms/phrases from Talon

## Checklist

- [/] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [/] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [/] I have not broken the cheatsheet
