### PR TITLE
Update insertion delimiter for document scope

### DIFF
--- a/data/fixtures/recorded/positions/bringHarpToAfterFile.yml
+++ b/data/fixtures/recorded/positions/bringHarpToAfterFile.yml
@@ -28,6 +28,7 @@ initialState:
 finalState:
   documentContents: |-
     hello world
+
     hello
   selections:
     - anchor: {line: 0, character: 0}

--- a/data/fixtures/recorded/positions/bringWhaleToBeforeFile.yml
+++ b/data/fixtures/recorded/positions/bringWhaleToBeforeFile.yml
@@ -28,7 +28,8 @@ initialState:
 finalState:
   documentContents: |-
     world
+
     hello world
   selections:
-    - anchor: {line: 1, character: 0}
-      active: {line: 1, character: 0}
+    - anchor: {line: 2, character: 0}
+      active: {line: 2, character: 0}

--- a/data/fixtures/recorded/selectionTypes/bringHarpToAfterFile.yml
+++ b/data/fixtures/recorded/selectionTypes/bringHarpToAfterFile.yml
@@ -28,6 +28,7 @@ initialState:
 finalState:
   documentContents: |-
     hello world
+
     hello
   selections:
     - anchor: {line: 0, character: 11}

--- a/data/fixtures/recorded/selectionTypes/bringWhaleToBeforeFile.yml
+++ b/data/fixtures/recorded/selectionTypes/bringWhaleToBeforeFile.yml
@@ -28,7 +28,8 @@ initialState:
 finalState:
   documentContents: |-
     world
+
     hello world
   selections:
-    - anchor: {line: 1, character: 11}
-      active: {line: 1, character: 11}
+    - anchor: {line: 2, character: 11}
+      active: {line: 2, character: 11}

--- a/data/fixtures/scopes/textual/document.scope
+++ b/data/fixtures/scopes/textual/document.scope
@@ -29,4 +29,4 @@ ccc
 5| ccc
    ---<
 
-[Insertion delimiter] = "\n"
+[Insertion delimiter] = "\n\n"

--- a/packages/cursorless-engine/src/processTargets/targets/DocumentTarget.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/DocumentTarget.ts
@@ -7,7 +7,7 @@ import { PlainTarget } from "./PlainTarget";
 export class DocumentTarget extends BaseTarget<CommonTargetParameters> {
   type = "DocumentTarget";
   textualType: TextualType = "line";
-  insertionDelimiter = "\n";
+  insertionDelimiter = "\n\n";
 
   constructor(parameters: CommonTargetParameters) {
     super(parameters);


### PR DESCRIPTION
Got tired of how often I need to say `"pour file slap"`. Also that the document should have a smaller insertion delimiter compared to a function is bit weird.