### PR TITLE
Only context override snippet insertion when Cursorless tag is active

### DIFF
--- a/cursorless-talon/src/snippets/snippets.py
+++ b/cursorless-talon/src/snippets/snippets.py
@@ -26,7 +26,8 @@ mod = Module()
 ctx = Context()
 
 ctx.matches = r"""
-not tag: user.code_language_forced
+tag: user.cursorless
+and not tag: user.code_language_forced
 """
 
 mod.list("cursorless_insert_snippet_action", desc="Cursorless insert snippet action")


### PR DESCRIPTION
Right now we are trying to use Cursorless to insert snippets no matter if we are actually in vscode or not