### PR TITLE
Fixed bug with edit new

### DIFF
--- a/data/fixtures/recorded/actions/pourStateAirAndLineBat.yml
+++ b/data/fixtures/recorded/actions/pourStateAirAndLineBat.yml
@@ -1,0 +1,62 @@
+languageId: typescript
+command:
+  version: 7
+  spokenForm: pour state air and line bat
+  action:
+    name: editNewLineAfter
+    target:
+      type: list
+      elements:
+        - type: primitive
+          mark: {type: decoratedSymbol, symbolColor: default, character: a}
+          modifiers:
+            - type: containingScope
+              scopeType: {type: statement}
+        - type: primitive
+          mark: {type: decoratedSymbol, symbolColor: default, character: b}
+          modifiers:
+            - type: containingScope
+              scopeType: {type: line}
+  usePrePhraseSnapshot: false
+initialState:
+  documentContents: |
+    function aaa() {
+    }
+
+    // bbb
+  selections:
+    - anchor: {line: 4, character: 0}
+      active: {line: 4, character: 0}
+  marks:
+    default.a:
+      start: {line: 0, character: 9}
+      end: {line: 0, character: 12}
+    default.b:
+      start: {line: 3, character: 3}
+      end: {line: 3, character: 6}
+finalState:
+  documentContents: |+
+    function aaa() {
+    }
+
+
+    // bbb
+
+  selections:
+    - anchor: {line: 2, character: 0}
+      active: {line: 2, character: 0}
+    - anchor: {line: 5, character: 0}
+      active: {line: 5, character: 0}
+  thatMark:
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 0, character: 0}
+        end: {line: 1, character: 1}
+      isReversed: false
+      hasExplicitRange: true
+    - type: UntypedTarget
+      contentRange:
+        start: {line: 4, character: 0}
+        end: {line: 4, character: 6}
+      isReversed: false
+      hasExplicitRange: true

--- a/packages/cursorless-engine/src/actions/EditNew/EditNew.ts
+++ b/packages/cursorless-engine/src/actions/EditNew/EditNew.ts
@@ -35,6 +35,7 @@ export class EditNew {
      */
     let state: State = {
       destinations,
+      actionTypes: destinations.map((d) => d.getEditNewActionType()),
       thatRanges: destinations.map(
         ({ target }) => target.thatTarget.contentRange,
       ),
@@ -63,9 +64,14 @@ export class EditNew {
       !useInsertLineAfter,
     );
 
-    const newSelections = state.destinations.map((destination, index) =>
-      state.cursorRanges[index]!.toSelection(destination.target.isReversed),
-    );
+    const newSelections = state.destinations.map((destination, index) => {
+      const cursorRange = state.cursorRanges[index];
+      if (cursorRange == null) {
+        throw Error("Cursor range is undefined for destination");
+      }
+      return cursorRange.toSelection(destination.target.isReversed);
+    });
+
     await editableEditor.setSelections(newSelections, { focusEditor: true });
 
     return {

--- a/packages/cursorless-engine/src/actions/EditNew/EditNew.types.ts
+++ b/packages/cursorless-engine/src/actions/EditNew/EditNew.types.ts
@@ -1,5 +1,8 @@
 import type { Range } from "@cursorless/common";
-import type { Destination } from "../../typings/target.types";
+import type {
+  Destination,
+  EditNewActionType,
+} from "../../typings/target.types";
 
 /**
  * Internal type to be used for storing a reference to a destination that will use an
@@ -28,6 +31,13 @@ export interface State {
    * This field stores the original destinations.
    */
   destinations: Destination[];
+
+  /**
+   * The action types for each destination. Important to read from this and not
+   * the destinations themself since they get updated during the process am we want
+   * the default value for this.
+   */
+  actionTypes: EditNewActionType[];
 
   /**
    * We use this field to track the desired `thatMark` at the end, updating it

--- a/packages/cursorless-engine/src/actions/EditNew/EditNew.types.ts
+++ b/packages/cursorless-engine/src/actions/EditNew/EditNew.types.ts
@@ -33,9 +33,9 @@ export interface State {
   destinations: Destination[];
 
   /**
-   * The action types for each destination. Important to read from this and not
-   * the destinations themself since they get updated during the process am we want
-   * the default value for this.
+   * The action types for each destination. It's important to read from this and not
+   * the destinations themselves, since they are changed as the action runs and
+   * we make multiple passes.
    */
   actionTypes: EditNewActionType[];
 

--- a/packages/cursorless-engine/src/actions/EditNew/runEditTargets.ts
+++ b/packages/cursorless-engine/src/actions/EditNew/runEditTargets.ts
@@ -26,7 +26,7 @@ export async function runEditTargets(
 ): Promise<State> {
   const destinations: EditDestination[] = state.destinations
     .map((destination, index) => {
-      if (useAllDestinations || destination.getEditNewActionType() === "edit") {
+      if (useAllDestinations || state.actionTypes[index] === "edit") {
         return {
           destination,
           index,
@@ -90,6 +90,7 @@ export async function runEditTargets(
 
   return {
     destinations: state.destinations,
+    actionTypes: state.actionTypes,
     thatRanges: updatedThatRanges,
     cursorRanges: finalCursorRanges,
   };

--- a/packages/cursorless-engine/src/actions/EditNew/runInsertLineAfterTargets.ts
+++ b/packages/cursorless-engine/src/actions/EditNew/runInsertLineAfterTargets.ts
@@ -25,7 +25,7 @@ export async function runInsertLineAfterTargets(
 ): Promise<State> {
   const destinations: EditDestination[] = state.destinations
     .map((destination, index) => {
-      const actionType = destination.getEditNewActionType();
+      const actionType = state.actionTypes[index];
       if (actionType === "insertLineAfter") {
         return {
           destination,
@@ -84,6 +84,7 @@ export async function runInsertLineAfterTargets(
         destination.target.withContentRange(updatedTargetRanges[index]),
       ),
     ),
+    actionTypes: state.actionTypes,
     thatRanges: updatedThatRanges,
     cursorRanges,
   };


### PR DESCRIPTION
If you said `"pour state air and line bat"` where `air` was a multiline statement you got an undefined exception at runtime.

I have corrected the problem with our logic and also removed a not null assertion in favor of actually checking for null.

## Release notes
`"pour state air and line bat"` (if `air` was a multiline statement) now works instead of raising an exception.