### PR TITLE
Update HaaLeo/publish-vscode-extension action version

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -43,13 +43,13 @@ jobs:
 
       - name: Publish to Open VSX Registry
         id: publishToOpenVSX
-        uses: HaaLeo/publish-vscode-extension@v1
+        uses: HaaLeo/publish-vscode-extension@v2
         with:
           pat: ${{ secrets.OPEN_VSX_TOKEN }}
           packagePath: packages/cursorless-vscode/dist
 
       - name: Publish to Visual Studio Marketplace
-        uses: HaaLeo/publish-vscode-extension@v1
+        uses: HaaLeo/publish-vscode-extension@v2
         with:
           pat: ${{ secrets.VS_MARKETPLACE_TOKEN }}
           registryUrl: https://marketplace.visualstudio.com

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -114,7 +114,7 @@ jobs:
 
       - name: Test create vsix
         id: createVsix
-        uses: HaaLeo/publish-vscode-extension@v1
+        uses: HaaLeo/publish-vscode-extension@v2
         with:
           pat: none
           packagePath: packages/cursorless-vscode/dist


### PR DESCRIPTION
Currently this action is failing in ci.
https://github.com/cursorless-dev/cursorless/actions/runs/13525259964/job/37794066786#step:21:34

Hopefully updating to the latest version will fix this.