### PR TITLE
Move the initializer into the constructor for instance members that r…

### DIFF
--- a/packages/cursorless-engine/src/actions/Actions.ts
+++ b/packages/cursorless-engine/src/actions/Actions.ts
@@ -200,7 +200,7 @@ export class Actions implements ActionRecord {
   deselect;
   editNew;
   editNewLineAfter: EditNewAfter;
-  editNewLineBefore: EditNewBefore;  );
+  editNewLineBefore: EditNewBefore;
   executeCommand;
   extractVariable;
   findInDocument;

--- a/packages/cursorless-engine/src/actions/Actions.ts
+++ b/packages/cursorless-engine/src/actions/Actions.ts
@@ -90,11 +90,11 @@ export class Actions implements ActionRecord {
   this.decrement = new Decrement(this);
   this.deselect = new Deselect();
   this.editNew = new EditNew(this.rangeUpdater, this);
-  this.editNewLineAfter: EditNewAfter = new EditNewAfter(
+  this.editNewLineAfter = new EditNewAfter(
     this,
     this.modifierStageFactory,
   );
-  this.editNewLineBefore: EditNewBefore = new EditNewBefore(
+  this.editNewLineBefore = new EditNewBefore(
     this,
     this.modifierStageFactory,
   );

--- a/packages/cursorless-engine/src/actions/Actions.ts
+++ b/packages/cursorless-engine/src/actions/Actions.ts
@@ -79,113 +79,184 @@ export class Actions implements ActionRecord {
     private snippets: Snippets,
     private rangeUpdater: RangeUpdater,
     private modifierStageFactory: ModifierStageFactory,
-  ) {}
-
-  addSelection = new AddSelection();
-  addSelectionBefore = new AddSelectionBefore();
-  addSelectionAfter = new AddSelectionAfter();
-  callAsFunction = new Call(this);
-  clearAndSetSelection = new Clear(this);
-  copyToClipboard = new CopyToClipboard(this, this.rangeUpdater);
-  cutToClipboard = new CutToClipboard(this);
-  decrement = new Decrement(this);
-  deselect = new Deselect();
-  editNew = new EditNew(this.rangeUpdater, this);
-  editNewLineAfter: EditNewAfter = new EditNewAfter(
+  ) {
+  this.addSelection = new AddSelection();
+  this.addSelectionBefore = new AddSelectionBefore();
+  this.addSelectionAfter = new AddSelectionAfter();
+  this.callAsFunction = new Call(this);
+  this.clearAndSetSelection = new Clear(this);
+  this.copyToClipboard = new CopyToClipboard(this, this.rangeUpdater);
+  this.cutToClipboard = new CutToClipboard(this);
+  this.decrement = new Decrement(this);
+  this.deselect = new Deselect();
+  this.editNew = new EditNew(this.rangeUpdater, this);
+  this.editNewLineAfter: EditNewAfter = new EditNewAfter(
     this,
     this.modifierStageFactory,
   );
-  editNewLineBefore: EditNewBefore = new EditNewBefore(
+  this.editNewLineBefore: EditNewBefore = new EditNewBefore(
     this,
     this.modifierStageFactory,
   );
-  executeCommand = new ExecuteCommand(this.rangeUpdater);
-  extractVariable = new ExtractVariable(this.rangeUpdater);
-  findInDocument = new FindInDocument(this);
-  findInWorkspace = new FindInWorkspace(this);
-  flashTargets = new FlashTargets();
-  foldRegion = new Fold(this.rangeUpdater);
-  followLink = new FollowLink({ openAside: false });
-  followLinkAside = new FollowLink({ openAside: true });
-  generateSnippet = new GenerateSnippet(this.snippets);
-  getText = new GetText();
-  gitAccept = new GitAccept(this.rangeUpdater);
-  gitRevert = new GitRevert(this.rangeUpdater);
-  gitStage = new GitStage(this.rangeUpdater);
-  gitUnstage = new GitUnstage(this.rangeUpdater);
-  highlight = new Highlight();
-  increment = new Increment(this);
-  indentLine = new IndentLine(this.rangeUpdater);
-  insertCopyAfter = new InsertCopyAfter(
+  this.executeCommand = new ExecuteCommand(this.rangeUpdater);
+  this.extractVariable = new ExtractVariable(this.rangeUpdater);
+  this.findInDocument = new FindInDocument(this);
+  this.findInWorkspace = new FindInWorkspace(this);
+  this.flashTargets = new FlashTargets();
+  this.foldRegion = new Fold(this.rangeUpdater);
+  this.followLink = new FollowLink({ openAside: false });
+  this.followLinkAside = new FollowLink({ openAside: true });
+  this.generateSnippet = new GenerateSnippet(this.snippets);
+  this.getText = new GetText();
+  this.gitAccept = new GitAccept(this.rangeUpdater);
+  this.gitRevert = new GitRevert(this.rangeUpdater);
+  this.gitStage = new GitStage(this.rangeUpdater);
+  this.gitUnstage = new GitUnstage(this.rangeUpdater);
+  this.highlight = new Highlight();
+  this.increment = new Increment(this);
+  this.indentLine = new IndentLine(this.rangeUpdater);
+  this.insertCopyAfter = new InsertCopyAfter(
     this.rangeUpdater,
     this.modifierStageFactory,
   );
-  insertCopyBefore = new InsertCopyBefore(
+  this.insertCopyBefore = new InsertCopyBefore(
     this.rangeUpdater,
     this.modifierStageFactory,
   );
-  insertEmptyLineAfter = new InsertEmptyLineAfter(
+  this.insertEmptyLineAfter = new InsertEmptyLineAfter(
     this.rangeUpdater,
     this.modifierStageFactory,
   );
-  insertEmptyLineBefore = new InsertEmptyLineBefore(
+  this.insertEmptyLineBefore = new InsertEmptyLineBefore(
     this.rangeUpdater,
     this.modifierStageFactory,
   );
-  insertEmptyLinesAround = new InsertEmptyLinesAround(
+  this.insertEmptyLinesAround = new InsertEmptyLinesAround(
     this.rangeUpdater,
     this.modifierStageFactory,
   );
-  insertSnippet = new InsertSnippet(
+  this.insertSnippet = new InsertSnippet(
     this.rangeUpdater,
     this.snippets,
     this,
     this.modifierStageFactory,
   );
-  joinLines = new JoinLines(this.rangeUpdater, this.modifierStageFactory);
-  breakLine = new BreakLine(this.rangeUpdater);
-  moveToTarget = new Move(this.rangeUpdater);
-  outdentLine = new OutdentLine(this.rangeUpdater);
-  pasteFromClipboard = new PasteFromClipboard(this.rangeUpdater, this);
-  randomizeTargets = new Random(this);
-  remove = new Remove(this.rangeUpdater);
-  rename = new Rename(this.rangeUpdater);
-  replace = new Replace(this.rangeUpdater);
-  replaceWithTarget = new Bring(this.rangeUpdater);
-  revealDefinition = new RevealDefinition(this.rangeUpdater);
-  revealTypeDefinition = new RevealTypeDefinition(this.rangeUpdater);
-  reverseTargets = new Reverse(this);
-  rewrapWithPairedDelimiter = new Rewrap(
+  this.joinLines = new JoinLines(this.rangeUpdater, this.modifierStageFactory);
+  this.breakLine = new BreakLine(this.rangeUpdater);
+  this.moveToTarget = new Move(this.rangeUpdater);
+  this.outdentLine = new OutdentLine(this.rangeUpdater);
+  this.pasteFromClipboard = new PasteFromClipboard(this.rangeUpdater, this);
+  this.randomizeTargets = new Random(this);
+  this.remove = new Remove(this.rangeUpdater);
+  this.rename = new Rename(this.rangeUpdater);
+  this.replace = new Replace(this.rangeUpdater);
+  this.replaceWithTarget = new Bring(this.rangeUpdater);
+  this.revealDefinition = new RevealDefinition(this.rangeUpdater);
+  this.revealTypeDefinition = new RevealTypeDefinition(this.rangeUpdater);
+  this.reverseTargets = new Reverse(this);
+  this.rewrapWithPairedDelimiter = new Rewrap(
     this.rangeUpdater,
     this.modifierStageFactory,
   );
-  scrollToBottom = new ScrollToBottom();
-  scrollToCenter = new ScrollToCenter();
-  scrollToTop = new ScrollToTop();
-  setSelection = new SetSelection();
-  setSelectionAfter = new SetSelectionAfter();
-  setSelectionBefore = new SetSelectionBefore();
-  showDebugHover = new ShowDebugHover(this.rangeUpdater);
-  showHover = new ShowHover(this.rangeUpdater);
-  showQuickFix = new ShowQuickFix(this.rangeUpdater);
-  showReferences = new ShowReferences(this.rangeUpdater);
-  sortTargets = new Sort(this);
-  swapTargets = new Swap(this.rangeUpdater);
-  toggleLineBreakpoint = new ToggleBreakpoint(this.modifierStageFactory);
-  toggleLineComment = new ToggleLineComment(this.rangeUpdater);
-  unfoldRegion = new Unfold(this.rangeUpdater);
-  wrapWithPairedDelimiter = new Wrap(this.rangeUpdater);
-  wrapWithSnippet = new WrapWithSnippet(
+  this.scrollToBottom = new ScrollToBottom();
+  this.scrollToCenter = new ScrollToCenter();
+  this.scrollToTop = new ScrollToTop();
+  this.setSelection = new SetSelection();
+  this.setSelectionAfter = new SetSelectionAfter();
+  this.setSelectionBefore = new SetSelectionBefore();
+  this.showDebugHover = new ShowDebugHover(this.rangeUpdater);
+  this.showHover = new ShowHover(this.rangeUpdater);
+  this.showQuickFix = new ShowQuickFix(this.rangeUpdater);
+  this.showReferences = new ShowReferences(this.rangeUpdater);
+  this.sortTargets = new Sort(this);
+  this.swapTargets = new Swap(this.rangeUpdater);
+  this.toggleLineBreakpoint = new ToggleBreakpoint(this.modifierStageFactory);
+  this.toggleLineComment = new ToggleLineComment(this.rangeUpdater);
+  this.unfoldRegion = new Unfold(this.rangeUpdater);
+  this.wrapWithPairedDelimiter = new Wrap(this.rangeUpdater);
+  this.wrapWithSnippet = new WrapWithSnippet(
     this.rangeUpdater,
     this.snippets,
     this.modifierStageFactory,
   );
 
-  ["experimental.setInstanceReference"] = new SetSpecialTarget(
+  this.["experimental.setInstanceReference"] = new SetSpecialTarget(
     "instanceReference",
   );
 
-  ["private.showParseTree"] = new ShowParseTree(this.treeSitter);
-  ["private.getTargets"] = new GetTargets();
-  ["private.setKeyboardTarget"] = new SetSpecialTarget("keyboard");
+  this.["private.showParseTree"] = new ShowParseTree(this.treeSitter);
+  this.["private.getTargets"] = new GetTargets();
+  this.["private.setKeyboardTarget"] = new SetSpecialTarget("keyboard");
+  }
+
+  addSelection;
+  addSelectionBefore;
+  addSelectionAfter;
+  callAsFunction;
+  clearAndSetSelection;
+  copyToClipboard;
+  cutToClipboard;
+  decrement;
+  deselect;
+  editNew;
+  editNewLineAfter: EditNewAfter;
+  editNewLineBefore: EditNewBefore;  );
+  executeCommand;
+  extractVariable;
+  findInDocument;
+  findInWorkspace;
+  flashTargets;
+  foldRegion;
+  followLink;
+  followLinkAside;
+  generateSnippet;
+  getText;
+  gitAccept;
+  gitRevert;
+  gitStage;
+  gitUnstage;
+  highlight;
+  increment;
+  indentLine;
+  insertCopyAfter;
+  insertCopyBefore;
+  insertEmptyLineAfter;
+  insertEmptyLineBefore;
+  insertEmptyLinesAround;
+  insertSnippet;
+  joinLines;
+  breakLine;
+  moveToTarget;
+  outdentLine;
+  pasteFromClipboard;
+  randomizeTargets;
+  remove;
+  rename;
+  replace;
+  replaceWithTarget;
+  revealDefinition;
+  revealTypeDefinition;
+  reverseTargets;
+  rewrapWithPairedDelimiter;
+  scrollToBottom;
+  scrollToCenter;
+  scrollToTop;
+  setSelection;
+  setSelectionAfter;
+  setSelectionBefore;
+  showDebugHover;
+  showHover;
+  showQuickFix;
+  showReferences;
+  sortTargets;
+  swapTargets;
+  toggleLineBreakpoint;
+  toggleLineComment;
+  unfoldRegion;
+  wrapWithPairedDelimiter;
+  wrapWithSnippet;
+  ["experimental.setInstanceReference"];
+  ["private.showParseTree"];
+  ["private.getTargets"];
+  ["private.setKeyboardTarget"];
 }

--- a/packages/cursorless-engine/src/actions/Actions.ts
+++ b/packages/cursorless-engine/src/actions/Actions.ts
@@ -180,13 +180,13 @@ export class Actions implements ActionRecord {
     this.modifierStageFactory,
   );
 
-  this.["experimental.setInstanceReference"] = new SetSpecialTarget(
+  this["experimental.setInstanceReference"] = new SetSpecialTarget(
     "instanceReference",
   );
 
-  this.["private.showParseTree"] = new ShowParseTree(this.treeSitter);
-  this.["private.getTargets"] = new GetTargets();
-  this.["private.setKeyboardTarget"] = new SetSpecialTarget("keyboard");
+  this["private.showParseTree"] = new ShowParseTree(this.treeSitter);
+  this["private.getTargets"] = new GetTargets();
+  this["private.setKeyboardTarget"] = new SetSpecialTarget("keyboard");
   }
 
   addSelection;

--- a/packages/cursorless-engine/src/actions/Actions.ts
+++ b/packages/cursorless-engine/src/actions/Actions.ts
@@ -75,118 +75,112 @@ import { Decrement, Increment } from "./incrementDecrement";
  */
 export class Actions implements ActionRecord {
   constructor(
-    private treeSitter: TreeSitter,
-    private snippets: Snippets,
-    private rangeUpdater: RangeUpdater,
-    private modifierStageFactory: ModifierStageFactory,
+    treeSitter: TreeSitter,
+    snippets: Snippets,
+    rangeUpdater: RangeUpdater,
+    modifierStageFactory: ModifierStageFactory,
   ) {
-  this.addSelection = new AddSelection();
-  this.addSelectionBefore = new AddSelectionBefore();
-  this.addSelectionAfter = new AddSelectionAfter();
-  this.callAsFunction = new Call(this);
-  this.clearAndSetSelection = new Clear(this);
-  this.copyToClipboard = new CopyToClipboard(this, this.rangeUpdater);
-  this.cutToClipboard = new CutToClipboard(this);
-  this.decrement = new Decrement(this);
-  this.deselect = new Deselect();
-  this.editNew = new EditNew(this.rangeUpdater, this);
-  this.editNewLineAfter = new EditNewAfter(
-    this,
-    this.modifierStageFactory,
-  );
-  this.editNewLineBefore = new EditNewBefore(
-    this,
-    this.modifierStageFactory,
-  );
-  this.executeCommand = new ExecuteCommand(this.rangeUpdater);
-  this.extractVariable = new ExtractVariable(this.rangeUpdater);
-  this.findInDocument = new FindInDocument(this);
-  this.findInWorkspace = new FindInWorkspace(this);
-  this.flashTargets = new FlashTargets();
-  this.foldRegion = new Fold(this.rangeUpdater);
-  this.followLink = new FollowLink({ openAside: false });
-  this.followLinkAside = new FollowLink({ openAside: true });
-  this.generateSnippet = new GenerateSnippet(this.snippets);
-  this.getText = new GetText();
-  this.gitAccept = new GitAccept(this.rangeUpdater);
-  this.gitRevert = new GitRevert(this.rangeUpdater);
-  this.gitStage = new GitStage(this.rangeUpdater);
-  this.gitUnstage = new GitUnstage(this.rangeUpdater);
-  this.highlight = new Highlight();
-  this.increment = new Increment(this);
-  this.indentLine = new IndentLine(this.rangeUpdater);
-  this.insertCopyAfter = new InsertCopyAfter(
-    this.rangeUpdater,
-    this.modifierStageFactory,
-  );
-  this.insertCopyBefore = new InsertCopyBefore(
-    this.rangeUpdater,
-    this.modifierStageFactory,
-  );
-  this.insertEmptyLineAfter = new InsertEmptyLineAfter(
-    this.rangeUpdater,
-    this.modifierStageFactory,
-  );
-  this.insertEmptyLineBefore = new InsertEmptyLineBefore(
-    this.rangeUpdater,
-    this.modifierStageFactory,
-  );
-  this.insertEmptyLinesAround = new InsertEmptyLinesAround(
-    this.rangeUpdater,
-    this.modifierStageFactory,
-  );
-  this.insertSnippet = new InsertSnippet(
-    this.rangeUpdater,
-    this.snippets,
-    this,
-    this.modifierStageFactory,
-  );
-  this.joinLines = new JoinLines(this.rangeUpdater, this.modifierStageFactory);
-  this.breakLine = new BreakLine(this.rangeUpdater);
-  this.moveToTarget = new Move(this.rangeUpdater);
-  this.outdentLine = new OutdentLine(this.rangeUpdater);
-  this.pasteFromClipboard = new PasteFromClipboard(this.rangeUpdater, this);
-  this.randomizeTargets = new Random(this);
-  this.remove = new Remove(this.rangeUpdater);
-  this.rename = new Rename(this.rangeUpdater);
-  this.replace = new Replace(this.rangeUpdater);
-  this.replaceWithTarget = new Bring(this.rangeUpdater);
-  this.revealDefinition = new RevealDefinition(this.rangeUpdater);
-  this.revealTypeDefinition = new RevealTypeDefinition(this.rangeUpdater);
-  this.reverseTargets = new Reverse(this);
-  this.rewrapWithPairedDelimiter = new Rewrap(
-    this.rangeUpdater,
-    this.modifierStageFactory,
-  );
-  this.scrollToBottom = new ScrollToBottom();
-  this.scrollToCenter = new ScrollToCenter();
-  this.scrollToTop = new ScrollToTop();
-  this.setSelection = new SetSelection();
-  this.setSelectionAfter = new SetSelectionAfter();
-  this.setSelectionBefore = new SetSelectionBefore();
-  this.showDebugHover = new ShowDebugHover(this.rangeUpdater);
-  this.showHover = new ShowHover(this.rangeUpdater);
-  this.showQuickFix = new ShowQuickFix(this.rangeUpdater);
-  this.showReferences = new ShowReferences(this.rangeUpdater);
-  this.sortTargets = new Sort(this);
-  this.swapTargets = new Swap(this.rangeUpdater);
-  this.toggleLineBreakpoint = new ToggleBreakpoint(this.modifierStageFactory);
-  this.toggleLineComment = new ToggleLineComment(this.rangeUpdater);
-  this.unfoldRegion = new Unfold(this.rangeUpdater);
-  this.wrapWithPairedDelimiter = new Wrap(this.rangeUpdater);
-  this.wrapWithSnippet = new WrapWithSnippet(
-    this.rangeUpdater,
-    this.snippets,
-    this.modifierStageFactory,
-  );
+    this.addSelection = new AddSelection();
+    this.addSelectionBefore = new AddSelectionBefore();
+    this.addSelectionAfter = new AddSelectionAfter();
+    this.callAsFunction = new Call(this);
+    this.clearAndSetSelection = new Clear(this);
+    this.copyToClipboard = new CopyToClipboard(this, rangeUpdater);
+    this.cutToClipboard = new CutToClipboard(this);
+    this.decrement = new Decrement(this);
+    this.deselect = new Deselect();
+    this.editNew = new EditNew(rangeUpdater, this);
+    this.editNewLineAfter = new EditNewAfter(this, modifierStageFactory);
+    this.editNewLineBefore = new EditNewBefore(this, modifierStageFactory);
+    this.executeCommand = new ExecuteCommand(rangeUpdater);
+    this.extractVariable = new ExtractVariable(rangeUpdater);
+    this.findInDocument = new FindInDocument(this);
+    this.findInWorkspace = new FindInWorkspace(this);
+    this.flashTargets = new FlashTargets();
+    this.foldRegion = new Fold(rangeUpdater);
+    this.followLink = new FollowLink({ openAside: false });
+    this.followLinkAside = new FollowLink({ openAside: true });
+    this.generateSnippet = new GenerateSnippet(snippets);
+    this.getText = new GetText();
+    this.gitAccept = new GitAccept(rangeUpdater);
+    this.gitRevert = new GitRevert(rangeUpdater);
+    this.gitStage = new GitStage(rangeUpdater);
+    this.gitUnstage = new GitUnstage(rangeUpdater);
+    this.highlight = new Highlight();
+    this.increment = new Increment(this);
+    this.indentLine = new IndentLine(rangeUpdater);
+    this.insertCopyAfter = new InsertCopyAfter(
+      rangeUpdater,
+      modifierStageFactory,
+    );
+    this.insertCopyBefore = new InsertCopyBefore(
+      rangeUpdater,
+      modifierStageFactory,
+    );
+    this.insertEmptyLineAfter = new InsertEmptyLineAfter(
+      rangeUpdater,
+      modifierStageFactory,
+    );
+    this.insertEmptyLineBefore = new InsertEmptyLineBefore(
+      rangeUpdater,
+      modifierStageFactory,
+    );
+    this.insertEmptyLinesAround = new InsertEmptyLinesAround(
+      rangeUpdater,
+      modifierStageFactory,
+    );
+    this.insertSnippet = new InsertSnippet(
+      rangeUpdater,
+      snippets,
+      this,
+      modifierStageFactory,
+    );
+    this.joinLines = new JoinLines(rangeUpdater, modifierStageFactory);
+    this.breakLine = new BreakLine(rangeUpdater);
+    this.moveToTarget = new Move(rangeUpdater);
+    this.outdentLine = new OutdentLine(rangeUpdater);
+    this.pasteFromClipboard = new PasteFromClipboard(rangeUpdater, this);
+    this.randomizeTargets = new Random(this);
+    this.remove = new Remove(rangeUpdater);
+    this.rename = new Rename(rangeUpdater);
+    this.replace = new Replace(rangeUpdater);
+    this.replaceWithTarget = new Bring(rangeUpdater);
+    this.revealDefinition = new RevealDefinition(rangeUpdater);
+    this.revealTypeDefinition = new RevealTypeDefinition(rangeUpdater);
+    this.reverseTargets = new Reverse(this);
+    this.rewrapWithPairedDelimiter = new Rewrap(
+      rangeUpdater,
+      modifierStageFactory,
+    );
+    this.scrollToBottom = new ScrollToBottom();
+    this.scrollToCenter = new ScrollToCenter();
+    this.scrollToTop = new ScrollToTop();
+    this.setSelection = new SetSelection();
+    this.setSelectionAfter = new SetSelectionAfter();
+    this.setSelectionBefore = new SetSelectionBefore();
+    this.showDebugHover = new ShowDebugHover(rangeUpdater);
+    this.showHover = new ShowHover(rangeUpdater);
+    this.showQuickFix = new ShowQuickFix(rangeUpdater);
+    this.showReferences = new ShowReferences(rangeUpdater);
+    this.sortTargets = new Sort(this);
+    this.swapTargets = new Swap(rangeUpdater);
+    this.toggleLineBreakpoint = new ToggleBreakpoint(modifierStageFactory);
+    this.toggleLineComment = new ToggleLineComment(rangeUpdater);
+    this.unfoldRegion = new Unfold(rangeUpdater);
+    this.wrapWithPairedDelimiter = new Wrap(rangeUpdater);
+    this.wrapWithSnippet = new WrapWithSnippet(
+      rangeUpdater,
+      snippets,
+      modifierStageFactory,
+    );
 
-  this["experimental.setInstanceReference"] = new SetSpecialTarget(
-    "instanceReference",
-  );
+    this["experimental.setInstanceReference"] = new SetSpecialTarget(
+      "instanceReference",
+    );
 
-  this["private.showParseTree"] = new ShowParseTree(this.treeSitter);
-  this["private.getTargets"] = new GetTargets();
-  this["private.setKeyboardTarget"] = new SetSpecialTarget("keyboard");
+    this["private.showParseTree"] = new ShowParseTree(treeSitter);
+    this["private.getTargets"] = new GetTargets();
+    this["private.setKeyboardTarget"] = new SetSpecialTarget("keyboard");
   }
 
   addSelection;


### PR DESCRIPTION
…eference identifiers declared in the constructor.

When TypeScript outputs modern language features, the below case throws an TS error.

class C {
  a = this.x; // TS2729: Property 'x' is used before its initialization.

  constructor(public x:number){}
}
This error is fixed by moving the initializer of such class members into the constructor.

This is a no-op change. This change came from Google.