### PR TITLE
Upgrade corepack for neovim publish

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -70,6 +70,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      # FIXME: https://github.com/cursorless-dev/cursorless/issues/2817
+      - name: Upgrade Corepack
+        run: npm install --global corepack@0.31.0
+
       - name: Enable Corepack
         run: corepack enable
 


### PR DESCRIPTION
Publishing neovim is still erroring about the corepack signature problem

This is not needed if we go the route of https://github.com/cursorless-dev/cursorless/pull/2825
