### PR TITLE
Re-add deprecated wrapper snippet lists

### DIFF
--- a/cursorless-talon/src/snippets_deprecated.py
+++ b/cursorless-talon/src/snippets_deprecated.py
@@ -14,6 +14,7 @@ tags = [
 lists = [
     "cursorless_insertion_snippet_no_phrase",
     "cursorless_insertion_snippet_single_phrase",
+    "cursorless_wrapper_snippet",
     "cursorless_phrase_terminator",
 ]
 


### PR DESCRIPTION
This list was accidentally dropped. It's deprecated, but it's still needed for now.