### PR TITLE
Clean up one of scope handler

### DIFF
--- a/packages/cursorless-engine/src/processTargets/modifiers/scopeHandlers/CollectionItemScopeHandler/CollectionItemScopeHandler.ts
+++ b/packages/cursorless-engine/src/processTargets/modifiers/scopeHandlers/CollectionItemScopeHandler/CollectionItemScopeHandler.ts
@@ -48,15 +48,8 @@ export class CollectionItemScopeHandler extends BaseScopeHandler {
 
       return OneOfScopeHandler.createFromScopeHandlers(
         scopeHandlerFactory,
-        {
-          type: "oneOf",
-          scopeTypes: [
-            languageScopeHandler.scopeType,
-            textualScopeHandler.scopeType,
-          ],
-        },
-        [languageScopeHandler, textualScopeHandler],
         languageId,
+        [languageScopeHandler, textualScopeHandler],
       );
     })();
   }

--- a/packages/cursorless-engine/src/processTargets/modifiers/scopeHandlers/NotebookCellScopeHandler.ts
+++ b/packages/cursorless-engine/src/processTargets/modifiers/scopeHandlers/NotebookCellScopeHandler.ts
@@ -46,15 +46,8 @@ export class NotebookCellScopeHandler extends BaseScopeHandler {
 
       return OneOfScopeHandler.createFromScopeHandlers(
         scopeHandlerFactory,
-        {
-          type: "oneOf",
-          scopeTypes: [
-            languageScopeHandler.scopeType,
-            apiScopeHandler.scopeType,
-          ],
-        },
-        [languageScopeHandler, apiScopeHandler],
         languageId,
+        [languageScopeHandler, apiScopeHandler],
       );
     })();
   }

--- a/packages/cursorless-engine/src/processTargets/modifiers/scopeHandlers/OneOfScopeHandler.ts
+++ b/packages/cursorless-engine/src/processTargets/modifiers/scopeHandlers/OneOfScopeHandler.ts
@@ -81,7 +81,7 @@ export class OneOfScopeHandler extends BaseScopeHandler {
     direction: Direction,
     hints: ScopeIteratorRequirements,
   ): Iterable<TargetScope> {
-    // If we have used a iteration scope handler, we only want to yield additional scopes from its handler.
+    // If we have used an iteration scope handler, we only want to yield additional scopes from its handler.
     if (this.iterationScopeHandler?.lastYieldedIndex != null) {
       const handlerIndex = this.iterationScopeHandler.lastYieldedIndex;
       const handler = this.scopeHandlers[handlerIndex];

--- a/packages/cursorless-engine/src/processTargets/modifiers/scopeHandlers/OneOfScopeHandler.ts
+++ b/packages/cursorless-engine/src/processTargets/modifiers/scopeHandlers/OneOfScopeHandler.ts
@@ -17,6 +17,7 @@ import type {
 
 export class OneOfScopeHandler extends BaseScopeHandler {
   protected isHierarchical = true;
+  public scopeType = undefined;
   private iterationScopeHandler: OneOfScopeHandler | undefined;
   private lastYieldedIndex: number | undefined;
 
@@ -31,21 +32,18 @@ export class OneOfScopeHandler extends BaseScopeHandler {
 
     return this.createFromScopeHandlers(
       scopeHandlerFactory,
-      scopeType,
-      scopeHandlers,
       languageId,
+      scopeHandlers,
     );
   }
 
   static createFromScopeHandlers(
     scopeHandlerFactory: ScopeHandlerFactory,
-    scopeType: OneOfScopeType,
-    scopeHandlers: ScopeHandler[],
     languageId: string,
+    scopeHandlers: ScopeHandler[],
   ): ScopeHandler {
     const getIterationScopeHandler = () =>
       new OneOfScopeHandler(
-        undefined,
         scopeHandlers.map((scopeHandler) =>
           scopeHandlerFactory.create(
             scopeHandler.iterationScopeType,
@@ -57,11 +55,14 @@ export class OneOfScopeHandler extends BaseScopeHandler {
         },
       );
 
-    return new OneOfScopeHandler(
-      scopeType,
-      scopeHandlers,
-      getIterationScopeHandler,
-    );
+    return new OneOfScopeHandler(scopeHandlers, getIterationScopeHandler);
+  }
+
+  private constructor(
+    private scopeHandlers: ScopeHandler[],
+    private getIterationScopeHandler: () => OneOfScopeHandler,
+  ) {
+    super();
   }
 
   get iterationScopeType(): CustomScopeType {
@@ -74,21 +75,13 @@ export class OneOfScopeHandler extends BaseScopeHandler {
     };
   }
 
-  private constructor(
-    public readonly scopeType: OneOfScopeType | undefined,
-    private scopeHandlers: ScopeHandler[],
-    private getIterationScopeHandler: () => OneOfScopeHandler,
-  ) {
-    super();
-  }
-
   *generateScopeCandidates(
     editor: TextEditor,
     position: Position,
     direction: Direction,
     hints: ScopeIteratorRequirements,
   ): Iterable<TargetScope> {
-    // If we have used the iteration scope handler, we only want to yield from its handler.
+    // If we have used a iteration scope handler, we only want to yield additional scopes from its handler.
     if (this.iterationScopeHandler?.lastYieldedIndex != null) {
       const handlerIndex = this.iterationScopeHandler.lastYieldedIndex;
       const handler = this.scopeHandlers[handlerIndex];


### PR DESCRIPTION
Passing in the scope type is only necessary if you're creating the scope handlers from that scope type. In the case where you're creating a one of handler from a list of scope handlers. Passing in the scope type as well just makes the code more verbose for no reason.

## Checklist

- [/] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [/] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [/] I have not broken the cheatsheet
