### PR TITLE
Remove snippets from spoken form json

### DIFF
--- a/cursorless-talon/src/csv_overrides.py
+++ b/cursorless-talon/src/csv_overrides.py
@@ -59,7 +59,7 @@ def csv_get_normalized_ctx():
 
 def init_csv_and_watch_changes(
     filename: str,
-    default_values: ListToSpokenForms,
+    default_values: ListToSpokenForms | None,
     handle_new_values: Optional[Callable[[list[SpokenFormEntry]], None]] = None,
     *,
     extra_ignored_values: Optional[list[str]] = None,
@@ -123,6 +123,13 @@ def init_csv_and_watch_changes(
         pluralize_lists = []
 
     file_path = get_full_path(filename)
+
+    # No default values and file does not exist. Do nothing.
+    if default_values is None:
+        if not file_path.is_file():
+            return lambda: None
+        default_values = {}
+
     super_default_values = get_super_values(default_values)
 
     file_path.parent.mkdir(parents=True, exist_ok=True)
@@ -151,7 +158,7 @@ def init_csv_and_watch_changes(
                 handle_new_values=handle_new_values,
             )
 
-    fs.watch(str(file_path.parent), on_watch)
+    fs.watch(file_path.parent, on_watch)
 
     if file_path.is_file():
         current_values = update_file(
@@ -188,7 +195,7 @@ def init_csv_and_watch_changes(
         )
 
     def unsubscribe():
-        fs.unwatch(str(file_path.parent), on_watch)
+        fs.unwatch(file_path.parent, on_watch)
 
     return unsubscribe
 
@@ -385,7 +392,7 @@ def csv_error(path: Path, index: int, message: str, value: str):
         index (int): The index into the file (for error reporting)
         text (str): The text of the error message to report if condition is false
     """
-    print(f"ERROR: {path}:{index+1}: {message} '{value}'")
+    print(f"ERROR: {path}:{index + 1}: {message} '{value}'")
 
 
 def read_file(

--- a/cursorless-talon/src/csv_overrides.py
+++ b/cursorless-talon/src/csv_overrides.py
@@ -59,12 +59,13 @@ def csv_get_normalized_ctx():
 
 def init_csv_and_watch_changes(
     filename: str,
-    default_values: ListToSpokenForms | None,
+    default_values: ListToSpokenForms,
     handle_new_values: Optional[Callable[[list[SpokenFormEntry]], None]] = None,
     *,
     extra_ignored_values: Optional[list[str]] = None,
     extra_allowed_values: Optional[list[str]] = None,
     allow_unknown_values: bool = False,
+    deprecated: bool = False,
     default_list_name: Optional[str] = None,
     headers: list[str] = [SPOKEN_FORM_HEADER, CURSORLESS_IDENTIFIER_HEADER],
     no_update_file: bool = False,
@@ -123,12 +124,11 @@ def init_csv_and_watch_changes(
         pluralize_lists = []
 
     file_path = get_full_path(filename)
+    is_file = file_path.is_file()
 
-    # No default values and file does not exist. Do nothing.
-    if default_values is None:
-        if not file_path.is_file():
-            return lambda: None
-        default_values = {}
+    # Deprecated file that doesn't exist. Do nothing.
+    if deprecated and not is_file:
+        return lambda: None
 
     super_default_values = get_super_values(default_values)
 
@@ -160,7 +160,7 @@ def init_csv_and_watch_changes(
 
     fs.watch(file_path.parent, on_watch)
 
-    if file_path.is_file():
+    if is_file:
         current_values = update_file(
             path=file_path,
             headers=headers,

--- a/cursorless-talon/src/spoken_forms.json
+++ b/cursorless-talon/src/spoken_forms.json
@@ -233,6 +233,12 @@
       "-from": "experimental.setInstanceReference"
     }
   },
+  "experimental/wrapper_snippets.csv": {},
+  "experimental/insertion_snippets.csv": {},
+  "experimental/insertion_snippets_single_phrase.csv": {},
+  "experimental/miscellaneous.csv": {
+    "phrase_terminator": { "over": "phraseTerminator" }
+  },
   "experimental/actions_custom.csv": {},
   "experimental/regex_scope_types.csv": {},
   "hat_styles.csv": {

--- a/cursorless-talon/src/spoken_forms.json
+++ b/cursorless-talon/src/spoken_forms.json
@@ -233,32 +233,6 @@
       "-from": "experimental.setInstanceReference"
     }
   },
-  "experimental/wrapper_snippets.csv": {
-    "wrapper_snippet": {
-      "else": "ifElseStatement.alternative",
-      "funk": "functionDeclaration.body",
-      "if else": "ifElseStatement.consequence",
-      "if": "ifStatement.consequence",
-      "try": "tryCatchStatement.body",
-      "link": "link.text"
-    }
-  },
-  "experimental/insertion_snippets.csv": {
-    "insertion_snippet_no_phrase": {
-      "if": "ifStatement",
-      "if else": "ifElseStatement",
-      "try": "tryCatchStatement"
-    }
-  },
-  "experimental/insertion_snippets_single_phrase.csv": {
-    "insertion_snippet_single_phrase": {
-      "funk": "functionDeclaration.name",
-      "link": "link.text"
-    }
-  },
-  "experimental/miscellaneous.csv": {
-    "phrase_terminator": { "over": "phraseTerminator" }
-  },
   "experimental/actions_custom.csv": {},
   "experimental/regex_scope_types.csv": {},
   "hat_styles.csv": {

--- a/cursorless-talon/src/spoken_forms.py
+++ b/cursorless-talon/src/spoken_forms.py
@@ -241,7 +241,7 @@ def on_ready():
 
     registry.register("update_captures", update_captures_debounced)
 
-    fs.watch(str(JSON_FILE.parent), on_watch)
+    fs.watch(JSON_FILE.parent, on_watch)
 
 
 app.register("ready", on_ready)

--- a/cursorless-talon/src/spoken_forms.py
+++ b/cursorless-talon/src/spoken_forms.py
@@ -32,9 +32,7 @@ def auto_construct_defaults(
     spoken_forms: dict[str, ListToSpokenForms],
     handle_new_values: Callable[[str, list[SpokenFormEntry]], None],
     f: Callable[
-        Concatenate[
-            str, ListToSpokenForms | None, Callable[[list[SpokenFormEntry]], None], P
-        ],
+        Concatenate[str, ListToSpokenForms, Callable[[list[SpokenFormEntry]], None], P],
         R,
     ],
 ):
@@ -55,7 +53,7 @@ def auto_construct_defaults(
     """
 
     def ret(filename: str, *args: P.args, **kwargs: P.kwargs) -> R:
-        default_values = spoken_forms.get(filename)
+        default_values = spoken_forms[filename]
         return f(
             filename,
             default_values,
@@ -169,23 +167,25 @@ def update():
         # DEPRECATED @ 2025-02-01
         handle_csv(
             "experimental/wrapper_snippets.csv",
+            deprecated=True,
             allow_unknown_values=True,
             default_list_name="wrapper_snippet",
         ),
         handle_csv(
             "experimental/insertion_snippets.csv",
+            deprecated=True,
             allow_unknown_values=True,
             default_list_name="insertion_snippet_no_phrase",
         ),
         handle_csv(
             "experimental/insertion_snippets_single_phrase.csv",
+            deprecated=True,
             allow_unknown_values=True,
             default_list_name="insertion_snippet_single_phrase",
         ),
         handle_csv(
             "experimental/miscellaneous.csv",
-            allow_unknown_values=True,
-            default_list_name="phrase_terminator",
+            deprecated=True,
         ),
         # ---
         handle_csv(

--- a/cursorless-talon/src/spoken_forms.py
+++ b/cursorless-talon/src/spoken_forms.py
@@ -32,7 +32,9 @@ def auto_construct_defaults(
     spoken_forms: dict[str, ListToSpokenForms],
     handle_new_values: Callable[[str, list[SpokenFormEntry]], None],
     f: Callable[
-        Concatenate[str, ListToSpokenForms, Callable[[list[SpokenFormEntry]], None], P],
+        Concatenate[
+            str, ListToSpokenForms | None, Callable[[list[SpokenFormEntry]], None], P
+        ],
         R,
     ],
 ):
@@ -53,7 +55,7 @@ def auto_construct_defaults(
     """
 
     def ret(filename: str, *args: P.args, **kwargs: P.kwargs) -> R:
-        default_values = spoken_forms.get(filename, {})
+        default_values = spoken_forms.get(filename)
         return f(
             filename,
             default_values,

--- a/cursorless-talon/src/spoken_forms.py
+++ b/cursorless-talon/src/spoken_forms.py
@@ -53,7 +53,7 @@ def auto_construct_defaults(
     """
 
     def ret(filename: str, *args: P.args, **kwargs: P.kwargs) -> R:
-        default_values = spoken_forms[filename]
+        default_values = spoken_forms.get(filename, {})
         return f(
             filename,
             default_values,
@@ -180,7 +180,11 @@ def update():
             allow_unknown_values=True,
             default_list_name="insertion_snippet_single_phrase",
         ),
-        handle_csv("experimental/miscellaneous.csv"),
+        handle_csv(
+            "experimental/miscellaneous.csv",
+            allow_unknown_values=True,
+            default_list_name="phrase_terminator",
+        ),
         # ---
         handle_csv(
             "experimental/actions_custom.csv",


### PR DESCRIPTION
Read from deprecated snippet csv files if the exists, but do not create them if they don't.

Fixes #2841

