### PR TITLE
Pin vscode version in CI for windows

### DIFF
--- a/packages/test-harness/src/launchVscodeAndRunTests.ts
+++ b/packages/test-harness/src/launchVscodeAndRunTests.ts
@@ -36,7 +36,7 @@ export async function launchVscodeAndRunTests(extensionTestsPath: string) {
     // we don't have to update the branch protection rules every time we bump
     // the legacy VSCode version.
 
-    const vscodeVersion = useLegacyVscode ? "1.82.0" : "stable";
+    const vscodeVersion = useLegacyVscode ? "1.82.0" : "1.97.2";
     const vscodeExecutablePath = await downloadAndUnzipVSCode(vscodeVersion);
     const [cli, ...args] =
       resolveCliArgsFromVSCodeExecutablePath(vscodeExecutablePath);

--- a/packages/test-harness/src/launchVscodeAndRunTests.ts
+++ b/packages/test-harness/src/launchVscodeAndRunTests.ts
@@ -36,14 +36,7 @@ export async function launchVscodeAndRunTests(extensionTestsPath: string) {
     // we don't have to update the branch protection rules every time we bump
     // the legacy VSCode version.
 
-    // NB: Because of a CI crashing issue the vscode version is pinned.
-    // https://github.com/cursorless-dev/cursorless/issues/2878
-
-    const vscodeVersion = useLegacyVscode
-      ? "1.82.0"
-      : os.platform() === "win32"
-        ? "stable"
-        : "1.97.2";
+    const vscodeVersion = useLegacyVscode ? "1.82.0" : "stable";
     const vscodeExecutablePath = await downloadAndUnzipVSCode(vscodeVersion);
     const [cli, ...args] =
       resolveCliArgsFromVSCodeExecutablePath(vscodeExecutablePath);

--- a/packages/test-harness/src/launchVscodeAndRunTests.ts
+++ b/packages/test-harness/src/launchVscodeAndRunTests.ts
@@ -36,6 +36,9 @@ export async function launchVscodeAndRunTests(extensionTestsPath: string) {
     // we don't have to update the branch protection rules every time we bump
     // the legacy VSCode version.
 
+    // NB: Because of a CI crashing issue the vscode version is pinned.
+    // https://github.com/cursorless-dev/cursorless/issues/2878
+
     const vscodeVersion = useLegacyVscode ? "1.82.0" : "1.97.2";
     const vscodeExecutablePath = await downloadAndUnzipVSCode(vscodeVersion);
     const [cli, ...args] =


### PR DESCRIPTION
We had already pinned the version for mac and Linux: https://github.com/cursorless-dev/cursorless/issues/2878 but it appears that we have the same problem on windows its just crashing with error code 0 which means our test runner wasn't signalling the failure.


Test run crashes on windows with false negative.
https://github.com/cursorless-dev/cursorless/actions/runs/14509376075/job/40704611423?pr=2893

It appears that it's `vscode.window.showTextDocument` in our `openNewEditor` utility that causes this. It's not always on the same test case. By default it crashes in the scope tests, but if I disable the scope test the same error occurs in our recorded tests that of course uses the same `openNewEditor` function. I can't recreate this locally. Looks like a memory leak or similar.
