### PR TITLE
Manual cli tool name mode for local/from PR plugin install scripts

### DIFF
--- a/packages/cursorless-org-docs/src/docs/contributing/CONTRIBUTING.mdx
+++ b/packages/cursorless-org-docs/src/docs/contributing/CONTRIBUTING.mdx
@@ -190,9 +190,22 @@ Once you have your package then you can install it into the sandbox using the fo
 
 You can install a local build of the Cursorless extension by running the following command:
 
-```bash
-pnpm -F cursorless-vscode install-local
-```
+<Tabs groupId="vsx">
+  <TabItem value="vscode" label="VSCode">
+
+    ```bash
+    pnpm -F cursorless-vscode install-local
+    ```
+
+  </TabItem>
+  <TabItem value="vscodium" label="VSCodium">
+
+    ```bash
+    pnpm -F cursorless-vscode install-local codium
+    ```
+
+  </TabItem>
+</Tabs>
 
 This will bundle and install a local version of Cursorless, uninstalling production Cursorless first and using a special extension id to break the update chain.
 
@@ -201,15 +214,41 @@ use `install-from-pr` instead, and pass a PR number to the command and it will
 download and install the artifact from the PR build. This requires the [`gh`
 cli](https://cli.github.com/). For example:
 
-```bash
-pnpm -F cursorless-vscode install-from-pr 1281
-```
+<Tabs groupId="vsx">
+  <TabItem value="vscode" label="VSCode">
+
+    ```bash
+    pnpm -F cursorless-vscode install-from-pr 1281
+    ```
+
+  </TabItem>
+  <TabItem value="vscodium" label="VSCodium">
+
+    ```bash
+    pnpm -F cursorless-vscode install-from-pr 1281 codium
+    ```
+
+  </TabItem>
+</Tabs>
 
 To uninstall the local build and revert to production cursorless, run the following command:
 
-```bash
-pnpm -F cursorless-vscode uninstall-local
-```
+<Tabs groupId="vsx">
+  <TabItem value="vscode" label="VSCode">
+
+    ```bash
+    pnpm -F cursorless-vscode uninstall-local
+    ```
+
+  </TabItem>
+  <TabItem value="vscodium" label="VSCodium">
+
+    ```bash
+    pnpm -F cursorless-vscode uninstall-local codium
+    ```
+
+  </TabItem>
+</Tabs>
 
 ## Regular manual maintenance tasks
 

--- a/packages/cursorless-vscode/scripts/install-local.sh
+++ b/packages/cursorless-vscode/scripts/install-local.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -eo pipefail
 # Bundles and installs a local version of Cursorless, uninstalling production
 # Cursorless first and using a special extension id to break update chain
 
@@ -13,11 +13,22 @@ pnpm populate-dist --local-install
 cd dist
 vsce package -o ../bundle.vsix
 
-# 3. Uninstall production cursorless
-code --uninstall-extension pokey.cursorless || echo "Cursorless not currently installed"
+if [ -z "$1" ]; then
+    # 3. Uninstall production cursorless
+    code --uninstall-extension pokey.cursorless || echo "Cursorless not currently installed"
 
-# 4. Install local Cursorless
-code --install-extension ../bundle.vsix --force
+    # 4. Install local Cursorless
+    code --install-extension ../bundle.vsix --force
+else
+    # Construct above commands in arrays to use specified cli tool name (see comments in ./install-from-pr.sh at line 59)
+    cmd_uninstall=($1)
+    cmd_uninstall+=(--uninstall-extension pokey.cursorless \|\| echo "Cursorless not currently installed")
+    "${cmd_uninstall[@]}"
+
+    cmd_install_local=($1)
+    cmd_install_local+=(--install-extension ../bundle.vsix --force)
+    "${cmd_install_local[@]}"
+fi
 
 echo -e "\e[1;32mPlease restart VSCode\e[0m"
 echo "To uninstall and revert to production Cursorless, run the adjacent uninstall-local.sh"

--- a/packages/cursorless-vscode/scripts/uninstall-local.sh
+++ b/packages/cursorless-vscode/scripts/uninstall-local.sh
@@ -1,13 +1,24 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -eo pipefail
 
 # Switch back to production Cursorless extension locally after having run
-# ./install-local.sh
+# ./install-local.sh or ./install-from-pr.sh
 
-# 1. Uninstall local cursorless
-code --uninstall-extension pokey.cursorless-development || echo "Cursorless development version not currently installed"
+if [ -z "$1" ]; then
+    # 1. Uninstall local cursorless
+    code --uninstall-extension pokey.cursorless-development || echo "Cursorless development version not currently installed"
 
-# 2. Install production Cursorless
-code --install-extension pokey.cursorless
+    # 2. Install production Cursorless
+    code --install-extension pokey.cursorless
+else
+    # Construct above commands in arrays to use specified cli tool name (see comments in ./install-from-pr.sh at line 59)
+    cmd_uninstall=($1)
+    cmd_uninstall+=(--uninstall-extension pokey.cursorless-development \|\| echo "Cursorless development version not currently installed")
+    "${cmd_uninstall[@]}"
+
+    cmd_install_prod=($1)
+    cmd_install_prod+=(--install-extension pokey.cursorless)
+    "${cmd_install_prod[@]}"
+fi
 
 echo -e "\e[1;32mPlease restart VSCode\e[0m"


### PR DESCRIPTION
Adds the ability to manually define the IDE cli tool name to `./packages/cursorless-vscode/scripts/install-from-pr.sh`, `[...]/install-local.sh`, and `[...]/uninstall-local.sh`, and updates `./packages/cursorless-org-docs/src/docs/contributing/CONTRIBUTING.mdx` to reflect these changes. 

Soft-blocks #3092 since I use VSCodium and can't (un)install a local plugin version without this fix. 

This requires changing `set -euo pipefail` to `set -eo pipefail` at the start of all three scripts, which might have unforeseen consequences I can't think of right now; I'm also certain there's a better way to demarcate an argument as being optional than how I did it in `install-from-pr.sh` but IDK what that would be, so feel free to change it to something less garbage!