### PR TITLE
head/tail are bounded by all interiors not just pair

### DIFF
--- a/data/fixtures/recorded/modifiers/interior/changeHead.yml
+++ b/data/fixtures/recorded/modifiers/interior/changeHead.yml
@@ -1,0 +1,22 @@
+languageId: typescriptreact
+command:
+  version: 7
+  spokenForm: change head
+  action:
+    name: clearAndSetSelection
+    target:
+      type: primitive
+      modifiers:
+        - {type: extendThroughStartOf}
+  usePrePhraseSnapshot: false
+initialState:
+  documentContents: <div>a b c</div>
+  selections:
+    - anchor: {line: 0, character: 8}
+      active: {line: 0, character: 8}
+  marks: {}
+finalState:
+  documentContents: <div> c</div>
+  selections:
+    - anchor: {line: 0, character: 5}
+      active: {line: 0, character: 5}

--- a/data/fixtures/recorded/modifiers/interior/changeHead.yml
+++ b/data/fixtures/recorded/modifiers/interior/changeHead.yml
@@ -10,13 +10,13 @@ command:
         - {type: extendThroughStartOf}
   usePrePhraseSnapshot: false
 initialState:
-  documentContents: <div>a b c</div>
+  documentContents: <div>abcd</div>
   selections:
-    - anchor: {line: 0, character: 8}
-      active: {line: 0, character: 8}
+    - anchor: {line: 0, character: 7}
+      active: {line: 0, character: 7}
   marks: {}
 finalState:
-  documentContents: <div> c</div>
+  documentContents: <div>cd</div>
   selections:
     - anchor: {line: 0, character: 5}
       active: {line: 0, character: 5}

--- a/data/fixtures/recorded/modifiers/interior/changeTail.yml
+++ b/data/fixtures/recorded/modifiers/interior/changeTail.yml
@@ -1,0 +1,22 @@
+languageId: typescriptreact
+command:
+  version: 7
+  spokenForm: change tail
+  action:
+    name: clearAndSetSelection
+    target:
+      type: primitive
+      modifiers:
+        - {type: extendThroughEndOf}
+  usePrePhraseSnapshot: false
+initialState:
+  documentContents: <div>a b c</div>
+  selections:
+    - anchor: {line: 0, character: 7}
+      active: {line: 0, character: 7}
+  marks: {}
+finalState:
+  documentContents: <div>a </div>
+  selections:
+    - anchor: {line: 0, character: 7}
+      active: {line: 0, character: 7}

--- a/data/fixtures/recorded/modifiers/interior/changeTail.yml
+++ b/data/fixtures/recorded/modifiers/interior/changeTail.yml
@@ -10,13 +10,13 @@ command:
         - {type: extendThroughEndOf}
   usePrePhraseSnapshot: false
 initialState:
-  documentContents: <div>a b c</div>
+  documentContents: <div>abcd</div>
   selections:
     - anchor: {line: 0, character: 7}
       active: {line: 0, character: 7}
   marks: {}
 finalState:
-  documentContents: <div>a </div>
+  documentContents: <div>ab</div>
   selections:
     - anchor: {line: 0, character: 7}
       active: {line: 0, character: 7}

--- a/packages/cursorless-engine/src/processTargets/modifiers/HeadTailStage.ts
+++ b/packages/cursorless-engine/src/processTargets/modifiers/HeadTailStage.ts
@@ -74,11 +74,11 @@ class BoundedLineStage implements ModifierStage {
 
   run(target: Target, options: ModifierStateOptions): Target[] {
     const line = this.getContainingLine(target, options);
-    const pairInterior = this.getContainingPairInterior(target, options);
+    const interior = this.getContainingInterior(target, options);
 
     const intersection =
-      pairInterior != null
-        ? line.contentRange.intersection(pairInterior.contentRange)
+      interior != null
+        ? line.contentRange.intersection(interior.contentRange)
         : null;
 
     if (intersection == null || intersection.isEmpty) {
@@ -94,15 +94,14 @@ class BoundedLineStage implements ModifierStage {
     ];
   }
 
-  private getContainingPairInterior(
+  private getContainingInterior(
     target: Target,
     options: ModifierStateOptions,
   ): Target | undefined {
     try {
       return this.getContaining(target, options, {
-        type: "surroundingPairInterior",
-        delimiter: "any",
-      })[0];
+        type: "interior",
+      });
     } catch (error) {
       if (error instanceof NoContainingScopeError) {
         return undefined;
@@ -117,16 +116,16 @@ class BoundedLineStage implements ModifierStage {
   ): Target {
     return this.getContaining(target, options, {
       type: "line",
-    })[0];
+    });
   }
 
   private getContaining(
     target: Target,
     options: ModifierStateOptions,
     scopeType: ScopeType,
-  ): Target[] {
+  ): Target {
     return this.modifierStageFactory
       .create({ type: "containingScope", scopeType })
-      .run(target, options);
+      .run(target, options)[0];
   }
 }


### PR DESCRIPTION
Today if you don't specify a scope after head/tail we default to the line bounded by optional surrounding pair interior. This change makes it so we use any interior. I gotten really used to head/tail being bounded by interior, but lately I've been doing a lot of jsx and I keep trying to use head and tail inside of a jsx element and accidentally removing half the line.