### PR TITLE
Close sidebar when running vscode tests

### DIFF
--- a/packages/vscode-common/src/testUtil/openNewEditor.ts
+++ b/packages/vscode-common/src/testUtil/openNewEditor.ts
@@ -33,7 +33,7 @@ export async function openNewEditor(
     await editor.edit((editBuilder) => editBuilder.setEndOfLine(eol));
   }
 
-  // Many times running these tests the sidebar will be opened so we close it.
+  // Many times running these tests opens the sidebar, which slows performance. Close it.
   vscode.commands.executeCommand("workbench.action.closeSidebar");
 
   return editor;

--- a/packages/vscode-common/src/testUtil/openNewEditor.ts
+++ b/packages/vscode-common/src/testUtil/openNewEditor.ts
@@ -33,6 +33,9 @@ export async function openNewEditor(
     await editor.edit((editBuilder) => editBuilder.setEndOfLine(eol));
   }
 
+  // Many times running these tests the sidebar will be opened so we close it.
+  vscode.commands.executeCommand("workbench.action.closeSidebar");
+
   return editor;
 }
 


### PR DESCRIPTION


## Checklist

- [/] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [/] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [/] I have not broken the cheatsheet
