### PR TITLE
Enable cursorless tag for jetbrains app

### DIFF
--- a/cursorless-talon/src/apps/cursorless_jetbrains.py
+++ b/cursorless-talon/src/apps/cursorless_jetbrains.py
@@ -1,0 +1,9 @@
+from talon import Context, actions
+
+ctx = Context()
+
+ctx.matches = r"""
+app: jetbrains
+"""
+
+ctx.tags = ["user.cursorless"]


### PR DESCRIPTION
Enables the user.cursorless tag, when jetbrains app is active.

My reasoning is, that if you have cursorless-talon installed, it is because you want to use it where it is supported.
