### PR TITLE
Added Cursorless icon to contributed views

### DIFF
--- a/packages/cursorless-vscode/package.json
+++ b/packages/cursorless-vscode/package.json
@@ -59,11 +59,13 @@
         {
           "type": "webview",
           "id": "cursorless.tutorial",
-          "name": "Tutorial"
+          "name": "Tutorial",
+          "icon": "images/logo.svg"
         },
         {
           "id": "cursorless.scopes",
-          "name": "Scopes"
+          "name": "Scopes",
+          "icon": "images/logo.svg"
         }
       ]
     },


### PR DESCRIPTION
Right now we get warnings about the icon's missing. Note that these icons are only used if you drag the view away from our Cursorless side panel and peanut as its own panel in the side bar. This is very unlikely and this is mostly to get rid of the warning    