### PR TITLE
Actions: attempt to validate PR description tests

### DIFF
--- a/.github/workflows/pr-description.yaml
+++ b/.github/workflows/pr-description.yaml
@@ -5,24 +5,24 @@ on:
     types: [opened, edited, reopened]
 
 jobs:
-  validate-pr-description:  
+  validate-pr-description:
     runs-on: ubuntu-latest
     steps:
-    - name: Set up workspace
-      uses: actions/checkout@v2
+      - name: Set up workspace
+        uses: actions/checkout@v2
 
-    - name: Validate description
-      run: |
-        # Fetch PR description from env with jq
-        PR_DESCRIPTION=$(jq -r ".pull_request.body" "$GITHUB_EVENT_PATH")
-        KEYWORD="REQUIRED_KEYWORD"
+      - name: Validate description
+        run: |
+          # Fetch PR description from env with jq
+          PR_DESCRIPTION=$(jq -r ".pull_request.body" "$GITHUB_EVENT_PATH")
+          KEYWORD="REQUIRED_KEYWORD"
 
-        # Ensure PR author removed the welcome comment
-        if [[ $PR_DESCRIPTION = *"<!--"* ]] || [[ $PR_DESCRIPTION = *"-->"* ]]; then
-          echo "FAILED: Please remove the welcome comment from your PR description."
-          exit 1
-        else
-          echo "OK: Welcome comment is removed your PR description."
-        fi
+          # Ensure PR author removed the welcome comment
+          if [[ $PR_DESCRIPTION = *"<!--"* ]] || [[ $PR_DESCRIPTION = *"-->"* ]]; then
+            echo "FAILED: Please remove the welcome comment from your PR description."
+            exit 1
+          else
+            echo "OK: Welcome comment is removed your PR description."
+          fi
 
-        echo "PASS: All checks OK!"
+          echo "PASS: All checks OK!"

--- a/.github/workflows/pr-description.yaml
+++ b/.github/workflows/pr-description.yaml
@@ -2,7 +2,7 @@ name: PR Description
 
 on:
   pull_request:
-    types: [opened, edited, reopened]
+    types: [opened, edited, reopened, synchronize]
   merge_group:
     branches: [main]
 

--- a/.github/workflows/pr-description.yaml
+++ b/.github/workflows/pr-description.yaml
@@ -1,0 +1,28 @@
+name: PR Description Validator
+
+on:
+  pull_request:
+    types: [opened, edited, reopened]
+
+jobs:
+  validate-pr-description:
+    name: Validate PR Description
+    runs-on: ubuntu-latest
+    steps:
+    - name: Set up workspace
+      uses: actions/checkout@v2
+
+    - name: Validate PR Description
+      run: |
+        # Ensure jq is installed
+        sudo apt-get install jq
+
+        # Fetch PR description using jq
+        PR_DESCRIPTION=$(jq -r ".pull_request.body" "$GITHUB_EVENT_PATH")
+        KEYWORD="REQUIRED_KEYWORD"
+
+        # Check for the required keyword in the PR description
+        if [[ $PR_DESCRIPTION = *"<!--"* ]] || [[ $PR_DESCRIPTION = *"-->"* ]]; then
+          echo "Please remove the welcome comment from your PR description."
+          exit 1
+        fi

--- a/.github/workflows/pr-description.yaml
+++ b/.github/workflows/pr-description.yaml
@@ -3,6 +3,8 @@ name: PR Description
 on:
   pull_request:
     types: [opened, edited, reopened]
+  merge_group:
+    branches: [main]
 
 jobs:
   validate-pr-description:

--- a/.github/workflows/pr-description.yaml
+++ b/.github/workflows/pr-description.yaml
@@ -5,24 +5,24 @@ on:
     types: [opened, edited, reopened]
 
 jobs:
-  validate-pr-description:
-    name: Validate Description
+  validate-pr-description:  
     runs-on: ubuntu-latest
     steps:
     - name: Set up workspace
       uses: actions/checkout@v2
 
-    - name: Validate
+    - name: Validate description
       run: |
-        # Ensure jq is installed
-        # sudo apt-get install jq
-
-        # Fetch PR description using jq
+        # Fetch PR description from env with jq
         PR_DESCRIPTION=$(jq -r ".pull_request.body" "$GITHUB_EVENT_PATH")
         KEYWORD="REQUIRED_KEYWORD"
 
-        # Users should remove the welcome comment
+        # Ensure PR author removed the welcome comment
         if [[ $PR_DESCRIPTION = *"<!--"* ]] || [[ $PR_DESCRIPTION = *"-->"* ]]; then
           echo "FAILED: Please remove the welcome comment from your PR description."
           exit 1
+        else
+          echo "OK: Welcome comment is removed your PR description."
         fi
+
+        echo "PASS: All checks OK!"

--- a/.github/workflows/pr-description.yaml
+++ b/.github/workflows/pr-description.yaml
@@ -1,4 +1,4 @@
-name: PR Description Validator
+name: PR Description
 
 on:
   pull_request:
@@ -6,23 +6,23 @@ on:
 
 jobs:
   validate-pr-description:
-    name: Validate PR Description
+    name: Validate Description
     runs-on: ubuntu-latest
     steps:
     - name: Set up workspace
       uses: actions/checkout@v2
 
-    - name: Validate PR Description
+    - name: Validate
       run: |
         # Ensure jq is installed
-        sudo apt-get install jq
+        # sudo apt-get install jq
 
         # Fetch PR description using jq
         PR_DESCRIPTION=$(jq -r ".pull_request.body" "$GITHUB_EVENT_PATH")
         KEYWORD="REQUIRED_KEYWORD"
 
-        # Check for the required keyword in the PR description
+        # Users should remove the welcome comment
         if [[ $PR_DESCRIPTION = *"<!--"* ]] || [[ $PR_DESCRIPTION = *"-->"* ]]; then
-          echo "Please remove the welcome comment from your PR description."
+          echo "FAILED: Please remove the welcome comment from your PR description."
           exit 1
         fi


### PR DESCRIPTION
GitHub includes the description comment when it formulates the commit message, which we don't want as it's pretty messy. We will ask users to remove the comment but we need to validate it before allowing merging.



Stolen from https://github.com/orgs/community/discussions/84771#discussioncomment-8039595.