### PR TITLE
Allow snippet insertion with a language unsupported by VSCode

### DIFF
--- a/cursorless-talon/src/snippets/snippets.py
+++ b/cursorless-talon/src/snippets/snippets.py
@@ -106,7 +106,17 @@ class UserActions:
             get_list_insertion_snippet(name, substitutions),
             ImplicitDestination(),
         )
-        actions.user.private_cursorless_command_and_wait(action)
+        try:
+            actions.user.private_cursorless_command_and_wait(action)
+        except Exception as e:
+            if str(e).startswith("No snippet available for language"):
+                action = InsertSnippetAction(
+                    get_insertion_snippet(name, substitutions),
+                    ImplicitDestination(),
+                )
+                actions.user.private_cursorless_command_and_wait(action)
+            else:
+                raise
 
     def private_cursorless_insert_community_snippet(
         name: str,  # pyright: ignore [reportGeneralTypeIssues]


### PR DESCRIPTION
As discussed on the community backlog session today.

It turns out that Cursorless already has support for inserting snippets when you have a forced language, but not when VSCode doesn't support the language that Talon thinks you're using (e.g. via an extension map).

```python
2025-06-14 13:56:05.190    IO > snip if
2025-06-14 13:56:05.212    IO exception: e=Exception("No snippet available for language '...'. Available languages: c, cpp, csharp, elixir, go, java, javascript, javascriptreact, kotlin, lua, php, python, r, ruby, rust, scala, stata, typescript, typescriptreact, vimscript")
2025-06-14 13:56:05.214 ERROR    19:                                   talon/scripting/talon_script.py:734| 
   18:                                   talon/scripting/talon_script.py:326| 
   17:                                        talon/scripting/actions.py:88 | 
   16:                    user/cursorless-talon/src/snippets/snippets.py:114| actions.user.private_cursorless_comman..
   15:                                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   14:                                        talon/scripting/actions.py:88 | 
   13:                              user/cursorless-talon/src/command.py:36 | response = actions.user.private_cursor..
   12:                                                                        
   11:                                        talon/scripting/actions.py:88 | 
   10:            user/cursorless-talon/src/cursorless_command_server.py:39 | return actions.user.run_rpc_command_ge..
    9:                                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    8:                                        talon/scripting/actions.py:88 | 
    7:        user/talon_community/core/command_client/command_client.py:113| return run_command(
    6:                                                                                       
    5:        user/talon_community/core/command_client/command_client.py:55 | return actions.user.rpc_client_run_com..
    4:                                                                                
    3:                                        talon/scripting/actions.py:88 | 
    2: user/talon_community/core/command_client/rpc_client/rpc_client.py:102| raise Exception(decoded_contents["error"])
    1:                                                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Exception: No snippet available for language '...'. Available languages: c, cpp, csharp, elixir, go, java, javascript, javascriptreact, kotlin, lua, php, python, r, ruby, rust, scala, stata, typescript, typescriptreact, vimscript
```

Forced languages still use RPC to insert a snippet:

```python
[3416.400] user/talon_community/plugin/command_history/command_history.py | IO > snip if else
[3416.400] user/talon_community/plugin/subtitles/on_phrase.py | action speech.enabled()
[3416.401] user/talon_community/core/snippets/snippets.talon | action user.insert_snippet_by_name('ifElseStatement')
[3416.401] user/talon_community/core/snippets/snippets_insert.py | action user.get_snippet('ifElseStatement')
[3416.401] user/talon_community/core/snippets/snippets.py | action user.get_snippets('ifElseStatement')
[3416.401] user/talon_community/core/snippets/snippets.py | action code.language()
[3416.401] user/talon_community/core/snippets/snippets_insert.py | action user.insert_snippet('if $1:\n\t$2\nelse:\n\t$0')
[3416.401] user/talon_community/apps/vscode/vscode.py | action user.run_rpc_command('editor.action.insertSnippet', {'snippet': 'if $1:\n\t$2\nelse:\n\t$0'})
[3416.401] user/talon_community/core/command_client/command_client.py | action user.command_server_directory()
[3416.401] user/talon_community/core/command_client/command_client.py | action user.rpc_client_run_command('vscode-command-server', user.trigger_command_server_command_execution()
    Issue keystroke to trigger command server to execute command that
was written to the file.  For internal use only, 'editor.action.insertSnippet', [{'snippet': 'if $1:\n\t$2\nelse:\n\t$0'}], False, False)
[3416.401] user/talon_community/core/command_client/rpc_client/rpc_client.py | action user.trigger_command_server_command_execution()
```

It seemed easier to do this on the cursorless-talon side since I'm trying to identify this exception rather than just having a universal fallback — don't want to suppress other exceptions.

