### PR TITLE
Support typescript return type of function type

### DIFF
--- a/data/fixtures/scopes/typescript.core/type/type.return2.scope
+++ b/data/fixtures/scopes/typescript.core/type/type.return2.scope
@@ -1,0 +1,36 @@
+const foo: () => number;
+---
+
+[#1 Content] = 0:11-0:23
+             >------------<
+0| const foo: () => number;
+
+[#1 Removal] = 0:9-0:23
+           >--------------<
+0| const foo: () => number;
+
+[#1 Leading delimiter] = 0:10-0:11
+            >-<
+0| const foo: () => number;
+
+[#1 Domain] = 0:0-0:24
+  >------------------------<
+0| const foo: () => number;
+
+[#1 Insertion delimiter] = " "
+
+
+[#2 Content] =
+[#2 Domain] = 0:17-0:23
+                   >------<
+0| const foo: () => number;
+
+[#2 Removal] = 0:13-0:23
+               >----------<
+0| const foo: () => number;
+
+[#2 Leading delimiter] = 0:13-0:17
+               >----<
+0| const foo: () => number;
+
+[#2 Insertion delimiter] = " "

--- a/queries/typescript.core.scm
+++ b/queries/typescript.core.scm
@@ -288,6 +288,14 @@
   )
 ) @_.domain
 
+;;!! foo() => string;
+;;!           ^^^^^^
+(_
+  parameters: (_) @_.leading.endOf
+  "=>"
+  return_type: (_) @type
+)
+
 ;;!! new Aaa<Bbb>()
 ;;!      ^^^^^^^^
 (new_expression


### PR DESCRIPTION
Fixes #3065

Note that I on purpose have set the domain the same as the content range. Take this example: 

`const foo: () => number;`

We already have a type scope with content range `() => number;`. If we set that as the domain for `number` it would probably be surprising if you are inside the parameters in want to target the type.    