### PR TITLE
Update `failedTests.properties` on success

### DIFF
--- a/packages/test-harness/src/runAllTests.ts
+++ b/packages/test-harness/src/runAllTests.ts
@@ -77,10 +77,11 @@ async function runTestsInDir(
       const failedTests: string[] = [];
 
       const runner = mocha.run((failures) => {
+        if (shouldLogFailedTests()) {
+          logFailedTests(failedTests);
+        }
+
         if (failures > 0) {
-          if (shouldLogFailedTests()) {
-            logFailedTests(failedTests);
-          }
           reject(`${failures} tests failed.`);
         } else {
           resolve();


### PR DESCRIPTION
I got tricked by `failedTests.properties` not updating when tests were successful.