### PR TITLE
Pass requireStrongContainment from head/tail modifier to interior scope handler

### DIFF
--- a/data/fixtures/recorded/headTail/changeTail4.yml
+++ b/data/fixtures/recorded/headTail/changeTail4.yml
@@ -1,0 +1,22 @@
+languageId: plaintext
+command:
+  version: 7
+  spokenForm: change tail
+  action:
+    name: clearAndSetSelection
+    target:
+      type: primitive
+      modifiers:
+        - {type: extendThroughEndOf}
+  usePrePhraseSnapshot: false
+initialState:
+  documentContents: (a) b
+  selections:
+    - anchor: {line: 0, character: 3}
+      active: {line: 0, character: 3}
+  marks: {}
+finalState:
+  documentContents: (a)
+  selections:
+    - anchor: {line: 0, character: 3}
+      active: {line: 0, character: 3}

--- a/packages/common/src/types/command/PartialTargetDescriptor.types.ts
+++ b/packages/common/src/types/command/PartialTargetDescriptor.types.ts
@@ -240,6 +240,9 @@ export interface InteriorScopeType {
 
   // The user has specified a scope type. eg "inside element".
   explicitScopeType?: boolean;
+
+  // Gets passed to surrounding pair scope handler
+  requireStrongContainment?: boolean;
 }
 
 export type SurroundingPairDirection = "left" | "right";

--- a/packages/cursorless-engine/src/processTargets/modifiers/HeadTailStage.ts
+++ b/packages/cursorless-engine/src/processTargets/modifiers/HeadTailStage.ts
@@ -101,6 +101,7 @@ class BoundedLineStage implements ModifierStage {
     try {
       return this.getContaining(target, options, {
         type: "interior",
+        requireStrongContainment: true,
       });
     } catch (error) {
       if (error instanceof NoContainingScopeError) {

--- a/packages/cursorless-engine/src/processTargets/modifiers/scopeHandlers/SurroundingPairScopeHandler/InteriorScopeHandler.ts
+++ b/packages/cursorless-engine/src/processTargets/modifiers/scopeHandlers/SurroundingPairScopeHandler/InteriorScopeHandler.ts
@@ -74,6 +74,7 @@ export class InteriorScopeHandler extends BaseScopeHandler {
       {
         type: "surroundingPair",
         delimiter: "any",
+        requireStrongContainment: this.scopeType.requireStrongContainment,
       },
       this.languageId,
     );


### PR DESCRIPTION
The test failed before this fix

`(a)| b`
`"change tail"` and you expect `| b` but because the domain of the surrounding pair interior is the entire surrounding pair you instead removed `)`. This fix requires strong containments on surrounding pair interiors.