### PR TITLE
Don't discard nodes with non adjacent error siblings

### DIFF
--- a/data/fixtures/recorded/surroundingPair/changePair.yml
+++ b/data/fixtures/recorded/surroundingPair/changePair.yml
@@ -1,0 +1,25 @@
+languageId: typescriptreact
+command:
+  version: 7
+  spokenForm: change pair
+  action:
+    name: clearAndSetSelection
+    target:
+      type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: surroundingPair, delimiter: any}
+  usePrePhraseSnapshot: false
+initialState:
+  documentContents: |
+    <div bbb={() => null}>hello &</div>
+  selections:
+    - anchor: {line: 0, character: 14}
+      active: {line: 0, character: 14}
+  marks: {}
+finalState:
+  documentContents: |
+    <div bbb=>hello &</div>
+  selections:
+    - anchor: {line: 0, character: 9}
+      active: {line: 0, character: 9}

--- a/packages/cursorless-engine/src/languages/TreeSitterQuery/isContainedInErrorNode.ts
+++ b/packages/cursorless-engine/src/languages/TreeSitterQuery/isContainedInErrorNode.ts
@@ -6,27 +6,35 @@ import type { SyntaxNode } from "web-tree-sitter";
  * @returns True if the given node is contained in an error node
  */
 export function isContainedInErrorNode(node: SyntaxNode) {
+  // This node or one of it descendants is an error node
   if (node.hasError) {
     return true;
   }
 
-  let currentNode: SyntaxNode | null = node.parent;
+  let ancestorNode: SyntaxNode | null = node.parent;
 
-  while (currentNode != null) {
-    // Ancestral node has errors, but it was not siblings to the previous node
-    // that caused the problem. We don't want to discard a node when a sibling
-    // that isn't adjacent is erroring.
-    if (currentNode.hasError) {
+  while (ancestorNode != null) {
+    // Ancestral node is an error node
+    if (ancestorNode.isError) {
+      return true;
+    }
+
+    // Ancestral node has errors, but it was not siblings to the previous node.
+    // We don't want to discard a node when a sibling that isn't adjacent is
+    // erroring.
+    if (ancestorNode.hasError) {
       return false;
     }
+
     // A adjacent sibling node was causing the problem. ie we are right next to the error node.
     if (
-      currentNode.previousSibling?.isError ||
-      currentNode.nextSibling?.isError
+      ancestorNode.previousSibling?.isError ||
+      ancestorNode.nextSibling?.isError
     ) {
       return true;
     }
-    currentNode = currentNode.parent;
+
+    ancestorNode = ancestorNode.parent;
   }
 
   return false;

--- a/packages/cursorless-engine/src/languages/TreeSitterQuery/isContainedInErrorNode.ts
+++ b/packages/cursorless-engine/src/languages/TreeSitterQuery/isContainedInErrorNode.ts
@@ -6,10 +6,24 @@ import type { SyntaxNode } from "web-tree-sitter";
  * @returns True if the given node is contained in an error node
  */
 export function isContainedInErrorNode(node: SyntaxNode) {
-  let currentNode: SyntaxNode | null = node;
+  if (node.hasError) {
+    return true;
+  }
+
+  let currentNode: SyntaxNode | null = node.parent;
 
   while (currentNode != null) {
+    // Ancestral node has errors, but it was not siblings to the previous node
+    // that caused the problem. We don't want to discard a node when a sibling
+    // that isn't adjacent is erroring.
     if (currentNode.hasError) {
+      return false;
+    }
+    // A adjacent sibling node was causing the problem. ie we are right next to the error node.
+    if (
+      currentNode.previousSibling?.isError ||
+      currentNode.nextSibling?.isError
+    ) {
       return true;
     }
     currentNode = currentNode.parent;


### PR DESCRIPTION
Today we discard parse tree nodes if any of the ancestral nodes has a error. That means that any of the ancestral nodes has a descendant that is an error node. That could be something a hundred lines below that isn't really relevant to the node we are evaluating. This updates changes so we only look at error nodes that are adjacent to our ascending path.