### PR TITLE
Hide output from visible text editors

### DIFF
--- a/packages/cursorless-vscode/src/ide/vscode/VscodeIDE.ts
+++ b/packages/cursorless-vscode/src/ide/vscode/VscodeIDE.ts
@@ -116,7 +116,9 @@ export class VscodeIDE implements IDE {
   }
 
   get visibleTextEditors(): VscodeTextEditorImpl[] {
-    return window.visibleTextEditors.map((e) => this.fromVscodeEditor(e));
+    return window.visibleTextEditors
+      .filter((e) => e.document.uri.scheme !== "output")
+      .map((e) => this.fromVscodeEditor(e));
   }
 
   get visibleNotebookEditors(): NotebookEditor[] {


### PR DESCRIPTION
Today we waste hats on the output which shouldn't really be a text editor  